### PR TITLE
Remove swarm hash from bytecode before hashing it

### DIFF
--- a/packages/cli/src/utils/contracts.js
+++ b/packages/cli/src/utils/contracts.js
@@ -12,7 +12,7 @@ export function constructorCode(instance) {
 }
 
 export function bytecodeDigest(rawBytecode) {
-  const bytecode = removeSwarmHash(rawBytecode.replace(/^0x/, ''))
+  const bytecode = tryRemoveSwarmHash(rawBytecode.replace(/^0x/, ''))
   const buffer = Buffer.from(bytecode, 'hex')
   const hash = crypto.createHash('sha256')
   return hash.update(buffer).digest('hex')
@@ -22,16 +22,16 @@ export function flattenSourceCode(contract) {
   return flatten(contract)
 }
 
+// Removes the last 43 bytes of the bytecode, i.e., the swarm hash that the solidity compiler appends and that
+// respects the following structure: 0xa1 0x65 'b' 'z' 'z' 'r' '0' 0x58 0x20 <32 bytes swarm hash> 0x00 0x29
+// (see https://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode)
+export function tryRemoveSwarmHash(bytecode) {
+  return bytecode.replace(/a165627a7a72305820[a-fA-F0-9]{64}0029$/, '')
+}
+
 function splitCode(instance) {
   const bytecode = instance.constructor.bytecode.replace(/^0x/, '')
   const body = instance.constructor.deployedBytecode.replace(/^0x/, '')
   const constructor = bytecode.substr(0, bytecode.indexOf(body))
   return { constructor, body }
-}
-
-// Removes the last 43 bytes of the bytecode, i.e., the swarm hash that the solidity compiler appends and that
-// respects the following structure: 0xa1 0x65 'b' 'z' 'z' 'r' '0' 0x58 0x20 <32 bytes swarm hash> 0x00 0x29
-// (see https://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode)
-function removeSwarmHash(bytecode) {
-  return bytecode.replace(/a165627a7a72305820.*0029$/, '')
 }

--- a/packages/cli/src/utils/contracts.js
+++ b/packages/cli/src/utils/contracts.js
@@ -29,6 +29,9 @@ function splitCode(instance) {
   return { constructor, body }
 }
 
+// Removes the last 43 bytes of the bytecode, i.e., the swarm hash that the solidity compiler appends and that
+// respects the following structure: 0xa1 0x65 'b' 'z' 'z' 'r' '0' 0x58 0x20 <32 bytes swarm hash> 0x00 0x29
+// (see https://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode)
 function removeSwarmHash(bytecode) {
   return bytecode.replace(/a165627a7a72305820.*0029$/, '')
 }

--- a/packages/cli/src/utils/contracts.js
+++ b/packages/cli/src/utils/contracts.js
@@ -1,3 +1,5 @@
+'use strict'
+
 import crypto from 'crypto'
 import flatten from 'truffle-flattener'
 
@@ -9,15 +11,8 @@ export function constructorCode(instance) {
   return splitCode(instance).constructor
 }
 
-export function splitCode(instance) {
-  const bytecode = instance.constructor.bytecode.replace(/^0x/, '')
-  const body = instance.constructor.deployedBytecode.replace(/^0x/, '')
-  const constructor = bytecode.substr(0, bytecode.indexOf(body))
-  return { constructor, body }
-}
-
 export function bytecodeDigest(rawBytecode) {
-  const bytecode = rawBytecode.replace(/^0x/, '')
+  const bytecode = removeSwarmHash(rawBytecode.replace(/^0x/, ''))
   const buffer = Buffer.from(bytecode, 'hex')
   const hash = crypto.createHash('sha256')
   return hash.update(buffer).digest('hex')
@@ -25,4 +20,15 @@ export function bytecodeDigest(rawBytecode) {
 
 export function flattenSourceCode(contract) {
   return flatten(contract)
+}
+
+function splitCode(instance) {
+  const bytecode = instance.constructor.bytecode.replace(/^0x/, '')
+  const body = instance.constructor.deployedBytecode.replace(/^0x/, '')
+  const constructor = bytecode.substr(0, bytecode.indexOf(body))
+  return { constructor, body }
+}
+
+function removeSwarmHash(bytecode) {
+  return bytecode.replace(/a165627a7a72305820.*0029$/, '')
 }

--- a/packages/cli/test/utils/contracts.test.js
+++ b/packages/cli/test/utils/contracts.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+require('../setup')
+
+import { tryRemoveSwarmHash } from '../../src/utils/contracts'
+
+describe('contracts util functions', function() {
+  describe('tryRemoveSwarmHash', function() {
+    describe('with valid swarm hash', function() {
+      it('removes swarm hash from bytecode', function() {
+        const swarmHash = '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a'
+        const swarmHashWrapper = `a165627a7a72305820${swarmHash}0029`
+        const bytecode = `0x01234567890abcdef${swarmHashWrapper}`
+
+        tryRemoveSwarmHash(bytecode).should.eq('0x01234567890abcdef')
+      })
+    })
+
+    describe('with a swarm hash size different than 32 bytes', function() {
+      it('does not change the bytecode', function() {
+        const invalidSwarmHash = '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b4'
+        const swarmHashWrapper = `27a7a72305820${invalidSwarmHash}0029`
+        const bytecode = `0x01234567890abcdefa16560029${swarmHashWrapper}`
+
+        tryRemoveSwarmHash(bytecode).should.eq(bytecode)
+      })
+    })
+
+    describe('with an invalid swarm hash format', function() {
+      it('does not change the bytecode', function() {
+        const swarmHash = '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a'
+        const invalidSwarmHashWrapper = `a165627a7a7230${swarmHash}abab29`
+        const bytecode = `0x01234567890abcdef${invalidSwarmHashWrapper}`
+
+        tryRemoveSwarmHash(bytecode).should.eq(bytecode)
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/38.
@spalladino should we add an option parameter to the `bytecodeDigest` function, e.g., `{ removeSwarmHash: true/false }` to decide whether to remove it or not?