### PR TITLE
Add guide on writing upgradeable contracts

### DIFF
--- a/packages/docs/docs/docs/advanced.md
+++ b/packages/docs/docs/docs/advanced.md
@@ -84,7 +84,9 @@ contract MyContract_v2 {
 
 Note that this must be so _even if you no longer use the variables_. There is no restriction (apart from gas limits) on including new variables in the upgraded versions of your contracts, or on removing or adding functions.
 
-This restriction is due to how [Solidity uses the storage space](https://solidity.readthedocs.io/en/v0.4.21/miscellaneous.html#layout-of-state-variables-in-storage). In short, the variables are allocated storage space in the order they appear (for the whole variable or some pointer to the actual storage slot, in the case of dynamically sized variables). When we upgrade a contract, its storage contents are preserved. This entails that if we remove variables, the new ones will be assigned storage space that is already occupied by the old variables.
+This restriction is due to how [Solidity uses the storage space](https://solidity.readthedocs.io/en/v0.4.21/miscellaneous.html#layout-of-state-variables-in-storage). In short, the variables are allocated storage space in the order they appear (for the whole variable or some pointer to the actual storage slot, in the case of dynamically sized variables). When we upgrade a contract, its storage contents are preserved. This entails that if we remove variables, the new ones will be assigned storage space that is already occupied by the old variables. 
+
+We are working to automatically detect any incompatible modifications to the storage structure, but for the time being, you need to perform this check manually whenever you introduce a new change.
 
 ## Initializers vs. constructors
 As we saw in the [Building upgradeable applications](building.md) guide, we did not include a constructor in our contracts, but used instead an `initialize` function. The reason for this is that constructors do not work as regular functions: they are invoked once upon a contract's creation, but their code is never stored in the blockchain. This means that they cannot be called from the contract's proxy as we call other functions. Thus, if we want to initialize variables in the _proxy's storage_, we need to include a regular function for doing so.

--- a/packages/docs/docs/docs/building.md
+++ b/packages/docs/docs/docs/building.md
@@ -16,7 +16,7 @@ Next, let's create a file named `MyContract.sol` in the `contracts/` folder with
 
 ```js
 pragma solidity ^0.4.21;
-import "zos-lib/contracts/migrations/Initializable.sol";
+import "zos-lib/contracts/Initializable.sol";
 
 contract MyContract is Initializable {
   uint256 public x;

--- a/packages/docs/docs/docs/writing_contracts.md
+++ b/packages/docs/docs/docs/writing_contracts.md
@@ -1,0 +1,252 @@
+---
+id: writing_contracts
+title: Writing upgradeable contracts
+sidebar_label: Writing upgradeable contracts
+---
+
+When working with upgradeable contracts in ZeppelinOS, there are a few minor caveats to keep in mind when writing your Solidity code. It's worth mentioning that these restrictions have their roots in how the Ethereum VM works, and apply to all projects that work with upgradeable contracts, not just ZeppelinOS.
+
+## Initializers
+
+You can use your Solidity contracts in ZeppelinOS without any modifications, except for their _constructors_. Due to a requirement of the proxy-based upgradeability system, no constructors can be used in upgradeable contracts. You can read in-depth about the reasons behind this restriction [in the advanced topics section](advanced.md#initializers-vs-constructors).
+
+This means that, when using a contract within ZeppelinOS, you need to change its constructor into a regular function, typically named `initialize`, where you run all the setup logic:
+
+```js
+// NOTE: Do not use this code snippet, it's incomplete and has a critical vulnerability!
+contract MyContract {
+  uint256 public x;
+
+  function initialize(uint256 _x) public {
+    x = _x;
+  }
+}
+```
+
+However, while Solidity ensures that a `constructor` is called only once in the lifetime of a contract, a regular function can be called many times. To prevent a contract from being _initialized_ multiple times, you need to add a check to ensure the `initialize` function is called only once:
+
+```js
+contract MyContract {
+  uint256 public x;
+  bool private initialized;
+
+  function initialize(uint256 _x) public {
+    require(!initialized);
+    initialized = true;
+    x = _x;
+  }
+}
+```
+
+Since this pattern is very common when writing upgradeable contracts, ZeppelinOS provides an `Initializable` base contract that has an `initializer` modifier that takes care of this:
+
+```js
+import "zos-lib/contracts/Initializable.sol";
+
+contract MyContract is Initializable {
+  uint256 public x;
+
+  function initialize(uint256 _x) initializer public {
+    x = _x;
+  }
+}
+```
+
+> **Note**: If you have a parameterless constructor in any of your contracts, ZeppelinOS will be able to use it without any errors, but the constructor will not be executed in your contract instances.
+
+Another difference between a `constructor` and a regular function is that Solidity takes care of automatically invoking the constructors of all ancestors of a contract. When writing an initializer, you need to take spacial care to manually call the initializers of all parent contracts:
+
+```js
+import "zos-lib/contracts/Initializable.sol";
+
+contract BaseContract is Initializable {
+  uint256 public y;
+
+  function initialize() initializer public {
+    y = 42;
+  }
+}
+
+contract MyContract is BaseContract {
+  uint256 public x;
+
+  function initialize(uint256 _x) initializer public {
+    BaseContract.initialize(); // Do not forget this call!
+    x = _x;
+  }
+}
+```
+
+### Use upgradeable libraries
+
+Keep in mind that this restriction affects not only your contracts, but also the contracts you import from a library. For instance, if you use the [`DetailedERC20` token implementation](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v1.12.0/contracts/token/ERC20/DetailedERC20.sol) from OpenZeppelin, the contract initializes the token's name, symbol and decimals in its constructor:
+
+```js
+contract DetailedERC20 is ERC20 {
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+
+  constructor(string _name, string _symbol, uint8 _decimals) public {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+  }
+}
+```
+
+This means that you should not be using these contracts in your ZeppelinOS project. Instead, make sure to use `openzeppelin-zos`, which is an official fork of OpenZeppelin, which has been modified to use initializers instead of constructors. For instance, an ERC20 implementation provided by `openzeppelin-zos` is the [`DetailedMintableToken`](https://github.com/OpenZeppelin/openzeppelin-zos/blob/v1.9.4/contracts/token/ERC20/DetailedMintableToken.sol):
+
+```js
+contract DetailedMintableToken is Initializable, DetailedERC20, MintableToken {
+  function initialize(address _sender, string _name, string _symbol, uint8 _decimals)
+    initializer public
+  {
+    DetailedERC20.initialize(_name, _symbol, _decimals);
+    MintableToken.initialize(_sender);
+  }
+}
+```
+
+Whether it is OpenZeppelin or another shared smart contracts library, always make sure that the library is set up to handle upgradeable contracts.
+
+## Creating new instances from your contract code
+
+When creating a new instance of a contract from your contract's code, these creations are handled directly by Solidity and not by ZeppelinOS, which means that **these contracts will not be upgradeable**. 
+
+For instance, in the following example, even if `MyContract` is upgradeable (if created via `zos create MyContract`), the `token` contract created is not:
+
+```js
+import "zos-lib/contracts/Initializable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
+
+contract MyContract is Initializable {
+  StandardToken public token;
+
+  function initialize() initializer public {
+    token = new DetailedERC20("Test", "TST", 18); // This contract will not be upgradeable
+  }
+}
+```
+
+The easiest way around this issue is to avoid creating contracts from your own altogether: instead of creating a contract in an `initialize` function, simply accept an instance of that contract as a parameter, and inject it after creating it from ZeppelinOS:
+
+```js
+import "zos-lib/contracts/Initializable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+
+contract MyContract is Initializable {
+  StandardToken public token;
+
+  function initialize(StandardToken _token) initializer public {
+    token = _token; // This contract will be upgradeable if it was created via ZeppelinOS
+  }
+}
+```
+
+```bash
+$ TOKEN=$(zos create TokenContract)
+$ zos create MyContract --init --args $TOKEN
+```
+
+An advanced alternative, if you need to create upgradeable contracts on the fly, is to keep an instance of your ZeppelinOS `App` in your contracts. The [`App`](api_application_BaseApp.md) is a contract that acts as the entrypoint for your ZeppelinOS project, which has references to your logic implementations, and can create new contract instances:
+
+```js
+import "zos-lib/contracts/Initializable.sol";
+import "zos-lib/contracts/application/BaseApp.sol";
+
+contract MyContract is Initializable {
+  BaseApp private app;
+
+  function initialize(BaseApp _app) initializer public {
+    app = _app;
+  }
+
+  function createNewToken() public returns(address) {
+    return app.create("openzeppelin-zos", "DetailedPremintedToken");
+  }
+}
+```
+
+## Modifying your contracts
+
+When writing new versions of your contracts, either due to new features or bugfixing, there is an additional restriction to observe: you cannot change the order in which the contract state variables are declared, nor their type. You can read more about the reasons behind this restriction [in the advanced topics section](advanced.md#preserving-the-storage-structure).
+
+This means that if you have an initial contract that looks like this:
+
+```js
+contract MyContract {
+  uint256 private x;
+  string private y;
+}
+```
+
+Then you cannot change the type of a variable:
+
+```js
+contract MyContract {
+  string private x;
+  string private y;
+}
+```
+
+Or change the order in which they are declared:
+
+```js
+contract MyContract {
+  string private y;
+  uint256 private x; 
+}
+```
+
+Or introduce a new variable before existing ones:
+
+```js
+contract MyContract {
+  bytes private a;
+  uint256 private x; 
+  string private y;
+}
+```
+
+Or remove an existing variable:
+
+```js
+contract MyContract {
+  string private y;
+}
+```
+
+If you need to introduce a new variable, make sure you always do so at the end:
+
+```js
+contract MyContract {
+  uint256 private x;
+  string private y;
+  bytes private z;
+}
+```
+
+
+Note that you may also be inadvertently changing the storage variables of your contract by changing its parent contracts. For instance, if you have the following contracts:
+
+```js
+contract A {
+  uint256 a;
+}
+
+contract B {
+  uint256 b;
+}
+
+contract MyContract is A, B { }
+```
+
+Then modifying `MyContract` by swapping the order in which the base contracts are declared, or introducing new base contracts, will change how the variables are actually stored:
+
+```js
+contract MyContract is B, A { }
+```
+
+Violating any of these storage layout restrictions will cause the upgraded version of the contract to have its storage values mixed up, and can lead to critical errors in your application.

--- a/packages/docs/docs/website/i18n/en.json
+++ b/packages/docs/docs/website/i18n/en.json
@@ -57,6 +57,8 @@
     "using": "Using the stdlib in your app",
     "Using the stdlib": "Using the stdlib",
     "whitepaper": "Whitepaper",
+    "writing_contracts": "Writing upgradeable contracts",
+    "Writing upgradeable contracts": "Writing upgradeable contracts",
     "Guides": "Guides",
     "Reference": "Reference",
     "Blog": "Blog",

--- a/packages/docs/docs/website/sidebars.json
+++ b/packages/docs/docs/website/sidebars.json
@@ -8,6 +8,7 @@
       "building",
       "using",
       "developing",
+      "writing_contracts",
       "testing"
     ],
     "DEMOS": [


### PR DESCRIPTION
Includes a section on using Initializable (fixes #48), another on
creating contracts from code (since I was at it), and yet another
explanation on preserving the storage layout (since it has been
a topic of confusion).