### PR TITLE
Status command for multiple dependencies

### DIFF
--- a/packages/cli/src/models/dependency/Dependency.js
+++ b/packages/cli/src/models/dependency/Dependency.js
@@ -16,13 +16,14 @@ export default class Dependency {
     return !requirement || version === requirement || semver.satisfies(version, requirement);
   }  
 
-  constructor(name, version) {
+  constructor(name, requirement) {
     this.name = name
     this._networkFiles = {}
 
     const packageVersion = this.getPackageFile().version
-    this._validateSatisfiesVersion(packageVersion, version)
-    this.version = version || tryWithCaret(packageVersion)    
+    this._validateSatisfiesVersion(packageVersion, requirement)
+    this.version = packageVersion
+    this.requirement = requirement || tryWithCaret(packageVersion)
   }
 
   async deploy(txParams) {
@@ -60,7 +61,7 @@ export default class Dependency {
       }
       
       this._networkFiles[network] = new ZosNetworkFile(this.getPackageFile(), network, filename)
-      this._validateSatisfiesVersion(this._networkFiles[network].version, this.version)
+      this._validateSatisfiesVersion(this._networkFiles[network].version, this.requirement)
     }
     return this._networkFiles[network]
   }

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -78,6 +78,10 @@ export default class ZosNetworkFile {
     return !_.isEmpty(this.getDependency(name))
   }
 
