### PR TITLE
Change admin command

### DIFF
--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -10,5 +10,6 @@ import freeze from './freeze'
 import session from './session'
 import remove from './remove'
 import verify from './verify'
+import setAdmin from './set-admin'
 
-export default [init, add, remove, push, create, update, bump, link, status, freeze, session, verify]
+export default [init, add, remove, push, create, update, bump, link, status, freeze, session, verify, setAdmin]

--- a/packages/cli/src/commands/set-admin.js
+++ b/packages/cli/src/commands/set-admin.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import setAdmin from '../scripts/set-admin'
+import runWithTruffle from '../utils/runWithTruffle'
+import { fromContractFullName } from '../utils/naming'
+import _ from 'lodash'
+
+const name = 'set-admin'
+const signature = `${name} [alias-or-address] [new-admin-address]`
+const description = 'change upgradeability admin of a contract instance. Provide the [alias] or [package]/[alias] you added your contract with, or its [address]. Note that if you transfer to an incorrect address, you may irreversibly lose control over upgrading your contract.'
+
+const register = program => program
+  .command(signature, { noHelp: true })
+  .usage('[alias-or-address] [new-admin-address] --network <network> [options]')
+  .description(description)
+  .option('-y, --yes', 'accept transferring admin rights (required)')
+  .withNetworkOptions()
+  .action(action)
+
+async function action(contractFullNameOrAddress, newAdmin, options) {
+  const { yes } = options
+  if (!yes) {
+    throw Error("This is a potentially irreversible operation: if you specify an incorrect admin address, you may lose the ability to upgrade your contract forever.\nPlease double check all parameters, and run the same command with --yes.")
+  }  
+
+  let proxyAddress, contractAlias, packageName
+  if (contractFullNameOrAddress && contractFullNameOrAddress.startsWith('0x')) {
+    proxyAddress = contractFullNameOrAddress
+  } else if (contractFullNameOrAddress) {
+    ({ contract: contractAlias, package: packageName } = fromContractFullName(contractFullNameOrAddress))
+  }
+  
+  const args = _.pickBy({ contractAlias, packageName, proxyAddress, newAdmin })
+  await runWithTruffle(async (opts) => await setAdmin({ ... args, ... opts }), options)
+}
+
+export default { name, signature, description, register, action }

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -232,13 +232,11 @@ export default class ZosNetworkFile {
     this.data.proxies[fullname].push(info)
   }
 
