### PR TITLE
Change `from` parameter value to lower case

### DIFF
--- a/packages/cli/src/utils/runWithTruffle.js
+++ b/packages/cli/src/utils/runWithTruffle.js
@@ -7,11 +7,13 @@ const DEFAULT_TIMEOUT = 10 * 60; // 10 minutes
 
 export default async function runWithTruffle(script, options) {
   const config = Truffle.config()
+  const { networks: networkList } = config
   const { network, from, timeout } = Session.getOptions(options)
-  const txParams = from ? { from } : {}
+  const txParams = from ? { from: from.toLowerCase() } : {}
 
   if (!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network
+  if (!from && networkList[network].from) networkList[network].from = networkList[network].from.toLowerCase()
   Contracts.setSyncTimeout((_.isNil(timeout) ? DEFAULT_TIMEOUT : timeout) * 1000)
   if (options.compile) await Truffle.compile(config)
   await initTruffle(config)


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/98.

It seems to be a `truffle-hdwallet-provider` well known problem, as mentioned [here](https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey#notes).