### PR TITLE
Preserve App, Package and Directory addresses

### DIFF
--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -72,13 +72,17 @@ export default class NetworkBaseController {
       log.info(`Creating new version ${requestedVersion}`);
       const provider = await this.newVersion(requestedVersion);
       this.networkFile.contracts = {};
-      this._registerVersion(requestedVersion, provider.address);
+      this._registerVersion(requestedVersion, provider);
     }
   }
 
-  _registerVersion(version, providerAddress) {
-    this.networkFile.provider = { address: providerAddress };
-    this.networkFile.version = version;
+  _registerPackage({ address }) {
+    this.networkFile.package = { address }
+  }
+
+  _registerVersion(version, { address }) {
+    this.networkFile.provider = { address }
+    this.networkFile.version = version
   }
 
   async newVersion(versionName) {

--- a/packages/cli/src/models/network/NetworkLibController.js
+++ b/packages/cli/src/models/network/NetworkLibController.js
@@ -13,11 +13,18 @@ export default class NetworkLibController extends NetworkBaseController {
   }
 
   async deploy() {
-    this.project = await LibProject.deploy(this.currentVersion, this.txParams)
-    const thepackage = await this.project.getProjectPackage()
-    this.networkFile.package = { address: thepackage.address }
-    const provider = await this.project.getCurrentDirectory();
-    this._registerVersion(this.currentVersion, provider.address)
+    try {
+      this.project = await LibProject.deploy(this.currentVersion, this.txParams)
+      this._registerPackage(await this.project.getProjectPackage())
+      this._registerVersion(this.currentVersion, await this.project.getCurrentDirectory())
+    } catch(deployError) {
+      this._tryRegisterPartialDeploy(deployError)
+    }
+  }
+
+  _tryRegisterPartialDeploy({ thepackage, directory }) {
+    if (thepackage) this._registerPackage(thepackage)
+    if (directory) this._registerVersion(this.currentVersion, directory)
   }
 
   async fetch() {

--- a/packages/lib/src/project/AppProject.js
+++ b/packages/lib/src/project/AppProject.js
@@ -1,6 +1,7 @@
 import BasePackageProject from "./BasePackageProject";
 import VersionedApp from "../app/VersionedApp";
 import Package from "../package/Package";
+import { AppDeployError } from '../utils/errors/DeployError';
 import _ from 'lodash';
 
 export default class AppProject extends BasePackageProject {
@@ -13,14 +14,20 @@ export default class AppProject extends BasePackageProject {
   }
 
   static async deploy(name = 'main', version = '0.1.0', txParams = {}) {
-    const thepackage = await Package.deploy(txParams)
-    const directory = await thepackage.newVersion(version)
-    const app = await VersionedApp.deploy(txParams)
-    await app.setPackage(name, thepackage.address, version)
-    const project = new this(app, name, version, txParams)
-    project.directory = directory
-    project.package = thepackage
-    return project
+    let thepackage, directory, app
+    try {
+      thepackage = await Package.deploy(txParams)
+      directory = await thepackage.newVersion(version)
+      app = await VersionedApp.deploy(txParams)
+      await app.setPackage(name, thepackage.address, version)
+      const project = new this(app, name, version, txParams)
+      project.directory = directory
+      project.package = thepackage
+
+      return project
+    } catch(error) {
+      throw new AppDeployError(error.message, thepackage, directory, app)
+    }
   }
 
   constructor(app, name = 'main', version = '0.1.0', txParams = {}) {

--- a/packages/lib/src/project/LibProject.js
+++ b/packages/lib/src/project/LibProject.js
@@ -1,5 +1,6 @@
 import BasePackageProject from "./BasePackageProject";
 import Package from "../package/Package";
+import { DeployError as LibDeployError } from '../utils/errors/DeployError';
 
 export default class LibProject extends BasePackageProject {
   static async fetch(packageAddress, version = '0.1.0', txParams) {
@@ -8,11 +9,17 @@ export default class LibProject extends BasePackageProject {
   }
 
   static async deploy(version = '0.1.0', txParams = {}) {
-    const thepackage = await Package.deploy(txParams)
-    const directory = await thepackage.newVersion(version)
-    const project = new this(thepackage, version, txParams)
-    project.directory = directory
-    return project
+    let thepackage, directory
+    try {
+      thepackage = await Package.deploy(txParams)
+      directory = await thepackage.newVersion(version)
+      const project = new this(thepackage, version, txParams)
+      project.directory = directory
+
+      return project
+    } catch(deployError) {
+      throw new LibDeployError(error.message, thepackage, directory)
+    }
   }
 
   constructor(thepackage, version = '0.1.0', txParams = {}) {

--- a/packages/lib/src/utils/errors/DeployError.js
+++ b/packages/lib/src/utils/errors/DeployError.js
@@ -1,0 +1,17 @@
+'use strict'
+
+export class DeployError extends Error {
+  constructor(message, thepackage, directory) {
+    super(message)
+    this.package = thepackage
+    this.directory = directory
+  }
+}
+
+export class AppDeployError extends DeployError {
+  constructor(message, thepackage, directory, app) {
+    super(message, thepackage, directory)
+    this.app = app
+  }
+}
+


### PR DESCRIPTION
Related to #35
A first approach to preserve addresses in `zos.network.json` if the project deployment fails at some point.

- [x] Implement an app, package and directory address tracker in lib and cli.
- [ ] Pick up already deployed contracts addresses on  future `push` runs.