### PR TITLE
Extend link CLI command to support multiple dependencies

### DIFF
--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -20,13 +20,14 @@ const register = program => program
   .action(action)
 
 async function action(name, version, options) {
-  const { force } = options
+  const { force, link, install: installLibs } = options
+
   if (options.lib) {
-    if (options.link) throw Error('Cannot set a stdlib in a library project')
+    if (link) throw Error('Cannot set a stdlib in a library project')
     await initLib({ name, version, force })
   } else {
-    const { link: libNameVersion, install: installLib } = options
-    await init({ name, version, libNameVersion, installLib, force })
+    const libs = link ? link.split(',') : []
+    await init({ name, version, libs, installLibs, force })
   }
   await push.tryAction(options)
 }

--- a/packages/cli/src/commands/link.js
+++ b/packages/cli/src/commands/link.js
@@ -4,20 +4,20 @@ import push from './push'
 import linkStdlib from '../scripts/link'
 
 const name = 'link'
-const signature = `${name} <library>`
-const description = 'links project with a library located in the <library> npm package'
+const signature = `${name} [libraries...]`
+const description = 'links project with a list of libraries located in each library npm package'
 
 const register = program => program
   .command(signature, { noHelp: true })
-  .usage('<library> [options]')
+  .usage('[libraryName1 ... libraryNameN] [options]')
   .description(description)
   .option('--no-install', 'skip installing library dependencies locally')
   .withPushOptions()
   .action(action)
 