+  hasDependencies() {
+    return !_.isEmpty(this.dependencies)
+  }
+
   getProxies({ package: packageName, contract, address } = {}) {
     if (_.isEmpty(this.data.proxies)) return []
     const allProxies = _.flatMap(this.data.proxies || {}, (proxiesList, fullname) => (
@@ -119,7 +123,7 @@ export default class ZosNetworkFile {
   }
 
   hasProxies(filter = {}) {
-    return _.isEmpty(this.getProxies(filter))
+    return !_.isEmpty(this.getProxies(filter))
   }
 
   hasMatchingVersion() {
@@ -182,6 +186,10 @@ export default class ZosNetworkFile {
   unsetDependency(name) {
     if (!this.data.dependencies) return
     delete this.data.dependencies[name]
+  }
+
+  updateDependency(name, fn) {
+    this.setDependency(name, fn(this.getDependency(name)));
   }
 
   addContract(alias, instance) {

--- a/packages/cli/src/models/files/ZosPackageFile.js
+++ b/packages/cli/src/models/files/ZosPackageFile.js
@@ -45,6 +45,10 @@ export default class ZosPackageFile {
     return !!(this.dependencies[name])
   }
 
+  hasDependencies() {
+    return !_.isEmpty(this.dependencies)
+  }
+
   get contracts() {
     return this.data.contracts || {}
   }

--- a/packages/cli/src/models/local/LocalAppController.js
+++ b/packages/cli/src/models/local/LocalAppController.js
@@ -4,10 +4,10 @@ import Dependency from '../dependency/Dependency';
 
 export default class LocalAppController extends LocalBaseController {
   async linkLib(libNameVersion, installLib = false) {
-    if(libNameVersion) {
+    if (libNameVersion) {
       const dependency = Dependency.fromNameWithVersion(libNameVersion)
       if (installLib) await dependency.install()
-      this.packageFile.setDependency(dependency.name, dependency.version)
+      this.packageFile.setDependency(dependency.name, dependency.requirement)
     }
   }
 

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -16,6 +16,10 @@ export default class NetworkAppController extends NetworkBaseController {
     return this.networkFile.appAddress
   }
 
+  get app() {
+    return this.project.getApp()
+  }
+
   async deploy() {
     this.project = await AppProject.deploy(this.packageFile.name, this.currentVersion, this.txParams);
     

--- a/packages/cli/src/scripts/status.js
+++ b/packages/cli/src/scripts/status.js
@@ -10,7 +10,7 @@ export default async function status({ network, txParams = {}, networkFile = und
 
   if (!(await rootInfo(controller))) return;
   if (!(await versionInfo(controller.networkFile))) return;
-  await stdlibInfo(controller.networkFile);
+  await depsInfo(controller.networkFile);
   await contractsInfo(controller);
   await proxiesInfo(controller.networkFile);
 }
@@ -21,14 +21,13 @@ function rootInfo(controller) {
 
 async function appInfo(controller) {
   if (!controller.appAddress) {
-    log.warn(`Application is not yet deployed`);
+    log.warn(`Application is not yet deployed to the network`);
     return false;
   }
 
   await controller.fetch();
   log.info(`Application is deployed at ${controller.appAddress}`);
-  log.info(`- Proxy factory is at ${controller.app.factory.address}`);
-  log.info(`- Package is at ${controller.app.package.address}`);
+  log.info(`- Package ${controller.packageFile.name} is at ${controller.networkFile.packageAddress}`);
   return true;
 }
 
@@ -81,44 +80,46 @@ async function contractsInfo(controller) {
     .forEach(contractAlias => log.warn(`- ${contractAlias} will be removed on next push`));
 }
 
-async function stdlibInfo(networkFile) {
+async function depsInfo(networkFile) {
   if (networkFile.isLib) return;
-  const packageFile = networkFile.packageFile
-  log.info('Standard library:');
+  const packageFile = networkFile.packageFile;
+  if (!packageFile.hasDependencies() && !networkFile.hasDependencies()) return;
+  log.info('Application dependencies:');
 
-  if (!packageFile.hasStdlib()) {
-    const deployedWarn = networkFile.hasStdlib() ? `(though ${networkFile.stdlibName}@${networkFile.stdlibVersion} is currently deployed)` : '';
-    log.info(`- No stdlib specified for current version ${deployedWarn}`);
-    return;
-  }
+  _.forEach(packageFile.dependencies, (requiredVersion, dependencyName) => {
+    const msgHead = `- ${dependencyName}@${requiredVersion}`
+    if (!networkFile.hasDependency(dependencyName)) {
+      log.info(`${msgHead} is required but is not linked`)
+    } else if (networkFile.dependencyHasMatchingCustomDeploy(dependencyName)) {
+      log.info(`${msgHead} is linked to a custom deployment`)
+    } else if (networkFile.dependencyHasCustomDeploy(dependencyName)) {
+      log.info(`${msgHead} is linked to a custom deployment of a different version (${networkFile.getDependency(dependencyName).version})`)
+    } else if (networkFile.dependencySatisfiesVersionRequirement(dependencyName)) {
+      const actualVersion = networkFile.getDependency(dependencyName).version;
+      if (actualVersion === requiredVersion) {
+        log.info(`${msgHead} is linked`)
+      } else {
+        log.info(`${msgHead} is linked to version ${actualVersion}`)
+      }
+    } else {
+      log.info(`${msgHead} is linked to a different version (${networkFile.getDependency(dependencyName).version})`)
+    }
+  });
 
-  log.info(`- Stdlib ${packageFile.stdlibName}@${packageFile.stdlibVersion} required by current version`);
-
-  if (!networkFile.hasStdlib()) {
-    log.info(`- No stdlib is deployed`);
-  } else if (networkFile.hasMatchingCustomDeploy()) {
-    log.info(`- Custom deploy of stdlib set at ${networkFile.stdlibAddress}`);
-  } else if (networkFile.hasCustomDeploy()) {
-    log.info(`- Custom deploy of different stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion} at ${networkFile.stdlibAddress}`);
-  } else if (packageFile.stdlibMatches(networkFile.stdlib)) {
-    log.info(`- Deployed application is correctly connected to stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion}`);
-  } else {
-    log.warn(`- Deployed application is connected to different stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion}`);
-  }
+  _.forEach(networkFile.dependenciesNamesMissingFromPackage, (dependencyName) => {
+    log.info(`- ${dependencyName} will be unlinked on next push`)
+  })
 }
 
 async function proxiesInfo(networkFile) {
   if (networkFile.isLib) return;
   log.info('Deployed proxies:');
-
   if (!networkFile.hasProxies()) {
     log.info('- No proxies created');
     return;
   }
 
-  _.each(networkFile.proxies, (proxyInfos, alias) => {
-    _.each(proxyInfos, ({ address, version }) => {
-      log.info(`- ${alias} at ${address} version ${version}`);
-    });
-  });
+  networkFile.getProxies().forEach(proxy =>
+    log.info(`- ${proxy.package}/${proxy.contract} at ${proxy.address} version ${proxy.version}`)
+  )
 }

--- a/packages/cli/src/scripts/status.js
+++ b/packages/cli/src/scripts/status.js
@@ -10,7 +10,7 @@ export default async function status({ network, txParams = {}, networkFile = und
 
   if (!(await rootInfo(controller))) return;
   if (!(await versionInfo(controller.networkFile))) return;
-  await depsInfo(controller.networkFile);
+  await dependenciesInfo(controller.networkFile);
   await contractsInfo(controller);
   await proxiesInfo(controller.networkFile);
 }
@@ -80,7 +80,7 @@ async function contractsInfo(controller) {
     .forEach(contractAlias => log.warn(`- ${contractAlias} will be removed on next push`));
 }
 
-async function depsInfo(networkFile) {
+async function dependenciesInfo(networkFile) {
   if (networkFile.isLib) return;
   const packageFile = networkFile.packageFile;
   if (!packageFile.hasDependencies() && !networkFile.hasDependencies()) return;

--- a/packages/cli/test/scripts/status.test.js
+++ b/packages/cli/test/scripts/status.test.js
@@ -159,7 +159,7 @@ contract('status script', function([_, owner]) {
         this.logs.text.should.match(/mock-stdlib-undeployed@1.1.0 is linked/i);
       });
 
-      it.skip('should log connected dependency when semver requirement matches', async function () {
+      it('should log connected dependency when semver requirement matches', async function () {
         await linkLib({ packageFile: this.packageFile, libNameVersion: 'mock-stdlib-undeployed@^1.0.0', installLib: false });
         await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
         this.networkFile.updateDependency('mock-stdlib-undeployed', dep => ({ ... dep, customDeploy: false }))

--- a/packages/cli/test/scripts/status.test.js
+++ b/packages/cli/test/scripts/status.test.js
@@ -6,44 +6,46 @@ import push from '../../src/scripts/push.js';
 import bumpVersion from '../../src/scripts/bump.js';
 import createProxy from '../../src/scripts/create.js';
 import status from '../../src/scripts/status.js';
-import linkStdlib from '../../src/scripts/link';
+import linkLib from '../../src/scripts/link';
 import ControllerFor from '../../src/models/local/ControllerFor';
 import CaptureLogs from '../helpers/captureLogs';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 import remove from '../../src/scripts/remove';
 
-contract.skip('status script', function([_, owner]) {
+contract('status script', function([_, owner]) {
   const txParams = { from: owner };
   const network = 'test';
   const contractName = 'ImplV1';
   const contractAlias = 'Impl';
   const contractsData = [{ name: contractName, alias: contractAlias }]
   const anotherContractName = 'AnotherImplV1';
-  const stdlibNameVersion = 'mock-stdlib@1.1.0';
+  const libNameVersion = 'mock-stdlib@1.1.0';
   
   beforeEach('setup', async function() {
-    this.logs = new CaptureLogs();
+    this.capturingLogs = ((promise) => {
+      this.logs = new CaptureLogs();
+      return promise;
+    }).bind(this);
   });
 
   afterEach('cleanup', function () {
-    this.logs.restore();
+    if (this.logs) this.logs.restore();
   });
 
   const shouldDescribeApp = function () {
     describe('root app', function () {
       it('should log undeployed app', async function () {
+        this.capturingLogs();
         await status({ network, networkFile: this.networkFile });
-
         this.logs.text.should.match(/not yet deployed/);
       });
 
       it('should log plain app info', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/deployed at 0x[0-9a-fA-F]{40}/i);
-        this.logs.text.should.match(/factory is at 0x[0-9a-fA-F]{40}/i);
-        this.logs.text.should.match(/package is at 0x[0-9a-fA-F]{40}/i);
+        this.logs.text.should.match(/package \w+ is at 0x[0-9a-fA-F]{40}/i);
         this.logs.text.should.match(/version 1.1.0 matches/i);
         this.logs.text.should.match(/no contracts registered/i);
       });
@@ -53,6 +55,7 @@ contract.skip('status script', function([_, owner]) {
   const shouldDescribeLib = function () {
     describe('root lib', function () {
       it('should log undeployed lib', async function () {
+        this.capturingLogs();
         await status({ network, networkFile: this.networkFile });
 
         this.logs.text.should.match(/not yet deployed/);
@@ -60,7 +63,7 @@ contract.skip('status script', function([_, owner]) {
 
       it('should log plain lib info', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/library package is deployed at 0x[0-9a-fA-F]{40}/i);
       });
@@ -72,7 +75,7 @@ contract.skip('status script', function([_, owner]) {
       it('should log version out-of-sync', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
         await bumpVersion({ version: '1.2.0', packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/version 1.1.0 is out of date/i);
         this.logs.text.should.match(/latest is 1.2.0/i);
@@ -85,7 +88,7 @@ contract.skip('status script', function([_, owner]) {
       it('should log contract name when different to alias', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
         await add({ contractsData, packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/Impl/i);
         this.logs.text.should.match(/implemented by ImplV1/i);
@@ -94,7 +97,7 @@ contract.skip('status script', function([_, owner]) {
       it('should not log contract name when matches alias', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
         await add({ contractsData: [{ name: anotherContractName }], packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/AnotherImplV1/i);
         this.logs.text.should.not.match(/implemented by/i);
@@ -103,7 +106,7 @@ contract.skip('status script', function([_, owner]) {
       it('should log undeployed contract', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
         await add({ contractsData, packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/not deployed/i);
       });
@@ -112,7 +115,7 @@ contract.skip('status script', function([_, owner]) {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
         await add({ contractsData: [{ name: anotherContractName, alias: contractAlias }], packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/out of date/i);
       });
@@ -120,7 +123,7 @@ contract.skip('status script', function([_, owner]) {
       it('should log deployed contract', async function () {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/is deployed and up to date/i);
       });    
@@ -129,75 +132,64 @@ contract.skip('status script', function([_, owner]) {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
         await remove({ contracts: [contractAlias], packageFile: this.packageFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/will be removed/i);
       });    
     });
   };
 
-  const shouldDescribeNoStdlib = function () {
-    it.skip('should log app info', async function () {
+  const shouldDescribeUnlinkedDependency = function () {
+    it('should log missing library', async function () {
       await push({ network, txParams, networkFile: this.networkFile });
-      await status({ network, networkFile: this.networkFile });
+      await linkLib({ packageFile: this.packageFile, libNameVersion, installLib: false });
+      await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-      this.logs.text.should.match(/no stdlib specified for current version/i);
-    });
-
-    it.skip('should log missing stdlib', async function () {
-      await push({ network, txParams, networkFile: this.networkFile });
-      await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion, installLib: false });
-      await status({ network, networkFile: this.networkFile });
-
-      this.logs.text.should.match(/mock-stdlib@1.1.0 required/i);
-      this.logs.text.should.match(/no stdlib is deployed/i);
+      this.logs.text.should.match(/mock-stdlib@1.1.0 is required but is not linked/i);
     });
   }
 
-  const shouldDescribeStdlib = function () {
-    describe.skip('stdlib', function () {
-      it('should log connected stdlib', async function () {
-        await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+  const shouldDescribeDependency = function () {
+    describe('dependency', function () {
+      it('should log connected dependency', async function () {
+        await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
+        this.networkFile.updateDependency('mock-stdlib-undeployed', dep => ({ ... dep, customDeploy: false }))
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-        this.logs.text.should.match(/mock-stdlib@1.1.0 required/i);
-        this.logs.text.should.match(/correctly connected to stdlib/i);
+        this.logs.text.should.match(/mock-stdlib-undeployed@1.1.0 is linked/i);
       });
 
-      it('should log connected stdlib when semver requirement matches', async function () {
-        await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib@^1.0.0', installLib: false });
-        await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+      it.skip('should log connected dependency when semver requirement matches', async function () {
+        await linkLib({ packageFile: this.packageFile, libNameVersion: 'mock-stdlib-undeployed@^1.0.0', installLib: false });
+        await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
+        this.networkFile.updateDependency('mock-stdlib-undeployed', dep => ({ ... dep, customDeploy: false }))
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-        this.logs.text.should.match(/mock-stdlib@\^1\.0\.0 required/i);
-        this.logs.text.should.match(/correctly connected to stdlib/i);
-        this.logs.text.should.match(/1\.1\.0/i);
+        this.logs.text.should.match(/mock-stdlib-undeployed@\^1\.0\.0 is linked to version 1\.1\.0/i);
       });
 
-      it('should log different stdlib connected', async function () {
-        await push({ network, txParams, networkFile: this.networkFile });
-        await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib-2@1.2.0', installLib: false });
-        await status({ network, networkFile: this.networkFile });
+      it('should log connected dependency to incorrect version', async function () {
+        await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
+        this.networkFile.updateDependency('mock-stdlib-undeployed', dep => ({ ... dep, customDeploy: false }))
+        this.packageFile.setDependency('mock-stdlib-undeployed', '^2.0.0');
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-        this.logs.text.should.match(/mock-stdlib-2@1.2.0 required/i);
-        this.logs.text.should.match(/connected to different stdlib mock-stdlib@1.1.0/i);
+        this.logs.text.should.match(/mock-stdlib-undeployed@\^2\.0\.0 is linked to a different version \(1\.1\.0\)/i);
       });
 
-      it('should log deployed stdlib', async function () {
-        await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+      it('should log deployed dependency', async function () {
+        await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-        this.logs.text.should.match(/mock-stdlib@1.1.0 required/i);
-        this.logs.text.should.match(/custom deploy of stdlib set at 0x[0-9a-fA-F]{40}/i);
+        this.logs.text.should.match(/mock-stdlib-undeployed@1\.1\.0 is linked to a custom deployment/i);
       });
 
-      it('should log different stdlib deployed', async function () {
-        await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
-        await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib-2@1.2.0', installLib: false });
-        await status({ network, networkFile: this.networkFile });
+      it('should log deployed dependency to incorrect version', async function () {
+        await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
+        this.packageFile.setDependency('mock-stdlib-undeployed', '^2.0.0');
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
-        this.logs.text.should.match(/mock-stdlib-2@1.2.0 required/i);
-        this.logs.text.should.match(/custom deploy of different stdlib mock-stdlib@1.1.0 at 0x[0-9a-fA-F]{40}/i);
+        this.logs.text.should.match(/mock-stdlib-undeployed@\^2\.0\.0 is linked to a custom deployment of a different version \(1\.1\.0\)/i);
       });
     });
   };
@@ -207,7 +199,7 @@ contract.skip('status script', function([_, owner]) {
       it('should log no proxies', async function () {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
         this.logs.text.should.match(/no proxies/i);
       });
@@ -216,7 +208,7 @@ contract.skip('status script', function([_, owner]) {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
         await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
-        await status({ network, networkFile: this.networkFile });
+        await this.capturingLogs(status({ network, networkFile: this.networkFile }));
         
         this.logs.text.should.match(/Impl at 0x[0-9a-fA-F]{40} version 1.1.0/i);
       });
@@ -227,9 +219,8 @@ contract.skip('status script', function([_, owner]) {
     it('should not deploy a new package', async function () {
       await push({ network, txParams, networkFile: this.networkFile });
       const packageAddress = ControllerFor(this.packageFile).onNetwork(network, txParams, this.networkFile).packageAddress;
-      this.logs.clear();
 
-      await status({ network, networkFile: this.networkFile });
+      await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
       this.logs.text.should.not.match(/deploying new package/i);
       ControllerFor(this.packageFile).onNetwork(network, txParams, this.networkFile).packageAddress.should.eq(packageAddress);
@@ -245,17 +236,17 @@ contract.skip('status script', function([_, owner]) {
     shouldDescribeApp();
     shouldDescribeVersion();
     shouldDescribeContracts();
-    shouldDescribeNoStdlib();
+    shouldDescribeUnlinkedDependency();
     shouldDescribeProxies();
     shouldNotModifyPackage();
 
-    describe.skip('with stdlib', function () {
+    describe('with dependency', function () {
       beforeEach('creating package and network files', function () {
-        this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-stdlib.zos.json')
+        this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
         this.networkFile = this.packageFile.networkFile(network)
       })
 
-      shouldDescribeStdlib();
+      shouldDescribeDependency();
     })
   });
 


### PR DESCRIPTION
Re-enables the `status` command that had been disabled for multiple dependencies on #17 .