-  updateProxy(proxy) {
-    const fullname = toContractFullName(proxy.package, proxy.contract)
-    const existing = _.find(this.data.proxies[fullname], { address: proxy.address })
-    Object.assign(existing, { 
-      version: proxy.version,
-      implementation: proxy.implementation
-    })
+  updateProxy({ package: proxyPackage, contract: proxyContract, address: proxyAddress }, fn) {
+    const fullname = toContractFullName(proxyPackage, proxyContract)
+    const index = _.findIndex(this.data.proxies[fullname], { address: proxyAddress })
+    if (index === -1) throw Error(`Proxy ${fullname} at ${proxyAddress} not found in network manifest`)    
+    this.data.proxies[fullname][index] = fn(this.data.proxies[fullname][index]);
   }
 
   write() {

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -93,15 +93,24 @@ export default class NetworkAppController extends NetworkBaseController {
     log.error(`Possible initialization method 'initialize' found in contract. Make sure you initialize your instance.`);
   }
 
-  async upgradeProxies(packageName, contractAlias, proxyAddress, initMethod, initArgs) {
-    // Fetch all proxies that match the filters provided
-    const proxies = this.networkFile.getProxies({ package: packageName, contract: contractAlias, address: proxyAddress})
-    if (_.isEmpty(proxies)) {
-      log.info('No proxies to update were found');
-      return [];
-    }
+  async setProxiesAdmin(packageName, contractAlias, proxyAddress, newAdmin) {
+    const proxies = this._fetchOwnedProxies(packageName, contractAlias, proxyAddress)
+    if (proxies.length === 0) return [];
+    await this.fetch();
 
-    // Load project
+    await allPromisesOrError(
+      _.map(proxies, async (proxy) => {
+        await this.project.changeProxyAdmin(proxy.address, newAdmin)
+        this.networkFile.updateProxy(proxy, proxy => ({ ... proxy, admin: newAdmin }))
+      })
+    );
+
+    return proxies;
+  }
+
+  async upgradeProxies(packageName, contractAlias, proxyAddress, initMethod, initArgs) {
+    const proxies = this._fetchOwnedProxies(packageName, contractAlias, proxyAddress)
+    if (proxies.length === 0) return [];
     await this.fetch();
 
     // Check if there is any migrate method in the contracts and warn the user to call it
@@ -113,7 +122,7 @@ export default class NetworkAppController extends NetworkBaseController {
     // Update all proxies loaded
     const newVersion = await this.project.getCurrentVersion();
     await allPromisesOrError(
-      _.map(proxies, (proxy) => this._upgradeProxy(proxy, initMethod, initArgs,newVersion))
+      _.map(proxies, (proxy) => this._upgradeProxy(proxy, initMethod, initArgs, newVersion))
     )
 
     return proxies;
@@ -124,15 +133,21 @@ export default class NetworkAppController extends NetworkBaseController {
       const contractClass = this.localController.getContractClass(proxy.package, proxy.contract);
       const currentImplementation = await this.project.app.getProxyImplementation(proxy.address)
       const contractImplementation = await this.project.app.getImplementation(proxy.package, proxy.contract)
+      let newImplementation;
+
       if (currentImplementation !== contractImplementation) {
         await this.project.upgradeProxy(proxy.address, contractClass, { packageName: proxy.package, contractName: proxy.contract, initMethod, initArgs });
-        proxy.implementation = contractImplementation
+        newImplementation = contractImplementation
       } else {
         log.info(`Contract ${proxy.contract} at ${proxy.address} is up to date.`)
-        proxy.implementation = currentImplementation
+        newImplementation = currentImplementation
       }
-      proxy.version = newVersion;
-      this.networkFile.updateProxy(proxy)
+
+      this.networkFile.updateProxy(proxy, proxy => ({
+        ... proxy,
+        implementation: newImplementation,
+        version: newVersion
+      }));
     } catch(error) {
       throw Error(`Proxy ${toContractFullName(proxy.package, proxy.contract)} at ${proxy.address} failed to update with error: ${error.message}`)
     }
@@ -146,6 +161,28 @@ export default class NetworkAppController extends NetworkBaseController {
     const migrateMethod = contractClass.abi.find(fn => fn.type === 'function' && fn.name === 'migrate');
     if (!migrateMethod) return;
     log.error(`Possible migration method 'migrate' found in contract ${contractClass.contractName}. Remember running the migration after deploying it.`);
+  }
+
+  _fetchOwnedProxies(packageName, contractAlias, proxyAddress) {
+    const proxies = this.networkFile.getProxies({ 
+      package: packageName || (contractAlias ? this.packageFile.name : undefined),
+      contract: contractAlias, 
+      address: proxyAddress
+    })
+
+    if (_.isEmpty(proxies)) {
+      log.info('No owned contract instances that match were found');
+      return [];
+    }
+
+    const ownedProxies = proxies.filter(proxy => !proxy.admin || proxy.admin === this.appAddress);
+
+    if (_.isEmpty(ownedProxies)) {
+      log.info('No matching contract instances are owned by this application');
+      return [];
+    }
+
+    return ownedProxies;
   }
 
   async linkLibs() {

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -100,6 +100,7 @@ export default class NetworkAppController extends NetworkBaseController {
 
     await allPromisesOrError(
       _.map(proxies, async (proxy) => {
+        log.info(`Changing admin of proxy ${proxy.address} to ${newAdmin}`)
         await this.project.changeProxyAdmin(proxy.address, newAdmin)
         this.networkFile.updateProxy(proxy, proxy => ({ ... proxy, admin: newAdmin }))
       })

--- a/packages/cli/src/scripts/set-admin.js
+++ b/packages/cli/src/scripts/set-admin.js
@@ -1,0 +1,17 @@
+import stdout from '../utils/stdout';
+import ControllerFor from '../models/network/ControllerFor'
+
+export default async function setAdmin({ newAdmin, packageName, contractAlias, proxyAddress, network, txParams = {}, networkFile = undefined}) {
+  if (!contractAlias && !proxyAddress) {
+    throw Error('The address or name of the contract to transfer upgradeability admin rights must be provided.')
+  }
+
+  const controller = new ControllerFor(network, txParams, networkFile)
+
+  try {
+    const proxies = await controller.setProxiesAdmin(packageName, contractAlias, proxyAddress, newAdmin);
+    proxies.forEach(proxy => stdout(proxy.address));
+  } finally {
+    controller.writeNetworkPackage();
+  }
+}

--- a/packages/cli/test/commands/setAdmin.test.js
+++ b/packages/cli/test/commands/setAdmin.test.js
@@ -1,0 +1,26 @@
+'use strict'
+require('../setup')
+
+import {stubCommands, itShouldParse} from './share';
+
+contract('set-admin command', function() {
+
+  stubCommands()
+
+  itShouldParse('should call set-admin script with proxy address', 'setAdmin', 'zos set-admin 0x20 0x30 -y --network test', function(update) {
+    update.should.have.been.calledWith( { proxyAddress: "0x20", newAdmin: "0x30", network: 'test', txParams: { } } )
+  })
+
+  itShouldParse('should call set-admin script with network options', 'setAdmin', 'zos set-admin 0x20 0x30 --network test --from 0x40 -y', function(update) {
+    update.should.have.been.calledWith( { proxyAddress: "0x20", newAdmin: "0x30", network: 'test', txParams: { from: '0x40' } } )
+  })
+
+  itShouldParse('should call set-admin script with contract name', 'setAdmin', 'zos set-admin Impl 0x30 --network test -y', function(update) {
+    update.should.have.been.calledWith( { contractAlias: "Impl", newAdmin: "0x30", network: 'test', txParams: { } } )
+  })
+
+  itShouldParse('should call set-admin script with package name and contract name', 'setAdmin', 'zos set-admin OpenZeppelin/Impl 0x30 -y --network test ', function(update) {
+    update.should.have.been.calledWith( { packageName: "OpenZeppelin", contractAlias: "Impl", newAdmin: "0x30", network: 'test', txParams: { } } )
+  })
+
+})

--- a/packages/cli/test/commands/share.js
+++ b/packages/cli/test/commands/share.js
@@ -16,11 +16,14 @@ import * as session from '../../src/scripts/session';
 import * as status from '../../src/scripts/status';
 import * as update from '../../src/scripts/update';
 import * as verify from '../../src/scripts/verify';
+import * as setAdmin from '../../src/scripts/set-admin';
 
 import * as runWithTruffle from '../../src/utils/runWithTruffle';
 import Session from '../../src/models/network/Session';
 import ErrorHandler from '../../src/models/ErrorHandler';
 import program from '../../src/bin/program';
+
+const assert = require('chai').assert
 
 program.Command.prototype.parseReset = function() {
   var self = this
@@ -56,6 +59,7 @@ exports.stubCommands = function () {
     this.status = sinon.stub(status, 'default')
     this.update = sinon.stub(update, 'default')
     this.verify = sinon.stub(verify, 'default')
+    this.setAdmin = sinon.stub(setAdmin, 'default')
     this.errorHandler = sinon.stub(ErrorHandler.prototype, 'call').callsFake(() => null)
     this.runWithTruffle = sinon.stub(runWithTruffle, 'default').callsFake(function (script, options) {
       const { network, from, timeout } = Session.getOptions(options)
@@ -82,6 +86,7 @@ exports.stubCommands = function () {
     this.status.restore()
     this.update.restore()
     this.verify.restore()
+    this.setAdmin.restore()
     this.errorHandler.restore()
     this.runWithTruffle.restore()
     program.parseReset()

--- a/packages/cli/test/scripts/set-admin.test.js
+++ b/packages/cli/test/scripts/set-admin.test.js
@@ -1,7 +1,7 @@
 'use strict'
 require('../setup')
 
-import { Contracts, AppProject, Proxy } from "zos-lib";
+import { Proxy } from "zos-lib";
 
 import push from '../../src/scripts/push.js';
 import createProxy from '../../src/scripts/create.js';
@@ -59,6 +59,10 @@ contract('set-admin script', function([_skipped, owner, newAdmin, anotherNewAdmi
 
     it('refuses to update all proxies', async function () {
       await setAdmin({ newAdmin, network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/address or name of the contract/);
+    })
+
+    it('refuses to update all proxies given package name', async function () {
+      await setAdmin({ packageName: "Herbs", newAdmin, network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/address or name of the contract/);
     })
   });
 

--- a/packages/cli/test/scripts/set-admin.test.js
+++ b/packages/cli/test/scripts/set-admin.test.js
@@ -1,0 +1,96 @@
+'use strict'
+require('../setup')
+
+import { Contracts, AppProject, Proxy } from "zos-lib";
+
+import push from '../../src/scripts/push.js';
+import createProxy from '../../src/scripts/create.js';
+import setAdmin from '../../src/scripts/set-admin.js';
+import ZosPackageFile from "../../src/models/files/ZosPackageFile";
+
+contract('set-admin script', function([_skipped, owner, newAdmin, anotherNewAdmin]) {
+  const network = 'test';
+  const version_1 = '1.1.0';
+  const txParams = { from: owner };
+
+  const assertAdmin = async function (address, expectedAdmin, networkFile) {
+    const actualAdmin = await Proxy.at(address).admin()
+    actualAdmin.should.eq(expectedAdmin, "Admin property in deployed proxy does not match")
+    
+    const proxyInfo = networkFile.getProxies({}).find(p => p.address === address)
+    if (!proxyInfo.admin) expectedAdmin.should.eq(networkFile.appAddress, "Expected admin should be app address as proxy admin is missing")
+    else proxyInfo.admin.should.eq(expectedAdmin, "Admin field in network json file does not match")
+  }
+
+  describe('on application contract', function () {
+    beforeEach('setup', async function() {
+      this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
+      this.networkFile = this.packageFile.networkFile(network)
+      await push({ network, txParams, networkFile: this.networkFile })
+
+      this.impl1 = await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+      this.impl2 = await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+      this.anotherImpl = await createProxy({ contractAlias: 'AnotherImpl', network, txParams, networkFile: this.networkFile });
+    });
+
+    it('changes admin of a proxy given its address', async function() {
+      await setAdmin({ proxyAddress: this.impl1.address, newAdmin, network, txParams, networkFile: this.networkFile });
+
+      await assertAdmin(this.impl1.address, newAdmin, this.networkFile)
+      await assertAdmin(this.impl2.address, this.networkFile.appAddress, this.networkFile)
+      await assertAdmin(this.anotherImpl.address, this.networkFile.appAddress, this.networkFile)
+    });
+
+    it('changes admin of several proxies given name', async function() {
+      await setAdmin({ contractAlias: 'Impl', newAdmin, network, txParams, networkFile: this.networkFile });
+      
+      await assertAdmin(this.impl1.address, newAdmin, this.networkFile)
+      await assertAdmin(this.impl2.address, newAdmin, this.networkFile)
+      await assertAdmin(this.anotherImpl.address, this.networkFile.appAddress, this.networkFile)
+    });
+
+    it('does not attempt to change admin of unowned proxy', async function() {
+      await setAdmin({ proxyAddress: this.impl1.address, newAdmin, network, txParams, networkFile: this.networkFile });
+      await setAdmin({ contractAlias: 'Impl', newAdmin: anotherNewAdmin, network, txParams, networkFile: this.networkFile });
+      await assertAdmin(this.impl1.address, newAdmin, this.networkFile)
+      await assertAdmin(this.impl2.address, anotherNewAdmin, this.networkFile)
+      await assertAdmin(this.anotherImpl.address, this.networkFile.appAddress, this.networkFile)
+    });
+
+    it('refuses to update all proxies', async function () {
+      await setAdmin({ newAdmin, network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/address or name of the contract/);
+    })
+  });
+
+  describe('on dependency contract', function () {
+    beforeEach('setup', async function() {
+      this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
+      this.networkFile = this.packageFile.networkFile(network)
+      await push({ network, txParams, deployLibs: true, networkFile: this.networkFile })
+
+      this.greeter1 = await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+      this.greeter2 = await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+    });
+
+    it('changes admin of a proxy given its address', async function() {
+      await setAdmin({ proxyAddress: this.greeter1.address, newAdmin, network, txParams, networkFile: this.networkFile });
+      
+      await assertAdmin(this.greeter1.address, newAdmin, this.networkFile)
+      await assertAdmin(this.greeter2.address, this.networkFile.appAddress, this.networkFile)
+    });
+
+    it('changes admin of several proxies given package and name', async function() {
+      await setAdmin({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', newAdmin, network, txParams, networkFile: this.networkFile });
+      
+      await assertAdmin(this.greeter1.address, newAdmin, this.networkFile)
+      await assertAdmin(this.greeter2.address, newAdmin, this.networkFile)
+    });
+
+    it('changes no admins if package is missing', async function() {
+      await setAdmin({ contractAlias: 'Greeter', newAdmin, network, txParams, networkFile: this.networkFile });
+      
+      await assertAdmin(this.greeter1.address, this.networkFile.appAddress, this.networkFile)
+      await assertAdmin(this.greeter2.address, this.networkFile.appAddress, this.networkFile)
+    });
+  });
+});

--- a/packages/lib/src/project/AppProject.js
+++ b/packages/lib/src/project/AppProject.js
@@ -60,6 +60,11 @@ export default class AppProject extends Project {
   }
 
   // TODO: Testme
+  async changeProxyAdmin(proxyAddress, newAdmin) {
+    return this.app.changeProxyAdmin(proxyAddress, newAdmin)
+  }
+
+  // TODO: Testme
   async createContract(contractClass, { packageName, contractName, initMethod, initArgs }) {
     if (!contractName) contractName = contractClass.contractName
     if (!packageName) packageName = this.name


### PR DESCRIPTION
Add new `set-admin` command to change admin ownership of a proxy. The command requires a `-y` or `--yes` flag to be actually run, otherwise it cowardly refuses. It can be run either with an address, or a contract name (optionally namespaced by a package). For instance:

```bash
$ zos session ...
$ zos set-admin MyContract $NEWADMIN -y
$ zos set-admin OpenZeppelin/ERC20 $NEWADMIN -y
$ zos set-admin 0x40 $NEWADMIN -y
```

Fixes #3 