-async function action(libNameVersion, options) {
-  const installLib = options.install
-  await linkStdlib({ libNameVersion, installLib })
+async function action(libs, options) {
+  const installLibs = options.install
+  await linkStdlib({ libs, installLibs })
   await push.tryAction(options)
 }
 

--- a/packages/cli/src/models/local/LocalAppController.js
+++ b/packages/cli/src/models/local/LocalAppController.js
@@ -3,12 +3,12 @@ import NetworkAppController from '../network/NetworkAppController';
 import Dependency from '../dependency/Dependency';
 
 export default class LocalAppController extends LocalBaseController {
-  async linkLib(libNameVersion, installLib = false) {
-    if (libNameVersion) {
+  async linkLibs(libs, installLibs = false) {
+    await Promise.all(libs.map(async libNameVersion => {
       const dependency = Dependency.fromNameWithVersion(libNameVersion)
-      if (installLib) await dependency.install()
+      if (installLibs) await dependency.install()
       this.packageFile.setDependency(dependency.name, dependency.requirement)
-    }
+    }))
   }
 
   onNetwork(network, txParams, networkFile = undefined) {

--- a/packages/cli/src/scripts/init.js
+++ b/packages/cli/src/scripts/init.js
@@ -6,6 +6,6 @@ export default async function init({ name, version, libs = [], installLibs = fal
   
   const controller = new LocalAppController(packageFile)
   controller.init(name, version, force)
-  if (!libs.length) await controller.linkLibs(libs, installLibs)
+  if (libs.length !== 0) await controller.linkLibs(libs, installLibs)
   controller.writePackage()
 }

--- a/packages/cli/src/scripts/init.js
+++ b/packages/cli/src/scripts/init.js
@@ -1,11 +1,11 @@
 import LocalAppController from  '../models/local/LocalAppController'
 import ZosPackageFile from "../models/files/ZosPackageFile"
 
-export default async function init({ name, version, libNameVersion = undefined, installLib = false, force = false, packageFile = new ZosPackageFile() }) {
+export default async function init({ name, version, libs = [], installLibs = false, force = false, packageFile = new ZosPackageFile() }) {
   if (!name) throw Error('A project name must be provided to initialize the project.')
   
   const controller = new LocalAppController(packageFile)
   controller.init(name, version, force)
-  if (libNameVersion) await controller.linkLib(libNameVersion, installLib)
+  if (!libs.length) await controller.linkLibs(libs, installLibs)
   controller.writePackage()
 }

--- a/packages/cli/src/scripts/link.js
+++ b/packages/cli/src/scripts/link.js
@@ -1,12 +1,12 @@
 import stdout from '../utils/stdout';
 import ControllerFor from "../models/local/ControllerFor";
 
-export default async function linkStdlib({ libNameVersion, installLib = false, packageFile = undefined }) {
+export default async function linkStdlib({ libs = [], installLibs = false, packageFile = undefined }) {
   const controller = ControllerFor(packageFile)
-  if (!libNameVersion) throw Error('The library name and version to be linked must be provided.')
+  if (!libs.length) throw Error('At least one library name and version to be linked must be provided.')
   if (controller.isLib) throw Error('Libraries cannot use a stdlib.')
 
-  await controller.linkLib(libNameVersion, installLib)
+  await controller.linkLibs(libs, installLibs)
   controller.writePackage()
-  stdout(libNameVersion)
+  libs.forEach(libNameVersion => stdout(libNameVersion))
 }

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -7,8 +7,9 @@ contract('init command', function() {
 
   stubCommands()
 
-  itShouldParse('should call init script with name, version and lib', 'init', 'zos init MyApp 0.2.0 --link mock-stdlib@1.1.0 --force --no-install', function(init) {
-    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', libNameVersion: 'mock-stdlib@1.1.0', installLib: false, force: true })
+  itShouldParse('should call init script with name, version and lib', 'init', 'zos init MyApp 0.2.0 --force --no-install --link mock-stdlib@1.1.0,mock-stdlib2@1.2.0', function(init) {
+    const libs = ['mock-stdlib@1.1.0', 'mock-stdlib2@1.2.0']
+    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', libs, installLibs: false, force: true })
   })
 
   itShouldParse('should call init-lib script with name, version', 'initLib', 'zos init MyLib 0.2.0 --lib --force', function(initLib) {

--- a/packages/cli/test/commands/link.test.js
+++ b/packages/cli/test/commands/link.test.js
@@ -1,17 +1,18 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
 contract('link command', function() {
 
   stubCommands()
 
-  itShouldParse('should call link script with lib and no install', 'link', 'zos link mock-stdlib@1.1.0 --no-install', function(link) {
-    link.should.have.been.calledWithExactly({ libNameVersion: 'mock-stdlib@1.1.0', installLib: false })
+  itShouldParse('should call link script with a list of libs and no install', 'link', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --no-install', function(link) {
+    const libs = ['mock-stdlib@1.1.0', 'mock-stdlib2@1.2.0']
+    link.should.have.been.calledWithExactly({ libs, installLibs: false })
   })
 
-  itShouldParse('should call push script when passing --push option', 'push', 'zos link mock-stdlib@1.1.0 --push test', function(push) {
+  itShouldParse('should call push script when passing --push option', 'push', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --push test', function(push) {
     push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 

--- a/packages/cli/test/scripts/bump.test.js
+++ b/packages/cli/test/scripts/bump.test.js
@@ -3,7 +3,7 @@ require('../setup')
 
 import add from '../../src/scripts/add.js';
 import bumpVersion from '../../src/scripts/bump.js';
-import linkLib from '../../src/scripts/link.js';
+import linkLibs from '../../src/scripts/link.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
 contract('bump script', function() {
@@ -29,7 +29,7 @@ contract('bump script', function() {
     });
 
     it('should preserve dependencies', async function () {
-      await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+      await linkLibs({ libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });
       await bumpVersion({ version: newVersion, packageFile: this.packageFile });
 
       this.packageFile.getDependencyVersion('mock-stdlib').should.eq('1.1.0');

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -7,7 +7,7 @@ import { Contracts, Logger } from 'zos-lib';
 import add from '../../src/scripts/add.js';
 import push from '../../src/scripts/push.js';
 import createProxy from '../../src/scripts/create.js';
-import linkLib from '../../src/scripts/link.js';
+import linkLibs from '../../src/scripts/link.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
 const ImplV1 = Contracts.getFromLocal('ImplV1');
@@ -154,7 +154,7 @@ contract('create script', function([_, owner]) {
 
   describe('with dependency', function () {
     beforeEach('setting dependency', async function () {
-      await linkLib({ libNameVersion: 'mock-stdlib-undeployed@1.1.0', packageFile: this.packageFile });
+      await linkLibs({ libs: ['mock-stdlib-undeployed@1.1.0'], packageFile: this.packageFile });
       await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
     });
 
@@ -171,7 +171,7 @@ contract('create script', function([_, owner]) {
 
   describe('with unlinked dependency', function () {
     beforeEach('setting dependency', async function () {
-      await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+      await linkLibs({ libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });
     });
 
     it('should refuse create a proxy for unlinked dependency', async function () {

--- a/packages/cli/test/scripts/init.test.js
+++ b/packages/cli/test/scripts/init.test.js
@@ -51,7 +51,7 @@ contract('init script', function() {
     });
 
     it('should set dependency', async function () {
-      await init({ name, version, libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+      await init({ name, version, libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });
       
       this.packageFile.getDependencyVersion('mock-stdlib').should.eq('1.1.0')
     });

--- a/packages/cli/test/scripts/link.test.js
+++ b/packages/cli/test/scripts/link.test.js
@@ -1,7 +1,7 @@
 'use strict'
 require('../setup')
 
-import linkLib from '../../src/scripts/link.js';
+import linkLibs from '../../src/scripts/link.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
 const should = require('chai').should();
@@ -19,51 +19,60 @@ contract('link script', function() {
   });
 
   it('should set a dependency', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+    await linkLibs({ libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });
     this.shouldHaveDependency('mock-stdlib', '1.1.0');
   });
 
   it('should set multiple dependencies', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
-    await linkLib({ libNameVersion: 'mock-stdlib-2@1.2.0', packageFile: this.packageFile });
+    const libs = ['mock-stdlib@1.1.0', 'mock-stdlib-2@1.2.0'];
+    await linkLibs({ libs, packageFile: this.packageFile });
     this.shouldHaveDependency('mock-stdlib', '1.1.0');
     this.shouldHaveDependency('mock-stdlib-2', '1.2.0');
   });
 
   it('should overwrite a dependency version', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@^1.0.0', packageFile: this.packageFile });
-    await linkLib({ libNameVersion: 'mock-stdlib@~1.1.0', packageFile: this.packageFile });
+    const initialLibs = ['mock-stdlib@^1.0.0', 'mock-stdlib-2@1.2.0']
+    const withUpdatedLib = ['mock-stdlib@~1.1.0']
+
+    await linkLibs({ libs: initialLibs, packageFile: this.packageFile });
+    await linkLibs({ libs: withUpdatedLib, packageFile: this.packageFile });
+
     this.shouldHaveDependency('mock-stdlib', '~1.1.0');
+    this.shouldHaveDependency('mock-stdlib-2', '1.2.0');
   });
 
-  it('should install the dependency if requested', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', installLib: true, packageFile: this.packageFile });
+  it('should install all dependencies if requested', async function () {
+    const libs = ['mock-stdlib@1.1.0', 'mock-stdlib-2@1.2.0']
+
+    await linkLibs({ libs, installLib: true, packageFile: this.packageFile });
+
     this.shouldHaveDependency('mock-stdlib', '1.1.0');
+    this.shouldHaveDependency('mock-stdlib-2', '1.2.0');
   });
 
   it('should refuse to set a dependency for a lib project', async function () {
     this.packageFile.lib = true
-    await linkLib({ libNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile })
+    await linkLibs({ libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile })
       .should.be.rejectedWith('Libraries cannot use a stdlib');
   });
 
   it('should raise an error if requested version of dependency does not match its package version', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib-invalid@1.0.0', packageFile: this.packageFile })
+    await linkLibs({ libs: ['mock-stdlib-invalid@1.0.0'], packageFile: this.packageFile })
       .should.be.rejectedWith('Required dependency version 1.0.0 does not match dependency package version 2.0.0')
   });
 
   it('should install the dependency if a valid version range is requested', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@^1.0.0', installLib: true, packageFile: this.packageFile });
+    await linkLibs({ libs: ['mock-stdlib@^1.0.0'], installLib: true, packageFile: this.packageFile });
     this.shouldHaveDependency('mock-stdlib', '^1.0.0');
   });
 
   it('should install the dependency if no version is requested', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib', installLib: true, packageFile: this.packageFile });
+    await linkLibs({ libs: ['mock-stdlib'], installLib: true, packageFile: this.packageFile });
     this.shouldHaveDependency('mock-stdlib', '^1.1.0');
   });
 
   it('should raise an error if requested version range does not match its package version', async function () {
-    await linkLib({ libNameVersion: 'mock-stdlib@~1.0.0', packageFile: this.packageFile })
+    await linkLibs({ libs: ['mock-stdlib@~1.0.0'], packageFile: this.packageFile })
       .should.be.rejectedWith('Required dependency version ~1.0.0 does not match dependency package version 1.1.0')
   });
-});
+})

--- a/packages/cli/test/scripts/status.test.js
+++ b/packages/cli/test/scripts/status.test.js
@@ -6,7 +6,7 @@ import push from '../../src/scripts/push.js';
 import bumpVersion from '../../src/scripts/bump.js';
 import createProxy from '../../src/scripts/create.js';
 import status from '../../src/scripts/status.js';
-import linkLib from '../../src/scripts/link';
+import linkLibs from '../../src/scripts/link';
 import ControllerFor from '../../src/models/local/ControllerFor';
 import CaptureLogs from '../helpers/captureLogs';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
@@ -19,7 +19,7 @@ contract('status script', function([_, owner]) {
   const contractAlias = 'Impl';
   const contractsData = [{ name: contractName, alias: contractAlias }]
   const anotherContractName = 'AnotherImplV1';
-  const libNameVersion = 'mock-stdlib@1.1.0';
+  const libs = ['mock-stdlib@1.1.0'];
   
   beforeEach('setup', async function() {
     this.capturingLogs = ((promise) => {
@@ -142,7 +142,7 @@ contract('status script', function([_, owner]) {
   const shouldDescribeUnlinkedDependency = function () {
     it('should log missing library', async function () {
       await push({ network, txParams, networkFile: this.networkFile });
-      await linkLib({ packageFile: this.packageFile, libNameVersion, installLib: false });
+      await linkLibs({ packageFile: this.packageFile, libs, installLib: false });
       await this.capturingLogs(status({ network, networkFile: this.networkFile }));
 
       this.logs.text.should.match(/mock-stdlib@1.1.0 is required but is not linked/i);
@@ -160,7 +160,7 @@ contract('status script', function([_, owner]) {
       });
 
       it('should log connected dependency when semver requirement matches', async function () {
-        await linkLib({ packageFile: this.packageFile, libNameVersion: 'mock-stdlib-undeployed@^1.0.0', installLib: false });
+        await linkLibs({ packageFile: this.packageFile, libs: ['mock-stdlib-undeployed@^1.0.0'], installLib: false });
         await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
         this.networkFile.updateDependency('mock-stdlib-undeployed', dep => ({ ... dep, customDeploy: false }))
         await this.capturingLogs(status({ network, networkFile: this.networkFile }));

--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -8,7 +8,7 @@ import CaptureLogs from '../helpers/captureLogs';
 import add from '../../src/scripts/add.js';
 import push from '../../src/scripts/push.js';
 import bumpVersion from '../../src/scripts/bump.js';
-import linkLib from '../../src/scripts/link.js';
+import linkLibs from '../../src/scripts/link.js';
 import createProxy from '../../src/scripts/create.js';
 import update from '../../src/scripts/update.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
@@ -213,7 +213,7 @@ contract('update script', function([_skipped, owner]) {
       await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
 
       await bumpVersion({ version: version_2, txParams, packageFile: this.packageFile });
-      await linkLib({ txParams, libNameVersion: 'mock-stdlib-undeployed-2@1.2.0', packageFile: this.packageFile });
+      await linkLibs({ txParams, libs: ['mock-stdlib-undeployed-2@1.2.0'], packageFile: this.packageFile });
       await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
 
       // We modify the proxies' package to v2, so we can upgrade them, simulating an upgrade to mock-stdlib-undeployed


### PR DESCRIPTION
Example usage:
```console
foo@bar:~$ zos link openzeppelin-zos gnosis-safe
```
or
```console
foo@bar:~$ zos init MyUpgradeableProjectWithDependencies 0.0.1 --link openzeppelin-zos,gnosis-safe
```