### PR TITLE
Validate storage layout

### DIFF
--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -1,7 +1,9 @@
 pragma solidity ^0.4.24;
 
 contract ImplV1 {
-  uint256 public value;
+  uint256 public value1;
+  uint256 public value2;
+  uint256 public value3;
 
   function initialize(uint256 _value) public {
     value = _value;

--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -1,9 +1,7 @@
 pragma solidity ^0.4.24;
 
 contract ImplV1 {
-  uint256 public value1;
-  uint256 public value2;
-  uint256 public value3;
+  uint256 public value;
 
   function initialize(uint256 _value) public {
     value = _value;

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9599,8 +9599,9 @@
       "integrity": "sha1-1bJ63qTFUvQ7cNwAh3I2t7aMdcg="
     },
     "truffle-flattener": {
-      "version": "github:alcuadrado/truffle-flattener#4b65f307ef2bcb0fd93fe44729a367d1f89c1eb9",
+      "version": "github:alcuadrado/truffle-flattener#b473640480dc177541e8ddce1bc4293f40a19a23",
       "requires": {
+        "chalk": "2.4.1",
         "find-up": "2.1.0",
         "mkdirp": "0.5.1",
         "semver": "5.5.0",

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -15,13 +15,14 @@ const register = program => program
   .option('--skip-compile', 'skips contract compilation')
   .option('-d, --deploy-libs', 'deploys libraries to the network if there is no existing deployment')
   .option('--reset', 'redeploys all contracts (not only the ones that changed)')
+  .option('-f, --force', 'ignores validation errors and deploys contracts')
   .withNetworkOptions()
   .action(action)
 
 async function action(options) {
-  const { skipCompile, deployLibs, reset: reupload } = options
+  const { skipCompile, deployLibs, force, reset: reupload } = options
   await runWithTruffle(
-    async (opts) => await push({ deployLibs, reupload, ... opts }),
+    async (opts) => await push({ force, deployLibs, reupload, ... opts }),
     { compile: !skipCompile, ... options }
   )
 }

--- a/packages/cli/src/interface/Validations.js
+++ b/packages/cli/src/interface/Validations.js
@@ -26,44 +26,44 @@ export function logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedS
 
     switch (action) {
       case 'insert':
-        log.error(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
-                  `  This pushes all variables after ${updated.label} to a higher position in storage, `+
+        log.error(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}. ` +
+                  `This pushes all variables after ${updated.label} to a higher position in storage, `+
                   `causing the updated contract to read incorrect initial values. Only add new variables at the `+
                   `end of your contract to prevent this issue.`);
         break;
       case 'delete':
-        log.error(`- Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
-                  `  This will move all variables after ${original.label} to a lower position in storage, `+
+        log.error(`- Variable '${originalVarDescription}' was removed from contract ${original.contract}. `+
+                  `This will move all variables after ${original.label} to a lower position in storage, `+
                   `causing the updated contract to read incorrect initial values. Avoid deleting existing ` +
                   `variables to prevent this issue, and rename them to communicate that they are not to be used.`);
         break;
       case 'append':
         log.info(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
-                 `at the end of the contract.\n` +
-                 `  This does not alter the original storage, and should be a safe change.`)
+                 `at the end of the contract. ` +
+                 `This does not alter the original storage, and should be a safe change.`)
         break;
       case 'pop':
-        log.warn(`- Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
-                 `  Though this will not alter the positions in storage of other variables, if a new variable is added ` +
+        log.warn(`- Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}. `+
+                 `Though this will not alter the positions in storage of other variables, if a new variable is added ` +
                  `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
                  `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
         break;
       case 'rename':
-        log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
-                 `  Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
+        log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.` +
+                 `Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
                  `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
         break;
       case 'typechange':
         log.warn(`- Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
-                 `to ${updatedVarType.label} in ${updatedVarSource}.\n` + 
-                 `  If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
+                 `to ${updatedVarType.label} in ${updatedVarSource}. ` + 
+                 `If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
                  `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
                  `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
         break;
       case 'replace':
         log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
-                 `in ${updatedVarSource}.\nThis will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
-                 `  If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
+                 `in ${updatedVarSource}. This will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
+                 `If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
                  `initialized with an invalid value after upgrading. Avoid changing types of existing ` +
                  `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
         break;

--- a/packages/cli/src/interface/Validations.js
+++ b/packages/cli/src/interface/Validations.js
@@ -1,4 +1,3 @@
-import { Logger } from "zos-lib";
 import _ from 'lodash';
 
 export function logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, log) {

--- a/packages/cli/src/interface/Validations.js
+++ b/packages/cli/src/interface/Validations.js
@@ -1,0 +1,79 @@
+import { Logger } from "zos-lib";
+import _ from 'lodash';
+
+export function logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, log) {
+  if (_.isEmpty(storageDiff)) return;
+
+  storageDiff.forEach(({ updated, original, action }) => {
+    const updatedSourceCode = updated && fs.exists(updated.path) && fs.read(updated.path)
+    const updatedVarType = updated && updatedStorageInfo.types[updated.type];
+    const updatedVarSource = updated && [updated.path, _srcToLineNumber(updated.path, updated.src)].join(':');
+    const updatedVarDescription = updated && 
+      (_tryGetSourceFragment(updatedSourceCode, updatedVarType.src) 
+       || [updatedVarType.label, updated.label].join(' '));
+    
+    const originalVarType = original && originalStorageInfo.types[original.type];
+    const originalVarDescription = original && [originalVarType.label, original.label].join(' ');
+
+    switch (action) {
+      case 'insert':
+        log.error(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
+                  `  This pushes all variables after ${updated.label} to a higher position in storage, `+
+                  `causing the updated contract to read incorrect initial values. Only add new variables at the `+
+                  `end of your contract to prevent this issue.`);
+        break;
+      case 'delete':
+        log.error(`- Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
+                  `  This will move all variables after ${original.label} to a lower position in storage, `+
+                  `causing the updated contract to read incorrect initial values. Avoid deleting existing ` +
+                  `variables to prevent this issue, and rename them to communicate that they are not to be used.`);
+        break;
+      case 'append':
+        log.info(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
+                 `at the end of the contract.\n` +
+                 `  This does not alter the original storage, and should be a safe change.`)
+        break;
+      case 'pop':
+        log.warn(`- Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
+                 `  Though this will not alter the positions in storage of other variables, if a new variable is added ` +
+                 `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
+                 `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
+        break;
+      case 'rename':
+        log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
+                 `  Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
+                 `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
+        break;
+      case 'typechange':
+        log.warn(`- Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
+                 `to ${updatedVarType.label} in ${updatedVarSource}.\n` + 
+                 `  If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
+                 `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
+                 `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
+        break;
+      case 'replace':
+        log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
+                 `in ${updatedVarSource}.\nThis will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
+                 `  If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
+                 `initialized with an invalid value after upgrading. Avoid changing types of existing ` +
+                 `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
+        break;
+      default:
+        log.error(`Unexpected layout changeset: ${action}`)
+    }
+  });
+
+  log.info('Read more at https://docs.zeppelinos.org/docs/advanced.html#preserving-the-storage-structure')
+}
+
+function _srcToLineNumber(sourceCode, srcFragment) {
+  if (!sourceCode || !srcFragment) return null;
+  const [begin] = srcFragment.split(':', 1);
+  return sourceCode.substr(0, begin).split('\n').length
+}
+
+function _tryGetSourceFragment(sourceCode, src) {
+  if (!src || !sourceCode) return null;
+  const [begin, count] = src.split(':');
+  return sourceCode.substr(begin, count);
+}

--- a/packages/cli/src/interface/Validations.js
+++ b/packages/cli/src/interface/Validations.js
@@ -1,4 +1,14 @@
 import _ from 'lodash';
+import { FileSystem as fs } from 'zos-lib';
+
+export function logUncheckedVars(vars, log) {
+  if (_.isEmpty(vars)) return;
+  const varList = vars.map(({ label, contract }) => `${label} (${contract})`).join(', ');
+  const variablesString = `Variable${vars.length === 1 ? '' : 's'}`;
+  log.warn(`- ${variablesString} ${varList} contain a struct or enum type, which are not being compared for layout changes in this version. ` +
+           `Double-check that the storage layout of these types was not modified in the updated contract. ` + 
+           `Read more at https://docs.zeppelinos.org/docs/advanced.html#preserving-the-storage-structure.`);
+}
 
 export function logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, log) {
   if (_.isEmpty(storageDiff)) return;

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -192,12 +192,13 @@ export default class ZosNetworkFile {
     this.setDependency(name, fn(this.getDependency(name)));
   }
 
-  addContract(alias, instance) {
+  addContract(alias, instance, extraData = {}) {
     this.setContract(alias, {
       address: instance.address,
       constructorCode: constructorCode(instance),
       bodyBytecodeHash: bytecodeDigest(bodyCode(instance)),
       bytecodeHash: bytecodeDigest(instance.constructor.bytecode),
+      ... extraData
     })
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -192,13 +192,14 @@ export default class ZosNetworkFile {
     this.setDependency(name, fn(this.getDependency(name)));
   }
 
-  addContract(alias, instance, extraData = {}) {
+  addContract(alias, instance, { types, storage }) {
     this.setContract(alias, {
       address: instance.address,
       constructorCode: constructorCode(instance),
       bodyBytecodeHash: bytecodeDigest(bodyCode(instance)),
       bytecodeHash: bytecodeDigest(instance.constructor.bytecode),
-      ... extraData
+      types,
+      storage
     })
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -192,7 +192,7 @@ export default class ZosNetworkFile {
     this.setDependency(name, fn(this.getDependency(name)));
   }
 
-  addContract(alias, instance, { types, storage }) {
+  addContract(alias, instance, { types, storage } = {}) {
     this.setContract(alias, {
       address: instance.address,
       constructorCode: constructorCode(instance),

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -38,8 +38,8 @@ export default class NetworkAppController extends NetworkBaseController {
     this.networkFile.app = { address }
   }
 
-  async push(reupload = false) {
-    await super.push(reupload);
+  async push(reupload = false, force = false) {
+    await super.push(reupload, force);
     await this.handleLibsLink()
   }
 

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -6,6 +6,7 @@ import Verifier from '../Verifier'
 import { flattenSourceCode } from '../../utils/contracts'
 import { allPromisesOrError } from '../../utils/async';
 import { getStorageLayout, getBuildArtifacts, compareStorageLayouts } from 'zos-lib/src';
+import { logStorageLayoutDiffs } from '../../interface/Validations';
 
 const log = new Logger('NetworkController');
 
@@ -154,85 +155,10 @@ export default class NetworkBaseController {
     const contract = Contracts.getFromLocal(contractName);
     const updatedStorageInfo = getStorageLayout(contract, buildArtifacts)
     const storageDiff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
-    if (!_.isEmpty(storageDiff)) {
-      this._logStorageLayoutDiffs(contract, storageDiff, originalStorageInfo, updatedStorageInfo, buildArtifacts)
-      log.info('Read more at https://docs.zeppelinos.org/docs/advanced.html#preserving-the-storage-structure')
-    }
+    logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, this.log)
 
+    // Validation passes only if all diff kinds are appends
     return _.every(storageDiff, diff => diff.action === 'append')
-  }
-
-  _logStorageLayoutDiffs(contract, storageDiff, originalStorageInfo, updatedStorageInfo, buildArtifacts) {
-    storageDiff.forEach(({ updated, original, action }) => {
-      const updatedSourceCode = updated && fs.exists(updated.path) && fs.read(updated.path)
-      const updatedVarType = updated && updatedStorageInfo.types[updated.type];
-      const updatedVarSource = updated && [updated.path, this._srcToLineNumber(updated.path, updated.src)].join(':');
-      const updatedVarDescription = updated && 
-        (this._tryGetSourceFragment(updatedSourceCode, updatedVarType.src) 
-         || [updatedVarType.label, updated.label].join(' '));
-      
-      const originalVarType = original && originalStorageInfo.types[original.type];
-      const originalVarDescription = original && [originalVarType.label, original.label].join(' ');
-
-      switch (action) {
-        case 'insert':
-          log.error(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
-                    `  This pushes all variables after ${updated.label} to a higher position in storage, `+
-                    `causing the updated contract to read incorrect initial values. Only add new variables at the `+
-                    `end of your contract to prevent this issue.`);
-          break;
-        case 'delete':
-          log.error(`- Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
-                    `  This will move all variables after ${original.label} to a lower position in storage, `+
-                    `causing the updated contract to read incorrect initial values. Avoid deleting existing ` +
-                    `variables to prevent this issue, and rename them to communicate that they are not to be used.`);
-          break;
-        case 'append':
-          log.info(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
-                   `at the end of the contract.\n` +
-                   `  This does not alter the original storage, and should be a safe change.`)
-          break;
-        case 'pop':
-          log.warn(`- Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
-                   `  Though this will not alter the positions in storage of other variables, if a new variable is added ` +
-                   `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
-                   `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
-          break;
-        case 'rename':
-          log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
-                   `  Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
-                   `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
-          break;
-        case 'typechange':
-          log.warn(`- Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
-                   `to ${updatedVarType.label} in ${updatedVarSource}.\n` + 
-                   `  If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
-                   `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
-                   `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
-          break;
-        case 'replace':
-          log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
-                   `in ${updatedVarSource}.\nThis will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
-                   `  If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
-                   `initialized with an invalid value after upgrading. Avoid changing types of existing ` +
-                   `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
-          break;
-        default:
-          log.error(`Unexpected layout changeset: ${action}`)
-      }
-    });
-  }
-
-  _srcToLineNumber(sourceCode, srcFragment) {
-    if (!sourceCode || !srcFragment) return null;
-    const [begin] = srcFragment.split(':', 1);
-    return sourceCode.substr(0, begin).split('\n').length
-  }
-
-  _tryGetSourceFragment(sourceCode, src) {
-    if (!src || !sourceCode) return null;
-    const [begin, count] = src.split(':');
-    return sourceCode.substr(begin, count);
   }
 
   checkContractDeployed(packageName, contractAlias, throwIfFail = false) {

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -176,42 +176,44 @@ export default class NetworkBaseController {
 
       switch (action) {
         case 'insert':
-          log.error(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
-                    `This pushes all variables after ${updated.label} to a higher position in storage, `+
+          log.error(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
+                    `  This pushes all variables after ${updated.label} to a higher position in storage, `+
                     `causing the updated contract to read incorrect initial values. Only add new variables at the `+
-                    `end of your contract to prevent this issue`);
+                    `end of your contract to prevent this issue.`);
           break;
         case 'delete':
-          log.error(`Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
-                    `This will move all variables after ${original.label} to a lower position in storage, `+
+          log.error(`- Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
+                    `  This will move all variables after ${original.label} to a lower position in storage, `+
                     `causing the updated contract to read incorrect initial values. Avoid deleting existing ` +
                     `variables to prevent this issue, and rename them to communicate that they are not to be used.`);
           break;
         case 'append':
-          log.info(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
-                   `at the end of the contract. This does not alter the original storage, and should be a safe change.`)
+          log.info(`- New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
+                   `at the end of the contract.\n` +
+                   `  This does not alter the original storage, and should be a safe change.`)
           break;
         case 'pop':
-          log.warn(`Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
-                    `Though this will not alter the positions in storage of other variables, if a new variable is added ` +
-                    `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
-                    `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
+          log.warn(`- Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
+                   `  Though this will not alter the positions in storage of other variables, if a new variable is added ` +
+                   `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
+                   `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
           break;
         case 'rename':
-          log.warn(`Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
-                   `Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
+          log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
+                   `  Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
                    `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
           break;
         case 'typechange':
-          log.warn(`Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
-                   `to ${updatedVarType.label} in ${updatedVarSource}.\nIf ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
+          log.warn(`- Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
+                   `to ${updatedVarType.label} in ${updatedVarSource}.\n` + 
+                   `  If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
                    `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
                    `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
           break;
         case 'replace':
-          log.warn(`Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
+          log.warn(`- Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
                    `in ${updatedVarSource}.\nThis will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
-                   `If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
+                   `  If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
                    `initialized with an invalid value after upgrading. Avoid changing types of existing ` +
                    `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
           break;

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -5,8 +5,8 @@ import StatusChecker from "../status/StatusChecker";
 import Verifier from '../Verifier'
 import { flattenSourceCode } from '../../utils/contracts'
 import { allPromisesOrError } from '../../utils/async';
-import { getStorageLayout, getBuildArtifacts, compareStorageLayouts } from 'zos-lib/src';
-import { logStorageLayoutDiffs } from '../../interface/Validations';
+import { getStorageLayout, getBuildArtifacts, compareStorageLayouts, getStructsOrEnums } from 'zos-lib/src';
+import { logUncheckedVars, logStorageLayoutDiffs } from '../../interface/Validations';
 
 const log = new Logger('NetworkController');
 
@@ -154,6 +154,8 @@ export default class NetworkBaseController {
     if (_.isEmpty(originalStorageInfo.storage)) return true;
     const contract = Contracts.getFromLocal(contractName);
     const updatedStorageInfo = getStorageLayout(contract, buildArtifacts)
+    const uncheckedVars = getStructsOrEnums(updatedStorageInfo)
+    logUncheckedVars(uncheckedVars, log)
     const storageDiff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
     logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, log)
 

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -155,7 +155,7 @@ export default class NetworkBaseController {
     const contract = Contracts.getFromLocal(contractName);
     const updatedStorageInfo = getStorageLayout(contract, buildArtifacts)
     const storageDiff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
-    logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, this.log)
+    logStorageLayoutDiffs(storageDiff, originalStorageInfo, updatedStorageInfo, log)
 
     // Validation passes only if all diff kinds are appends
     return _.every(storageDiff, diff => diff.action === 'append')

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -153,14 +153,13 @@ export default class NetworkBaseController {
     if (_.isEmpty(originalStorageInfo.storage)) return true;
     const contract = Contracts.getFromLocal(contractName);
     const updatedStorageInfo = getStorageLayout(contract, buildArtifacts)
-    const diff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
-    if (!_.isEmpty(diff)) {
-      this._logStorageLayoutDiffs(contract, diff, originalStorageInfo, updatedStorageInfo, buildArtifacts)
+    const storageDiff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
+    if (!_.isEmpty(storageDiff)) {
+      this._logStorageLayoutDiffs(contract, storageDiff, originalStorageInfo, updatedStorageInfo, buildArtifacts)
       log.info('Read more at https://docs.zeppelinos.org/docs/advanced.html#preserving-the-storage-structure')
-      return false
     }
 
-    return true
+    return _.every(storageDiff, diff => diff.action === 'append')
   }
 
   _logStorageLayoutDiffs(contract, storageDiff, originalStorageInfo, updatedStorageInfo, buildArtifacts) {
@@ -177,8 +176,7 @@ export default class NetworkBaseController {
 
       switch (action) {
         case 'insert':
-          log.error(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} before ` +
-                    `variable '${updatedStorageInfo[updated.index + 1].label}'.\n`+
+          log.error(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource}\n` +
                     `This pushes all variables after ${updated.label} to a higher position in storage, `+
                     `causing the updated contract to read incorrect initial values. Only add new variables at the `+
                     `end of your contract to prevent this issue`);
@@ -205,10 +203,18 @@ export default class NetworkBaseController {
                    `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
           break;
         case 'typechange':
-          log.warn(`Variable ${original.label} in contract ${original.contract} was changed from ${originalVarType.label} \n` +
-                   `to ${updatedVarType.label} in ${updatedVarSource}. If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
+          log.warn(`Variable '${original.label}' in contract ${original.contract} was changed from ${originalVarType.label} ` +
+                   `to ${updatedVarType.label} in ${updatedVarSource}.\nIf ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
                    `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
                    `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
+          break;
+        case 'replace':
+          log.warn(`Variable '${originalVarDescription}' in contract ${original.contract} was replaced with '${updatedVarDescription}' ` +
+                   `in ${updatedVarSource}.\nThis will cause ${updated.label} to be initialized with the value of ${original.label}. ` +
+                   `If type ${updatedVarType.label} is not compatible with ${originalVarType.label}, then ${updated.label} could be `+
+                   `initialized with an invalid value after upgrading. Avoid changing types of existing ` +
+                   `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
+          break;
         default:
           log.error(`Unexpected layout changeset: ${action}`)
       }
@@ -218,7 +224,7 @@ export default class NetworkBaseController {
   _srcToLineNumber(sourceCode, srcFragment) {
     if (!sourceCode || !srcFragment) return null;
     const [begin] = srcFragment.split(':', 1);
-    return read(sourceCode).substr(0, begin).split('\n').length
+    return sourceCode.substr(0, begin).split('\n').length
   }
 
   _tryGetSourceFragment(sourceCode, src) {

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { Contracts, Logger, App } from 'zos-lib';
+import { Contracts, Logger, App, FileSystem as fs } from 'zos-lib';
 import StatusComparator from '../status/StatusComparator'
 import StatusChecker from "../status/StatusChecker";
 import Verifier from '../Verifier'
@@ -148,20 +148,83 @@ export default class NetworkBaseController {
   }
 
   validateContract(contractAlias, contractName, buildArtifacts) {
+    log.info(`Validating contract ${contractName} before push`)
     const originalStorageInfo = _.pick(this.networkFile.contract(contractAlias), 'storage', 'types')
     if (_.isEmpty(originalStorageInfo.storage)) return true;
-    const updatedStorageInfo = getStorageLayout(Contracts.getFromLocal(contractName), buildArtifacts)
+    const contract = Contracts.getFromLocal(contractName);
+    const updatedStorageInfo = getStorageLayout(contract, buildArtifacts)
     const diff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
     if (!_.isEmpty(diff)) {
-      this._logStorageLayoutDiffs(contractAlias, contractName, diff)
+      this._logStorageLayoutDiffs(contract, diff, originalStorageInfo, updatedStorageInfo, buildArtifacts)
+      log.info('Read more at https://docs.zeppelinos.org/docs/advanced.html#preserving-the-storage-structure')
       return false
     }
 
     return true
   }
 
-  _logStorageLayoutDiffs(contractAlias, contractName, storageDiff) {
-    // TODO: DO!
+  _logStorageLayoutDiffs(contract, storageDiff, originalStorageInfo, updatedStorageInfo, buildArtifacts) {
+    storageDiff.forEach(({ updated, original, action }) => {
+      const updatedSourceCode = updated && fs.exists(updated.path) && fs.read(updated.path)
+      const updatedVarType = updated && updatedStorageInfo.types[updated.type];
+      const updatedVarSource = updated && [updated.path, this._srcToLineNumber(updated.path, updated.src)].join(':');
+      const updatedVarDescription = updated && 
+        (this._tryGetSourceFragment(updatedSourceCode, updatedVarType.src) 
+         || [updatedVarType.label, updated.label].join(' '));
+      
+      const originalVarType = original && originalStorageInfo.types[original.type];
+      const originalVarDescription = original && [originalVarType.label, original.label].join(' ');
+
+      switch (action) {
+        case 'insert':
+          log.error(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} before ` +
+                    `variable '${updatedStorageInfo[updated.index + 1].label}'.\n`+
+                    `This pushes all variables after ${updated.label} to a higher position in storage, `+
+                    `causing the updated contract to read incorrect initial values. Only add new variables at the `+
+                    `end of your contract to prevent this issue`);
+          break;
+        case 'delete':
+          log.error(`Variable '${originalVarDescription}' was removed from contract ${original.contract}.\n`+
+                    `This will move all variables after ${original.label} to a lower position in storage, `+
+                    `causing the updated contract to read incorrect initial values. Avoid deleting existing ` +
+                    `variables to prevent this issue, and rename them to communicate that they are not to be used.`);
+          break;
+        case 'append':
+          log.info(`New variable '${updatedVarDescription}' was added in contract ${updated.contract} in ${updatedVarSource} `+
+                   `at the end of the contract. This does not alter the original storage, and should be a safe change.`)
+          break;
+        case 'pop':
+          log.warn(`Variable '${originalVarDescription}' was removed from the end of contract ${original.contract}.\n`+
+                    `Though this will not alter the positions in storage of other variables, if a new variable is added ` +
+                    `at the end of the contract, it will have the initial value of ${original.label} when upgrading. ` +
+                    `Avoid deleting existing variables to prevent this issue, and rename them to communicate that they are not to be used.`);
+          break;
+        case 'rename':
+          log.warn(`Variable '${originalVarDescription}' in contract ${original.contract} was renamed to ${updated.label} in ${updatedVarSource}.\n` +
+                   `Note that the new variable ${updated.label} will have the value of ${original.label} after upgrading. ` +
+                   `If this is not the desired behavior, add a new variable ${updated.label} at the end of your contract instead.`)
+          break;
+        case 'typechange':
+          log.warn(`Variable ${original.label} in contract ${original.contract} was changed from ${originalVarType.label} \n` +
+                   `to ${updatedVarType.label} in ${updatedVarSource}. If ${updatedVarType.label} is not compatible with ${originalVarType.label}, ` +
+                   `then ${updated.label} could be initialized with an invalid value after upgrading. Avoid changing types of existing ` +
+                   `variables to prevent this issue, and declare new ones at the end of your contract instead.`)
+        default:
+          log.error(`Unexpected layout changeset: ${action}`)
+      }
+    });
+  }
+
+  _srcToLineNumber(sourceCode, srcFragment) {
+    if (!sourceCode || !srcFragment) return null;
+    const [begin] = srcFragment.split(':', 1);
+    return read(sourceCode).substr(0, begin).split('\n').length
+  }
+
+  _tryGetSourceFragment(sourceCode, src) {
+    if (!src || !sourceCode) return null;
+    const [begin, count] = src.split(':');
+    return sourceCode.substr(begin, count);
   }
 
   checkContractDeployed(packageName, contractAlias, throwIfFail = false) {

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -5,6 +5,7 @@ import StatusChecker from "../status/StatusChecker";
 import Verifier from '../Verifier'
 import { flattenSourceCode } from '../../utils/contracts'
 import { allPromisesOrError } from '../../utils/async';
+import { getStorageLayout, getBuildArtifacts, compareStorageLayouts } from 'zos-lib/src';
 
 const log = new Logger('NetworkController');
 
@@ -50,21 +51,27 @@ export default class NetworkBaseController {
     throw Error('Unimplemented function createProxy()')
   }
 
-  async push(reupload = false) {
+  async push(reupload = false, force = false) {
+    const contracts = this._contractsListForPush(!reupload)
+    const buildArtifacts = getBuildArtifacts();
+
+    if (!this.validateContracts(contracts, buildArtifacts) && !force) {
+      throw Error('Please review the warnings listed above and fix them, or run the command again with the --force option.')
+    }
+
     this._checkVersion()
     await this.fetchOrDeploy()
 
     await Promise.all([
-      this.uploadContracts(reupload),
+      this.uploadContracts(contracts, buildArtifacts), 
       this.unsetContracts()
     ])
   }
 
   _checkVersion() {
-    const requestedVersion = this.packageFile.version;
-    const currentVersion = this.networkFile.version;
-
-    if (requestedVersion !== currentVersion) {
+    if (this._newVersionRequired()) {
+      const requestedVersion = this.packageFile.version;
+      const currentVersion = this.networkFile.version;
       log.info(`Current version ${currentVersion}`);
       log.info(`Creating new version ${requestedVersion}`);
       this.networkFile.contracts = {};
@@ -84,23 +91,37 @@ export default class NetworkBaseController {
     this.networkFile.provider = { address }
     this.networkFile.version = version
   }
+  
+  _newVersionRequired() {
+    const requestedVersion = this.packageFile.version;
+    const currentVersion = this.networkFile.version;
+    return (requestedVersion !== currentVersion);
+  }
 
-  async uploadContracts(reupload) {
+  _contractsListForPush(onlyChanged = false) {
+    const newVersion = this._newVersionRequired()
+    return _(this.packageFile.contracts)
+      .toPairs()
+      .filter(([contractAlias, _contractName]) => newVersion || !onlyChanged || this.hasContractChanged(contractAlias))
+      .value()
+  }
+
+  async newVersion(versionName) {
+    return this.project.newVersion(versionName);
+  }
+
+  async uploadContracts(contracts, buildArtifacts) {
     await allPromisesOrError(
-      _(this.packageFile.contracts)
-        .toPairs()
-        .filter(([contractAlias, contractName]) => reupload || this.hasContractChanged(contractAlias))
-        .map(([contractAlias, contractName]) => this.uploadContract(contractAlias, contractName))
-        .value()
+      contracts.map(([contractAlias, contractName]) => this.uploadContract(contractAlias, contractName, buildArtifacts))
     )
   }
 
-  async uploadContract(contractAlias, contractName) {
+  async uploadContract(contractAlias, contractName, buildArtifacts) {
     try {
       const contractClass = Contracts.getFromLocal(contractName);
       log.info(`Uploading ${contractName} contract as ${contractAlias}`);
       const contractInstance = await this.project.setImplementation(contractClass, contractAlias);
-      this.networkFile.addContract(contractAlias, contractInstance)
+      this.networkFile.addContract(contractAlias, contractInstance, getStorageLayout(contractClass, buildArtifacts))
     } catch(error) {
       throw Error(`${contractAlias} deployment failed with error: ${error.message}`)
     }
@@ -120,6 +141,27 @@ export default class NetworkBaseController {
     } catch(error) {
       throw Error(`Removal of ${contractAlias} failed with error: ${error.message}`)
     }
+  }
+
+  validateContracts(contracts, buildArtifacts) {
+    return _.every(contracts.map(([contractAlias, contractName]) => this.validateContract(contractAlias, contractName, buildArtifacts)))
+  }
+
+  validateContract(contractAlias, contractName, buildArtifacts) {
+    const originalStorageInfo = _.pick(this.networkFile.contract(contractAlias), 'storage', 'types')
+    if (_.isEmpty(originalStorageInfo.storage)) return true;
+    const updatedStorageInfo = getStorageLayout(Contracts.getFromLocal(contractName), buildArtifacts)
+    const diff = compareStorageLayouts(originalStorageInfo, updatedStorageInfo)
+    if (!_.isEmpty(diff)) {
+      this._logStorageLayoutDiffs(contractAlias, contractName, diff)
+      return false
+    }
+
+    return true
+  }
+
+  _logStorageLayoutDiffs(contractAlias, contractName, storageDiff) {
+    // TODO: DO!
   }
 
   checkContractDeployed(packageName, contractAlias, throwIfFail = false) {

--- a/packages/cli/src/scripts/push.js
+++ b/packages/cli/src/scripts/push.js
@@ -1,12 +1,12 @@
 import stdout from '../utils/stdout';
 import ControllerFor from "../models/network/ControllerFor";
 
-export default async function push({ network, deployLibs, reupload = false, txParams = {}, networkFile = undefined }) {
+export default async function push({ network, deployLibs, reupload = false, force = false, txParams = {}, networkFile = undefined }) {
   const controller = ControllerFor(network, txParams, networkFile);
   
   try {
     if (deployLibs && !controller.isLib) await controller.deployLibs();
-    await controller.push(reupload);
+    await controller.push(reupload, force);
     stdout(controller.isLib ? controller.packageAddress : controller.appAddress);
   } finally {
     controller.writeNetworkPackage();

--- a/packages/cli/test/commands/add.test.js
+++ b/packages/cli/test/commands/add.test.js
@@ -16,7 +16,7 @@ contract('add command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos add --all --push test --skip-compile', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/bump.test.js
+++ b/packages/cli/test/commands/bump.test.js
@@ -12,7 +12,7 @@ contract('bump command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos bump 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -17,7 +17,7 @@ contract('init command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos init MyApp 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/link.test.js
+++ b/packages/cli/test/commands/link.test.js
@@ -13,7 +13,7 @@ contract('link command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -7,8 +7,8 @@ contract('push command', function() {
 
   stubCommands()
 
-  itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: true, reupload: true, network: 'test', txParams: {} })
+  itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f', function(push) {
+    push.should.have.been.calledWithExactly({ force: true, deployLibs: true, reupload: true, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/remove.test.js
+++ b/packages/cli/test/commands/remove.test.js
@@ -12,7 +12,7 @@ contract('remove command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos remove Impl --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/unlink.test.js
+++ b/packages/cli/test/commands/unlink.test.js
@@ -12,7 +12,7 @@ contract('unlink command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos unlink mock-stdlib@1.1.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployLibs: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/models/StatusComparator.test.js
+++ b/packages/cli/test/models/StatusComparator.test.js
@@ -1,7 +1,7 @@
 'use strict'
 require('../setup')
 
-import { Contracts } from 'zos-lib'
+import { Contracts, getStorageLayout } from 'zos-lib'
 
 import push from '../../src/scripts/push'
 import link from '../../src/scripts/link'
@@ -325,8 +325,8 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
           this.impl = await ImplV1.new()
           this.anotherImpl = await AnotherImplV1.new()
 
-          this.networkFile.addContract('Impl', this.impl)
-          this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+          this.networkFile.addContract('Impl', this.impl, getStorageLayout(ImplV1))
+          this.networkFile.addContract('AnotherImpl', this.anotherImpl, getStorageLayout(AnotherImplV1))
         })
 
         describe('when the directory of the current version does not have any contract', function () {
@@ -441,8 +441,8 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
         this.impl = await ImplV1.new()
         this.anotherImpl = await AnotherImplV1.new()
 
-        this.networkFile.addContract('Impl', this.impl)
-        this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+        this.networkFile.addContract('Impl', this.impl, getStorageLayout(ImplV1))
+        this.networkFile.addContract('AnotherImpl', this.anotherImpl, getStorageLayout(AnotherImplV1))
 
         await this.directory.setImplementation('Impl', this.impl.address)
         await this.directory.unsetImplementation('Impl', txParams)

--- a/packages/cli/test/models/StatusFetcher.test.js
+++ b/packages/cli/test/models/StatusFetcher.test.js
@@ -1,7 +1,7 @@
 'use strict'
 require('../setup')
 
-import { Contracts } from 'zos-lib'
+import { Contracts, getStorageLayout } from 'zos-lib'
 
 import push from '../../src/scripts/push'
 import link from '../../src/scripts/link'
@@ -327,8 +327,8 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
           this.impl = await ImplV1.new()
           this.anotherImpl = await AnotherImplV1.new()
 
-          this.networkFile.addContract('Impl', this.impl)
-          this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+          this.networkFile.addContract('Impl', this.impl, getStorageLayout(ImplV1))
+          this.networkFile.addContract('AnotherImpl', this.anotherImpl, getStorageLayout(AnotherImplV1))
         })
 
         describe('when the directory of the current version does not have any contract', function () {
@@ -446,8 +446,8 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
         this.impl = await ImplV1.new()
         this.anotherImpl = await AnotherImplV1.new()
 
-        this.networkFile.addContract('Impl', this.impl)
-        this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+        this.networkFile.addContract('Impl', this.impl, getStorageLayout(ImplV1))
+        this.networkFile.addContract('AnotherImpl', this.anotherImpl, getStorageLayout(AnotherImplV1))
 
         await this.directory.setImplementation('Impl', this.impl.address)
         await this.directory.unsetImplementation('Impl')

--- a/packages/lib/contracts/mocks/StorageMocks.sol
+++ b/packages/lib/contracts/mocks/StorageMocks.sol
@@ -1,5 +1,8 @@
 pragma solidity ^0.4.24;
 
+// Added just for having a circular reference
+import "./StorageMocks3.sol";
+
 contract SimpleStorageMock {
   uint256 public my_public_uint256;
   string internal my_internal_string;

--- a/packages/lib/contracts/mocks/StorageMocks.sol
+++ b/packages/lib/contracts/mocks/StorageMocks.sol
@@ -13,6 +13,12 @@ contract SimpleStorageMock {
   address private my_private_address;
 }
 
+contract StorageMockWithBytes {
+  bytes internal my_bytes;
+  bytes8 internal my_bytes8;
+  bytes32 internal my_bytes32;
+}
+
 contract StorageMockWithConstants {
   uint256 public constant my_public_uint256 = 256;
   string internal constant my_internal_string = "foo";

--- a/packages/lib/contracts/mocks/StorageMocks.sol
+++ b/packages/lib/contracts/mocks/StorageMocks.sol
@@ -1,0 +1,87 @@
+pragma solidity ^0.4.24;
+
+contract SimpleStorageMock {
+  uint256 public my_public_uint256;
+  string internal my_internal_string;
+  uint8 private my_private_uint8;
+  int8 private my_private_uint16;
+  bool private my_private_bool;
+  uint private my_private_uint;
+  address private my_private_address;
+}
+
+contract StorageMockWithConstants {
+  uint256 public constant my_public_uint256 = 256;
+  string internal constant my_internal_string = "foo";
+  uint8 private constant my_private_uint8 = 8;
+}
+
+contract StorageMockWithArrays {
+  uint256[] public my_public_uint256_dynarray;
+  string[] internal my_internal_string_dynarray;
+  address[] private my_private_address_dynarray;
+  int8[10] public my_public_int8_staticarray;
+  bool[20] internal my_internal_bool_staticarray;
+  uint[30] private my_private_uint_staticarray;
+}
+
+contract StorageMockWithMappings {
+  mapping(uint256 => string) public my_mapping;
+  mapping(uint256 => mapping(string => address)) internal my_nested_mapping;
+  mapping(uint256 => bool[]) private my_mapping_with_arrays;
+}
+
+contract StorageMockWithContracts {
+  SimpleStorageMock public my_contract;
+  SimpleStorageMock[] private my_contract_dynarray;
+  SimpleStorageMock[10] internal my_contract_staticarray;
+  mapping(uint256 => SimpleStorageMock) private my_contract_mapping;
+  mapping(uint256 => SimpleStorageMock[]) private my_contract_dynarray_mapping;
+  mapping(uint256 => SimpleStorageMock[10]) private my_contract_staticarray_mapping;
+}
+
+contract StorageMockWithStructs {
+  struct MyStruct {
+    uint256 struct_uint256;
+    string struct_string;
+    address struct_address;
+  }  
+
+  MyStruct internal my_struct;
+  MyStruct[] private my_struct_dynarray;
+  MyStruct[10] internal my_struct_staticarray;
+  mapping(uint256 => MyStruct) private my_struct_mapping;
+}
+
+contract StorageMockWithEnums {
+  enum MyEnum { State1, State2 }
+ 
+  MyEnum public my_enum;
+  MyEnum[] internal my_enum_dynarray;
+  MyEnum[10] internal my_enum_staticarray;
+  mapping(uint256 => MyEnum) private my_enum_mapping;
+}
+
+contract StorageMockWithComplexStructs {
+  struct MyStruct {
+    uint256[] uint256_dynarray;
+    mapping(string => StorageMockWithEnums.MyEnum) mapping_enums;
+    StorageMockWithStructs.MyStruct other_struct;
+  }
+
+  MyStruct internal my_struct;
+  StorageMockWithStructs.MyStruct internal my_other_struct;
+}
+
+contract StorageMockWithRecursiveStructs {
+  struct MyStruct {
+    OtherStruct[] other_structs;
+  }
+
+  struct OtherStruct {
+    MyStruct my_struct;
+  }
+
+  MyStruct internal my_struct;
+}
+

--- a/packages/lib/contracts/mocks/StorageMocks.sol
+++ b/packages/lib/contracts/mocks/StorageMocks.sol
@@ -101,3 +101,5 @@ contract StorageMockWithRecursiveStructs {
   MyStruct internal my_struct;
 }
 
+contract StorageMockMixed is StorageMockWithStructs, StorageMockWithEnums, SimpleStorageMock {
+}

--- a/packages/lib/contracts/mocks/StorageMocks.sol
+++ b/packages/lib/contracts/mocks/StorageMocks.sol
@@ -34,6 +34,13 @@ contract StorageMockWithMappings {
   mapping(uint256 => bool[]) private my_mapping_with_arrays;
 }
 
+contract StorageMockWithFunctions {
+  function(uint) internal my_fun;
+  function(string, string)[] internal my_fun_dynarray;
+  function(uint) returns (address)[10] internal my_fun_staticarray;
+  mapping(uint256 => function(bool)) internal my_fun_mapping;
+}
+
 contract StorageMockWithContracts {
   SimpleStorageMock public my_contract;
   SimpleStorageMock[] private my_contract_dynarray;

--- a/packages/lib/contracts/mocks/StorageMocks2.sol
+++ b/packages/lib/contracts/mocks/StorageMocks2.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.24;
+
+import "./StorageMocks.sol";
+
+contract StorageMockWithReferences {
+  StorageMockWithEnums.MyEnum internal my_enum;
+  StorageMockWithStructs.MyStruct internal my_struct;
+  SimpleStorageMock internal my_contract;
+}
+
+contract StorageMockChainBase {
+  uint256 internal base;
+}
+
+contract StorageMockChainA1 is StorageMockChainBase {
+  uint256 internal a1;
+  uint256 internal a2;
+}
+
+contract StorageMockChainA2 is StorageMockChainA1 {
+  uint256 public a3;
+  uint256 public a4;
+}
+
+contract StorageMockChainB is StorageMockChainBase {
+  uint256 internal b1;
+  uint256 internal b2;
+}
+
+contract StorageMockChainChild is StorageMockChainA2, StorageMockChainB {
+  uint256 internal child;
+
+  function slots() public pure returns(uint256 baseSlot, uint256 a1Slot, uint256 a3Slot, uint256 b1Slot, uint256 childSlot) {
+    assembly {
+      baseSlot := base_slot
+      a1Slot := a1_slot
+      a3Slot := a3_slot
+      b1Slot := b1_slot
+      childSlot := child_slot
+    }
+  }
+}
+
+

--- a/packages/lib/contracts/mocks/StorageMocks2.sol
+++ b/packages/lib/contracts/mocks/StorageMocks2.sol
@@ -1,11 +1,18 @@
 pragma solidity ^0.4.24;
 
 import "./StorageMocks.sol";
+import "mock-dependency/contracts/DependencyStorageMock.sol";
 
 contract StorageMockWithReferences {
   StorageMockWithEnums.MyEnum internal my_enum;
   StorageMockWithStructs.MyStruct internal my_struct;
   SimpleStorageMock internal my_contract;
+}
+
+contract StorageMockWithNodeModulesReferences {
+  DependencyStorageMock.MyEnum internal my_enum;
+  DependencyStorageMock.MyStruct internal my_struct;
+  DependencyStorageMock internal my_contract;
 }
 
 contract StorageMockChainBase {

--- a/packages/lib/contracts/mocks/StorageMocks3.sol
+++ b/packages/lib/contracts/mocks/StorageMocks3.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.24;
+
+import "./StorageMocks2.sol";
+
+contract StorageMockWithRecursiveReferences {
+  StorageMockWithEnums.MyEnum internal my_enum;
+  StorageMockWithStructs.MyStruct internal my_struct;
+  SimpleStorageMock internal my_contract;
+}

--- a/packages/lib/contracts/mocks/StorageMocks3.sol
+++ b/packages/lib/contracts/mocks/StorageMocks3.sol
@@ -45,3 +45,11 @@ contract StorageMockSimpleWithTypeChanged {
   uint256 a;
   string b;
 }
+
+contract StorageMockSimpleWithDeletedVar {
+  uint256 b;
+}
+
+contract StorageMockSimpleWithPoppedVar {
+  uint256 a;
+}

--- a/packages/lib/contracts/mocks/StorageMocks3.sol
+++ b/packages/lib/contracts/mocks/StorageMocks3.sol
@@ -7,3 +7,41 @@ contract StorageMockWithTransitiveReferences {
   StorageMockWithStructs.MyStruct internal my_struct;
   SimpleStorageMock internal my_contract;
 }
+
+contract StorageMockSimpleOriginal {
+  uint256 a;
+  uint256 b;
+}
+
+contract StorageMockSimpleUnchanged {
+  uint256 a;
+  uint256 b;
+}
+
+contract StorageMockSimpleWithAddedVar {
+  uint256 a;
+  uint256 b;
+  uint256 c;
+}
+
+contract StorageMockSimpleWithInsertedVar {
+  uint256 a;
+  uint256 c;
+  uint256 b;
+}
+
+contract StorageMockSimpleWithUnshiftedVar {
+  uint256 c;
+  uint256 a;
+  uint256 b;
+}
+
+contract StorageMockSimpleWithRenamedVar {
+  uint256 a;
+  uint256 c;
+}
+
+contract StorageMockSimpleWithTypeChanged {
+  uint256 a;
+  string b;
+}

--- a/packages/lib/contracts/mocks/StorageMocks3.sol
+++ b/packages/lib/contracts/mocks/StorageMocks3.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.24;
 
 import "./StorageMocks2.sol";
 
-contract StorageMockWithRecursiveReferences {
+contract StorageMockWithTransitiveReferences {
   StorageMockWithEnums.MyEnum internal my_enum;
   StorageMockWithStructs.MyStruct internal my_struct;
   SimpleStorageMock internal my_contract;

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -10,8 +10,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -37,10 +37,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -49,9 +49,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -77,7 +77,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "any-observable": {
@@ -93,8 +93,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -103,7 +103,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -112,7 +112,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -139,7 +139,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -233,21 +233,21 @@
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.11.0",
-        "convert-source-map": "^1.5.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^4.17.4",
-        "output-file-sync": "^1.1.2",
-        "path-is-absolute": "^1.0.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6",
-        "v8flags": "^2.1.1"
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "commander": {
@@ -262,12 +262,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "source-map": {
@@ -284,9 +284,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -301,11 +301,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -322,25 +322,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "babylon": {
@@ -363,14 +363,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -393,9 +393,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -404,9 +404,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -415,10 +415,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -427,10 +427,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -439,9 +439,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -450,10 +450,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -462,11 +462,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -475,8 +475,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -485,8 +485,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -495,8 +495,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -505,9 +505,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -516,11 +516,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -529,12 +529,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -543,8 +543,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -553,7 +553,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -562,7 +562,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -637,9 +637,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -648,9 +648,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -659,9 +659,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -670,10 +670,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -682,11 +682,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -695,7 +695,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -704,7 +704,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -713,11 +713,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -726,15 +726,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -743,8 +743,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -753,7 +753,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -762,8 +762,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -772,7 +772,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -781,9 +781,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -792,7 +792,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -801,9 +801,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -812,10 +812,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -824,9 +824,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -835,9 +835,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -846,8 +846,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -856,12 +856,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -870,8 +870,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -880,7 +880,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -889,9 +889,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -900,7 +900,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -909,7 +909,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -918,9 +918,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -929,9 +929,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -940,8 +940,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -950,8 +950,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -960,8 +960,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -970,7 +970,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -979,8 +979,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-polyfill": {
@@ -989,9 +989,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1008,36 +1008,36 @@
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.7",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -1046,30 +1046,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-stage-1": {
@@ -1078,9 +1078,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1089,10 +1089,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1101,11 +1101,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1114,13 +1114,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.5",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "source-map": {
@@ -1135,7 +1135,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6"
+            "source-map": "0.5.7"
           }
         }
       }
@@ -1146,8 +1146,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1156,11 +1156,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babylon": {
@@ -1177,15 +1177,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babylon": {
@@ -1202,10 +1202,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1217,8 +1217,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1226,13 +1225,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1241,7 +1240,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1250,7 +1249,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1259,7 +1258,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1268,9 +1267,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1294,7 +1293,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "big.js": {
@@ -1331,7 +1330,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "bn.js": {
@@ -1345,16 +1344,15 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1364,9 +1362,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -1385,12 +1383,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-sha3": {
@@ -1398,7 +1396,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "requires": {
-        "js-sha3": "^0.3.1"
+        "js-sha3": "0.3.1"
       }
     },
     "browserslist": {
@@ -1407,8 +1405,8 @@
       "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000835",
-        "electron-to-chromium": "^1.3.45"
+        "caniuse-lite": "1.0.30000841",
+        "electron-to-chromium": "1.3.47"
       }
     },
     "buffer-xor": {
@@ -1428,15 +1426,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1501,8 +1499,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chai": {
@@ -1511,12 +1509,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chai-as-promised": {
@@ -1525,7 +1523,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "^1.0.2"
+        "check-error": "1.0.2"
       }
     },
     "chai-bignumber": {
@@ -1539,9 +1537,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "has-flag": {
@@ -1554,7 +1552,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1578,15 +1576,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "cipher-base": {
@@ -1594,8 +1592,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "class-utils": {
@@ -1604,10 +1602,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1616,7 +1614,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -1633,7 +1631,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -1666,7 +1664,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       }
     },
     "cli-width": {
@@ -1681,9 +1679,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -1704,7 +1702,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "clone-stats": {
@@ -1719,9 +1717,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -1741,8 +1739,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1750,7 +1748,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1770,7 +1768,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -1794,8 +1792,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -1827,11 +1824,11 @@
       "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.6.1",
-        "lcov-parse": "^0.0.10",
-        "log-driver": "^1.2.5",
-        "minimist": "^1.2.0",
-        "request": "^2.79.0"
+        "js-yaml": "3.11.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.85.0"
       },
       "dependencies": {
         "minimist": {
@@ -1847,10 +1844,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.10"
       }
     },
     "create-hmac": {
@@ -1858,12 +1855,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.10"
       }
     },
     "cross-spawn": {
@@ -1872,11 +1869,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.4",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -1885,7 +1882,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -1894,7 +1891,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -1916,7 +1913,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-fns": {
@@ -1964,7 +1961,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "deep-eql": {
@@ -1973,7 +1970,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-extend": {
@@ -1994,8 +1991,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2004,7 +2001,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2013,7 +2010,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2022,9 +2019,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -2059,7 +2056,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "diff": {
@@ -2074,8 +2071,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -2084,7 +2081,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -2100,9 +2097,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6"
       }
     },
     "duplexer3": {
@@ -2118,7 +2115,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "editions": {
@@ -2150,13 +2147,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -2171,9 +2168,9 @@
       "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "tapable": "1.0.0"
       }
     },
     "envinfo": {
@@ -2188,7 +2185,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error": {
@@ -2197,8 +2194,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
       }
     },
     "error-ex": {
@@ -2207,7 +2204,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -2221,11 +2218,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "^2.7.1",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -2241,7 +2238,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2269,8 +2266,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
       "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
       "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^4.3.0"
+        "bn.js": "4.11.8",
+        "ethereumjs-util": "4.5.0"
       }
     },
     "ethereumjs-testrpc-sc": {
@@ -2279,8 +2276,8 @@
       "integrity": "sha512-dBTav4AZQ7zuajmICv1k7bEesqS+8f0u0wciXNUJZb842RTBi0lgKEDF8WgZshzv4ThI+XVQSRNV/A+seiK4aA==",
       "dev": true,
       "requires": {
-        "source-map-support": "^0.5.3",
-        "webpack-cli": "^2.0.9"
+        "source-map-support": "0.5.4",
+        "webpack-cli": "2.1.3"
       }
     },
     "ethereumjs-util": {
@@ -2288,11 +2285,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
       "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
       "requires": {
-        "bn.js": "^4.8.0",
-        "create-hash": "^1.1.2",
-        "keccakjs": "^0.2.0",
-        "rlp": "^2.0.0",
-        "secp256k1": "^3.0.1"
+        "bn.js": "4.11.8",
+        "create-hash": "1.1.3",
+        "keccakjs": "0.2.1",
+        "rlp": "2.0.0",
+        "secp256k1": "3.5.0"
       }
     },
     "ethjs-abi": {
@@ -2322,8 +2319,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "execa": {
@@ -2332,13 +2329,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -2347,9 +2344,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         }
       }
@@ -2366,7 +2363,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -2375,7 +2372,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -2384,7 +2381,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "extend": {
@@ -2399,8 +2396,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2409,7 +2406,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2420,9 +2417,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -2431,7 +2428,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -2451,12 +2448,12 @@
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.0.2",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.2",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -2477,16 +2474,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2495,7 +2492,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2506,13 +2503,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -2521,7 +2518,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -2530,7 +2527,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -2539,7 +2536,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2548,7 +2545,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -2559,7 +2556,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2568,7 +2565,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -2579,9 +2576,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -2598,14 +2595,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -2614,7 +2611,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -2623,7 +2620,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2634,10 +2631,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2646,7 +2643,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2657,8 +2654,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -2667,7 +2664,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -2678,7 +2675,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2687,7 +2684,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2696,9 +2693,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -2713,7 +2710,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -2722,7 +2719,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2731,7 +2728,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2754,19 +2751,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -2788,7 +2785,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "filename-regex": {
@@ -2803,11 +2800,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "find-up": {
@@ -2816,8 +2813,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "first-chunk-stream": {
@@ -2826,7 +2823,7 @@
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "flow-parser": {
@@ -2847,7 +2844,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -2862,9 +2859,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "fragment-cache": {
@@ -2873,7 +2870,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from2": {
@@ -2882,8 +2879,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -2892,11 +2889,11 @@
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs-readdir-recursive": {
@@ -2908,8 +2905,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -2918,8 +2914,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3470,7 +3466,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gh-got": {
@@ -3479,8 +3475,8 @@
       "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
       "dev": true,
       "requires": {
-        "got": "^7.0.0",
-        "is-plain-obj": "^1.1.0"
+        "got": "7.1.0",
+        "is-plain-obj": "1.1.0"
       },
       "dependencies": {
         "got": {
@@ -3489,20 +3485,20 @@
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         },
         "p-cancelable": {
@@ -3517,7 +3513,7 @@
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
           "requires": {
-            "p-finally": "^1.0.0"
+            "p-finally": "1.0.0"
           }
         },
         "prepend-http": {
@@ -3532,7 +3528,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         }
       }
@@ -3543,21 +3539,20 @@
       "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
       "dev": true,
       "requires": {
-        "gh-got": "^6.0.0"
+        "gh-got": "6.0.0"
       }
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-all": {
@@ -3566,8 +3561,8 @@
       "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5",
-        "yargs": "~1.2.6"
+        "glob": "7.1.3",
+        "yargs": "1.2.6"
       },
       "dependencies": {
         "minimist": {
@@ -3582,7 +3577,7 @@
           "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
           "dev": true,
           "requires": {
-            "minimist": "^0.1.0"
+            "minimist": "0.1.0"
           }
         }
       }
@@ -3593,8 +3588,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -3603,7 +3598,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-to-regexp": {
@@ -3618,9 +3613,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -3629,11 +3624,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -3648,13 +3643,13 @@
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "fast-glob": "2.2.2",
+        "glob": "7.1.2",
+        "ignore": "3.3.8",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3663,12 +3658,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "pify": {
@@ -3685,23 +3680,23 @@
       "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.0",
+        "p-cancelable": "0.4.1",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       },
       "dependencies": {
         "pify": {
@@ -3724,7 +3719,7 @@
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.2"
+        "lodash": "4.17.5"
       }
     },
     "growl": {
@@ -3739,10 +3734,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "source-map": {
@@ -3751,7 +3746,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -3768,8 +3763,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -3778,7 +3773,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-color": {
@@ -3805,7 +3800,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -3814,9 +3809,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -3833,8 +3828,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -3843,7 +3838,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3852,7 +3847,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -3863,7 +3858,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3873,7 +3868,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "hash.js": {
@@ -3881,8 +3876,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "hawk": {
@@ -3891,10 +3886,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -3908,9 +3903,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -3925,8 +3920,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -3935,7 +3930,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3956,9 +3951,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "iconv-lite": {
@@ -3967,7 +3962,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -3982,8 +3977,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -3998,17 +3993,16 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -4028,19 +4022,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "5.5.10",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4061,8 +4055,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -4071,7 +4065,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -4088,8 +4082,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invariant": {
@@ -4098,7 +4092,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -4113,7 +4107,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-arrayish": {
@@ -4129,7 +4123,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -4144,7 +4138,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-data-descriptor": {
@@ -4153,7 +4147,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-descriptor": {
@@ -4162,9 +4156,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4187,7 +4181,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -4208,7 +4202,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -4217,7 +4211,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -4226,7 +4220,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hex-prefixed": {
@@ -4240,7 +4234,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-object": {
@@ -4255,7 +4249,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "^0.2.2"
+        "symbol-observable": "0.2.4"
       },
       "dependencies": {
         "symbol-observable": {
@@ -4272,7 +4266,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4295,7 +4289,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -4336,7 +4330,7 @@
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "dev": true,
       "requires": {
-        "scoped-regex": "^1.0.0"
+        "scoped-regex": "1.0.0"
       }
     },
     "is-stream": {
@@ -4402,20 +4396,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.11.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.1.2",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -4430,11 +4424,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "resolve": {
@@ -4451,9 +4445,9 @@
       "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "dev": true,
       "requires": {
-        "binaryextensions": "2",
-        "editions": "^1.3.3",
-        "textextensions": "2"
+        "binaryextensions": "2.1.1",
+        "editions": "1.3.4",
+        "textextensions": "2.2.0"
       }
     },
     "isurl": {
@@ -4462,8 +4456,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jade": {
@@ -4507,8 +4501,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -4524,21 +4518,21 @@
       "integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-preset-es2015": "^6.9.0",
-        "babel-preset-stage-1": "^6.5.0",
-        "babel-register": "^6.9.0",
-        "babylon": "^7.0.0-beta.30",
-        "colors": "^1.1.2",
-        "flow-parser": "^0.*",
-        "lodash": "^4.13.1",
-        "micromatch": "^2.3.7",
-        "neo-async": "^2.5.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-stage-1": "6.24.1",
+        "babel-register": "6.26.0",
+        "babylon": "7.0.0-beta.47",
+        "colors": "1.2.5",
+        "flow-parser": "0.72.0",
+        "lodash": "4.17.5",
+        "micromatch": "2.3.11",
+        "neo-async": "2.5.1",
         "node-dir": "0.1.8",
-        "nomnom": "^1.8.1",
-        "recast": "^0.14.1",
-        "temp": "^0.8.1",
-        "write-file-atomic": "^1.2.0"
+        "nomnom": "1.8.1",
+        "recast": "0.14.7",
+        "temp": "0.8.3",
+        "write-file-atomic": "1.3.4"
       }
     },
     "jsesc": {
@@ -4588,7 +4582,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsprim": {
@@ -4608,8 +4602,8 @@
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
       "requires": {
-        "browserify-sha3": "^0.0.1",
-        "sha3": "^1.1.0"
+        "browserify-sha3": "0.0.1",
+        "sha3": "1.2.2"
       }
     },
     "keyv": {
@@ -4627,7 +4621,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -4636,7 +4630,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "lazy-cache": {
@@ -4652,7 +4646,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lcov-parse": {
@@ -4667,8 +4661,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "listr": {
@@ -4677,23 +4671,23 @@
       "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "figures": "^1.7.0",
-        "indent-string": "^2.1.0",
-        "is-observable": "^0.2.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.4.0",
-        "listr-verbose-renderer": "^0.4.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "ora": "^0.2.3",
-        "p-map": "^1.1.1",
-        "rxjs": "^5.4.2",
-        "stream-to-observable": "^0.2.0",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.10",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4708,11 +4702,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "figures": {
@@ -4721,8 +4715,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -4731,7 +4725,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "supports-color": {
@@ -4754,14 +4748,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4776,11 +4770,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "figures": {
@@ -4789,8 +4783,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "indent-string": {
@@ -4805,7 +4799,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "supports-color": {
@@ -4822,10 +4816,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4840,11 +4834,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-cursor": {
@@ -4853,7 +4847,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "figures": {
@@ -4862,8 +4856,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "onetime": {
@@ -4878,8 +4872,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "supports-color": {
@@ -4896,11 +4890,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "loader-utils": {
@@ -4909,9 +4903,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
       }
     },
     "locate-path": {
@@ -4919,8 +4913,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -4954,7 +4948,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "log-update": {
@@ -4963,8 +4957,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -4979,7 +4973,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "onetime": {
@@ -4994,8 +4988,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         }
       }
@@ -5012,7 +5006,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -5027,8 +5021,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -5037,7 +5031,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5060,7 +5054,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "math-random": {
@@ -5074,8 +5068,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       },
       "dependencies": {
         "hash-base": {
@@ -5083,8 +5077,8 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5095,7 +5089,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "mem-fs": {
@@ -5104,9 +5098,9 @@
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0",
-        "vinyl": "^1.1.0",
-        "vinyl-file": "^2.0.0"
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "vinyl-file": "2.0.0"
       }
     },
     "mem-fs-editor": {
@@ -5115,17 +5109,17 @@
       "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "deep-extend": "^0.5.1",
-        "ejs": "^2.5.9",
-        "glob": "^7.0.3",
-        "globby": "^8.0.0",
-        "isbinaryfile": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "multimatch": "^2.0.0",
-        "rimraf": "^2.2.8",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.1"
+        "commondir": "1.0.1",
+        "deep-extend": "0.5.1",
+        "ejs": "2.6.1",
+        "glob": "7.1.3",
+        "globby": "8.0.1",
+        "isbinaryfile": "3.0.2",
+        "mkdirp": "0.5.1",
+        "multimatch": "2.1.0",
+        "rimraf": "2.6.2",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -5152,12 +5146,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -5168,8 +5162,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "memorystream": {
@@ -5190,19 +5184,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime-db": {
@@ -5217,7 +5211,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -5246,9 +5240,8 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -5263,8 +5256,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5273,7 +5266,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -5320,12 +5313,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "growl": {
@@ -5346,7 +5339,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -5933,10 +5926,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -5956,18 +5949,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -6014,8 +6007,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6030,9 +6023,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "strip-ansi": {
@@ -6049,7 +6042,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.0.9"
       }
     },
     "normalize-package-data": {
@@ -6058,10 +6051,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -6070,7 +6063,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-url": {
@@ -6079,9 +6072,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.1",
+        "sort-keys": "2.0.0"
       }
     },
     "npm-run-path": {
@@ -6090,7 +6083,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -6133,9 +6126,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -6144,7 +6137,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -6155,7 +6148,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6172,8 +6165,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -6182,7 +6175,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6197,9 +6190,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -6208,7 +6200,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "openzeppelin-solidity": {
@@ -6222,8 +6214,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
@@ -6240,12 +6232,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ora": {
@@ -6254,10 +6246,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6272,11 +6264,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-cursor": {
@@ -6285,7 +6277,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "onetime": {
@@ -6300,8 +6292,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "supports-color": {
@@ -6329,7 +6321,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -6344,9 +6336,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-cancelable": {
@@ -6361,7 +6353,7 @@
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-finally": {
@@ -6387,7 +6379,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -6395,7 +6387,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -6416,7 +6408,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -6430,10 +6422,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -6442,7 +6434,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -6469,14 +6461,13 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -6496,9 +6487,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pathval": {
@@ -6537,7 +6528,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -6546,7 +6537,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -6555,7 +6546,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -6638,9 +6629,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "randomatic": {
@@ -6649,9 +6640,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -6674,8 +6665,8 @@
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1"
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.1"
       },
       "dependencies": {
         "pify": {
@@ -6692,9 +6683,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -6703,8 +6694,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -6713,13 +6704,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -6729,10 +6720,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "recast": {
@@ -6742,9 +6733,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.11.3",
-        "esprima": "~4.0.0",
-        "private": "~0.1.5",
-        "source-map": "~0.6.1"
+        "esprima": "4.0.0",
+        "private": "0.1.8",
+        "source-map": "0.6.1"
       }
     },
     "rechoir": {
@@ -6753,7 +6744,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.7.0"
       }
     },
     "regenerate": {
@@ -6774,9 +6765,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -6785,7 +6776,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -6794,8 +6785,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -6804,9 +6795,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "regjsgen": {
@@ -6821,7 +6812,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -6848,7 +6839,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -6863,7 +6854,7 @@
       "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
       "dev": true,
       "requires": {
-        "req-from": "^1.0.1"
+        "req-from": "1.0.1"
       }
     },
     "req-from": {
@@ -6872,7 +6863,7 @@
       "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
       "dev": true,
       "requires": {
-        "resolve-from": "^2.0.0"
+        "resolve-from": "2.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -6889,28 +6880,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "require-directory": {
@@ -6937,7 +6928,7 @@
       "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -6946,7 +6937,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -6955,8 +6946,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -6977,7 +6968,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -6986,8 +6977,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -7003,7 +6994,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -7012,7 +7003,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "ripemd160": {
@@ -7020,8 +7011,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
       }
     },
     "rlp": {
@@ -7035,7 +7026,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rxjs": {
@@ -7058,7 +7049,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -7078,14 +7069,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.3.0",
+        "bip66": "1.1.5",
+        "bn.js": "4.11.8",
+        "create-hash": "1.1.3",
+        "drbg.js": "1.0.1",
+        "elliptic": "6.4.0",
+        "nan": "2.9.2",
+        "safe-buffer": "5.1.1"
       }
     },
     "semver": {
@@ -7113,10 +7104,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7125,7 +7116,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -7135,8 +7126,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "sha3": {
@@ -7160,7 +7151,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -7175,9 +7166,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.3",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "sigmund": {
@@ -7216,14 +7207,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7232,7 +7223,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -7241,7 +7232,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -7258,9 +7249,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7269,7 +7260,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -7278,7 +7269,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -7287,7 +7278,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -7296,9 +7287,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -7321,7 +7312,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -7330,7 +7321,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "sol-explore": {
@@ -7345,11 +7336,11 @@
       "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
       "dev": true,
       "requires": {
-        "fs-extra": "^0.30.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
+        "fs-extra": "0.30.0",
+        "memorystream": "0.3.1",
+        "require-from-string": "1.2.1",
+        "semver": "5.5.0",
+        "yargs": "4.8.1"
       }
     },
     "solidity-coverage": {
@@ -7358,15 +7349,15 @@
       "integrity": "sha512-iA3MT20rh1LllcNwfxAKU3ZBDu8R/4K8jANJAk7BcJU1foOjEh3tYhGqL8w2kRJPIo5XtoW0wxyVt95X2eJk/A==",
       "dev": true,
       "requires": {
-        "death": "^1.1.0",
+        "death": "1.1.0",
         "ethereumjs-testrpc-sc": "6.1.2",
-        "istanbul": "^0.4.5",
-        "keccakjs": "^0.2.1",
-        "req-cwd": "^1.0.1",
-        "shelljs": "^0.7.4",
-        "sol-explore": "^1.6.2",
+        "istanbul": "0.4.5",
+        "keccakjs": "0.2.1",
+        "req-cwd": "1.0.1",
+        "shelljs": "0.7.8",
+        "sol-explore": "1.6.2",
         "solidity-parser-sc": "0.4.7",
-        "web3": "^0.18.4"
+        "web3": "0.18.4"
       }
     },
     "solidity-parser-sc": {
@@ -7375,9 +7366,9 @@
       "integrity": "sha512-wbX2806sm6thZME1aniqLcLH9HYwNwuKke6aw/FEgupCvoT9Iq5PdwuN9OyHWKGBOVeczpM5tCrnRXWNQ04YVw==",
       "dev": true,
       "requires": {
-        "mocha": "^2.4.5",
-        "pegjs": "^0.10.0",
-        "yargs": "^4.6.0"
+        "mocha": "2.5.3",
+        "pegjs": "0.10.0",
+        "yargs": "4.8.1"
       },
       "dependencies": {
         "commander": {
@@ -7413,8 +7404,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
           }
         },
         "lru-cache": {
@@ -7429,8 +7420,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         },
         "mocha": {
@@ -7471,7 +7462,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -7486,11 +7477,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -7499,7 +7490,7 @@
       "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.0"
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -7514,8 +7505,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7530,8 +7521,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7546,7 +7537,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -7561,14 +7552,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "static-extend": {
@@ -7577,8 +7568,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7587,7 +7578,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -7598,7 +7589,7 @@
       "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
       "dev": true,
       "requires": {
-        "any-observable": "^0.2.0"
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -7619,9 +7610,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -7630,7 +7621,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -7645,7 +7636,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -7654,7 +7645,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -7663,8 +7654,8 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
       }
     },
     "strip-eof": {
@@ -7687,7 +7678,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "^1.0.0"
+        "has-flag": "1.0.0"
       }
     },
     "symbol-observable": {
@@ -7708,8 +7699,8 @@
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -7744,8 +7735,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "timed-out": {
@@ -7760,7 +7751,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-fast-properties": {
@@ -7781,7 +7772,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -7790,10 +7781,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -7802,8 +7793,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -7812,7 +7803,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -7823,7 +7814,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "trim-right": {
@@ -7838,7 +7829,7 @@
       "integrity": "sha1-vydYaYi0/4RWPt+/MrR5QUCKdq0=",
       "dev": true,
       "requires": {
-        "mocha": "^4.1.0",
+        "mocha": "4.1.0",
         "original-require": "1.0.1",
         "solc": "0.4.24"
       }
@@ -7853,11 +7844,11 @@
       "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
       "integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
       "requires": {
-        "find-up": "^2.1.0",
+        "find-up": "2.1.0",
         "lodash": "4.17.10",
         "original-require": "1.0.1",
-        "truffle-error": "^0.0.3",
-        "truffle-provider": "^0.0.6"
+        "truffle-error": "0.0.3",
+        "truffle-provider": "0.0.6"
       },
       "dependencies": {
         "find-up": {
@@ -7865,7 +7856,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "lodash": {
@@ -7881,15 +7872,14 @@
       "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
       "requires": {
         "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "^0.0.5",
-        "truffle-contract-schema": "^2.0.1",
-        "truffle-error": "^0.0.3",
+        "truffle-blockchain-utils": "0.0.5",
+        "truffle-contract-schema": "2.0.1",
+        "truffle-error": "0.0.3",
         "web3": "0.20.6"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "web3": {
           "version": "0.20.6",
@@ -7897,10 +7887,10 @@
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
             "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xhr2": "0.1.4",
+            "xmlhttprequest": "1.8.0"
           }
         }
       }
@@ -7910,9 +7900,9 @@
       "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
       "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
       "requires": {
-        "ajv": "^5.1.1",
-        "crypto-js": "^3.1.9-1",
-        "debug": "^3.1.0"
+        "ajv": "5.5.2",
+        "crypto-js": "3.1.9-1",
+        "debug": "3.1.0"
       },
       "dependencies": {
         "crypto-js": {
@@ -7940,13 +7930,12 @@
       "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
       "integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
       "requires": {
-        "truffle-error": "^0.0.3",
+        "truffle-error": "0.0.3",
         "web3": "0.20.6"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "web3": {
           "version": "0.20.6",
@@ -7954,10 +7943,10 @@
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
             "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xhr2": "0.1.4",
+            "xmlhttprequest": "1.8.0"
           }
         }
       }
@@ -7973,7 +7962,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -7989,7 +7978,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -8005,9 +7994,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8024,8 +8013,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -8057,9 +8046,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -8084,10 +8073,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8096,7 +8085,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -8105,10 +8094,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -8119,8 +8108,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -8129,9 +8118,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -8177,7 +8166,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0"
+        "prepend-http": "2.0.0"
       }
     },
     "url-to-options": {
@@ -8192,7 +8181,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8238,7 +8227,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -8247,8 +8236,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "verror": {
@@ -8257,9 +8246,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -8268,8 +8257,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -8279,12 +8268,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       }
     },
     "web3": {
@@ -8293,15 +8282,14 @@
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
         "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
+        "crypto-js": "3.1.8",
+        "utf8": "2.1.2",
+        "xhr2": "0.1.4",
+        "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         }
       }
     },
@@ -8311,7 +8299,7 @@
       "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
       "dev": true,
       "requires": {
-        "jscodeshift": "^0.4.0"
+        "jscodeshift": "0.4.1"
       },
       "dependencies": {
         "ast-types": {
@@ -8332,21 +8320,21 @@
           "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
           "dev": true,
           "requires": {
-            "async": "^1.5.0",
-            "babel-plugin-transform-flow-strip-types": "^6.8.0",
-            "babel-preset-es2015": "^6.9.0",
-            "babel-preset-stage-1": "^6.5.0",
-            "babel-register": "^6.9.0",
-            "babylon": "^6.17.3",
-            "colors": "^1.1.2",
-            "flow-parser": "^0.*",
-            "lodash": "^4.13.1",
-            "micromatch": "^2.3.7",
+            "async": "1.5.2",
+            "babel-plugin-transform-flow-strip-types": "6.22.0",
+            "babel-preset-es2015": "6.24.1",
+            "babel-preset-stage-1": "6.24.1",
+            "babel-register": "6.26.0",
+            "babylon": "6.18.0",
+            "colors": "1.2.5",
+            "flow-parser": "0.72.0",
+            "lodash": "4.17.5",
+            "micromatch": "2.3.11",
             "node-dir": "0.1.8",
-            "nomnom": "^1.8.1",
-            "recast": "^0.12.5",
-            "temp": "^0.8.1",
-            "write-file-atomic": "^1.2.0"
+            "nomnom": "1.8.1",
+            "recast": "0.12.9",
+            "temp": "0.8.3",
+            "write-file-atomic": "1.3.4"
           }
         },
         "recast": {
@@ -8356,10 +8344,10 @@
           "dev": true,
           "requires": {
             "ast-types": "0.10.1",
-            "core-js": "^2.4.1",
-            "esprima": "~4.0.0",
-            "private": "~0.1.5",
-            "source-map": "~0.6.1"
+            "core-js": "2.5.5",
+            "esprima": "4.0.0",
+            "private": "0.1.8",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -8370,32 +8358,32 @@
       "integrity": "sha512-5AsKoL/Ccn8iTrwk3uErdyhetGH+c7VRQ7Itim2GL0IhBRq5rtojVDk00buMRmFmBpw1RvHXq97Gup965LbozA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.2",
-        "cross-spawn": "^6.0.5",
-        "diff": "^3.5.0",
-        "enhanced-resolve": "^4.0.0",
-        "envinfo": "^4.4.2",
-        "glob-all": "^3.1.0",
-        "global-modules": "^1.0.0",
-        "got": "^8.2.0",
-        "import-local": "^1.0.0",
-        "inquirer": "^5.1.0",
-        "interpret": "^1.0.4",
-        "jscodeshift": "^0.5.0",
-        "listr": "^0.13.0",
-        "loader-utils": "^1.1.0",
-        "lodash": "^4.17.5",
-        "log-symbols": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "p-each-series": "^1.0.0",
-        "p-lazy": "^1.0.0",
-        "prettier": "^1.5.3",
-        "supports-color": "^5.3.0",
-        "v8-compile-cache": "^1.1.2",
-        "webpack-addons": "^1.1.5",
-        "yargs": "^11.1.0",
-        "yeoman-environment": "^2.0.0",
-        "yeoman-generator": "^2.0.4"
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "diff": "3.5.0",
+        "enhanced-resolve": "4.0.0",
+        "envinfo": "4.4.2",
+        "glob-all": "3.1.0",
+        "global-modules": "1.0.0",
+        "got": "8.3.1",
+        "import-local": "1.0.0",
+        "inquirer": "5.2.0",
+        "interpret": "1.1.0",
+        "jscodeshift": "0.5.0",
+        "listr": "0.13.0",
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "mkdirp": "0.5.1",
+        "p-each-series": "1.0.0",
+        "p-lazy": "1.0.0",
+        "prettier": "1.12.1",
+        "supports-color": "5.4.0",
+        "v8-compile-cache": "1.1.2",
+        "webpack-addons": "1.1.5",
+        "yargs": "11.1.0",
+        "yeoman-environment": "2.1.1",
+        "yeoman-generator": "2.0.5"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8416,9 +8404,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "diff": {
@@ -8433,7 +8421,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "has-flag": {
@@ -8454,9 +8442,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -8465,8 +8453,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -8475,7 +8463,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -8484,7 +8472,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -8499,18 +8487,18 @@
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -8519,7 +8507,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -8530,7 +8518,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -8557,15 +8545,14 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "1.3.4",
@@ -8573,9 +8560,9 @@
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
       }
     },
     "xhr2": {
@@ -8612,20 +8599,20 @@
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dev": true,
       "requires": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "lodash.assign": "4.2.0",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "2.4.1"
       }
     },
     "yargs-parser": {
@@ -8634,8 +8621,8 @@
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
+        "camelcase": "3.0.0",
+        "lodash.assign": "4.2.0"
       }
     },
     "yeoman-environment": {
@@ -8644,21 +8631,21 @@
       "integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "diff": "^3.3.1",
-        "escape-string-regexp": "^1.0.2",
-        "globby": "^8.0.1",
-        "grouped-queue": "^0.3.3",
-        "inquirer": "^5.2.0",
-        "is-scoped": "^1.0.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.1.0",
-        "mem-fs": "^1.1.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "untildify": "^3.0.2"
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "globby": "8.0.1",
+        "grouped-queue": "0.3.3",
+        "inquirer": "5.2.0",
+        "is-scoped": "1.0.0",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "mem-fs": "1.1.3",
+        "strip-ansi": "4.0.0",
+        "text-table": "0.2.0",
+        "untildify": "3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8694,7 +8681,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -8705,31 +8692,31 @@
       "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "chalk": "^2.3.0",
-        "cli-table": "^0.3.1",
-        "cross-spawn": "^6.0.5",
-        "dargs": "^5.1.0",
-        "dateformat": "^3.0.3",
-        "debug": "^3.1.0",
-        "detect-conflict": "^1.0.0",
-        "error": "^7.0.2",
-        "find-up": "^2.1.0",
-        "github-username": "^4.0.0",
-        "istextorbinary": "^2.2.1",
-        "lodash": "^4.17.10",
-        "make-dir": "^1.1.0",
-        "mem-fs-editor": "^4.0.0",
-        "minimist": "^1.2.0",
-        "pretty-bytes": "^4.0.2",
-        "read-chunk": "^2.1.0",
-        "read-pkg-up": "^3.0.0",
-        "rimraf": "^2.6.2",
-        "run-async": "^2.0.0",
-        "shelljs": "^0.8.0",
-        "text-table": "^0.2.0",
-        "through2": "^2.0.0",
-        "yeoman-environment": "^2.0.5"
+        "async": "2.6.0",
+        "chalk": "2.4.1",
+        "cli-table": "0.3.1",
+        "cross-spawn": "6.0.5",
+        "dargs": "5.1.0",
+        "dateformat": "3.0.3",
+        "debug": "3.1.0",
+        "detect-conflict": "1.0.1",
+        "error": "7.0.2",
+        "find-up": "2.1.0",
+        "github-username": "4.1.0",
+        "istextorbinary": "2.2.1",
+        "lodash": "4.17.10",
+        "make-dir": "1.3.0",
+        "mem-fs-editor": "4.0.2",
+        "minimist": "1.2.0",
+        "pretty-bytes": "4.0.2",
+        "read-chunk": "2.1.0",
+        "read-pkg-up": "3.0.0",
+        "rimraf": "2.6.2",
+        "run-async": "2.3.0",
+        "shelljs": "0.8.2",
+        "text-table": "0.2.0",
+        "through2": "2.0.3",
+        "yeoman-environment": "2.1.1"
       },
       "dependencies": {
         "async": {
@@ -8738,7 +8725,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.10"
           }
         },
         "debug": {
@@ -8756,7 +8743,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -8765,10 +8752,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -8789,8 +8776,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -8799,7 +8786,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -8814,9 +8801,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -8825,8 +8812,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "shelljs": {
@@ -8835,9 +8822,9 @@
           "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.3",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
           }
         },
         "strip-bom": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -54,6 +54,7 @@
     "bignumber.js": "^7.2.0",
     "chalk": "^2.4.1",
     "ethereumjs-abi": "^0.6.5",
+    "glob": "^7.1.3",
     "openzeppelin-solidity": "~1.10.0",
     "truffle-config": "^1.0.6",
     "truffle-contract": "^3.0.6",

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -11,6 +11,11 @@ import FileSystem from './utils/FileSystem'
 import Contracts from './utils/Contracts'
 import { sendTransaction, deploy } from './utils/Transactions'
 
+// validations
+import { getStorageLayout } from './validations/Storage';
+import { getBuildArtifacts } from './utils/BuildArtifacts';
+import { compareStorageLayouts } from './validations/Layout';
+
 // test behaviors
 import { behaviors, helpers } from './test'
 const assertions = helpers.assertions
@@ -35,6 +40,9 @@ export {
   behaviors,
   sendTransaction,
   deploy,
+  getBuildArtifacts,
+  getStorageLayout,
+  compareStorageLayouts,
   Proxy,
   Logger,
   FileSystem,

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -12,7 +12,7 @@ import Contracts from './utils/Contracts'
 import { sendTransaction, deploy } from './utils/Transactions'
 
 // validations
-import { getStorageLayout } from './validations/Storage';
+import { getStorageLayout, getStructsOrEnums } from './validations/Storage';
 import { getBuildArtifacts } from './utils/BuildArtifacts';
 import { compareStorageLayouts } from './validations/Layout';
 
@@ -43,6 +43,7 @@ export {
   getBuildArtifacts,
   getStorageLayout,
   compareStorageLayouts,
+  getStructsOrEnums,
   Proxy,
   Logger,
   FileSystem,

--- a/packages/lib/src/utils/BuildArtifacts.js
+++ b/packages/lib/src/utils/BuildArtifacts.js
@@ -1,0 +1,41 @@
+import Contracts from "../utils/Contracts";
+import { parseJson } from "../utils/FileSystem";
+import _ from 'lodash';
+
+export function getBuildArtifacts() {
+  return new BuildArtifacts(Contracts.listBuildArtifacts())
+}
+
+class BuildArtifacts {
+  constructor(artifactsPaths) {
+    this.sourcesToArtifacts = {};
+    artifactsPaths.forEach(path => {
+      const artifact = parseJson(path)
+      const sourcePath = this.getSourcePathFromArtifact(artifact)
+      this.registerArtifactForSourcePath(sourcePath, artifact)
+    })
+  }
+
+  listSourcePaths() {
+    return _.keys(this.sourcesToArtifacts)
+  }
+
+  listArtifacts() {
+    return _.flatten(_.values(this.sourcesToArtifacts));
+  }
+
+  getArtifactsFromSourcePath(sourcePath) {
+    return this.sourcesToArtifacts[sourcePath];
+  }
+
+  getSourcePathFromArtifact(artifact) {
+    return artifact.ast.absolutePath;
+  }
+
+  registerArtifactForSourcePath(sourcePath, artifact) {
+    if (!this.sourcesToArtifacts[sourcePath]) {
+      this.sourcesToArtifacts[sourcePath] = []
+    }
+    this.sourcesToArtifacts[sourcePath].push(artifact)
+  }
+}

--- a/packages/lib/src/utils/Contracts.js
+++ b/packages/lib/src/utils/Contracts.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import truffleContract from 'truffle-contract'
 import truffleProvision from 'truffle-provisioner'
+import glob from 'glob'
 
 const DEFAULT_TESTING_TX_PARAMS = {
   gas: 6721975,
@@ -25,9 +26,12 @@ export default {
   },
 
   getLocalPath(contractName) {
-    const defaultBuildDir = `${process.cwd()}/build/contracts`
-    const buildDir = this._getTruffleBuildDir() || defaultBuildDir
+    const buildDir = this.getLocalBuildDir()
     return `${buildDir}/${contractName}.json`
+  },
+
+  getLocalBuildDir() {
+    return this._getTruffleBuildDir() || `${process.cwd()}/build/contracts`
   },
 
   getLibPath(contractName) {
@@ -48,6 +52,11 @@ export default {
 
   getFromNodeModules(dependency, contractName) {
     return this._getFromPath(this.getNodeModulesPath(dependency, contractName))
+  },
+
+  listBuildArtifacts() {
+    const buildDir = this.getLocalBuildDir()
+    return glob.sync(`${buildDir}/*.json`)
   },
 
   _getFromPath(path) {

--- a/packages/lib/src/validations/Layout.js
+++ b/packages/lib/src/validations/Layout.js
@@ -105,6 +105,5 @@ function walk(matrix, originalStorage, updatedStorage, areMatchFn) {
     }
   }
 
-  // console.log(`Walked matrix at position ${i},${j}:\n${matrix.map(util.inspect).join('\n')}\n\nOperations:${operations.map(op => `${op.action}: ${(op.original || {}).label} ${(op.updated || {}).label}`).join('\n')}\n)`)
   return operations;
 }

--- a/packages/lib/src/validations/Layout.js
+++ b/packages/lib/src/validations/Layout.js
@@ -6,7 +6,6 @@ const SUBSTITUTION_COST = 3,
       DELETION_COST = 2;
 
 export function compareStorageLayouts(original, updated) {
-  // TODO: Check cases with empty storage (both for original and updated)
   const areMatch = (var1, var2) => storageEntryMatches(var1, var2, original.types, updated.types)
   const areEqual = (var1, var2) => (areMatch(var1, var2) === 'equal')
   const distanceMatrix = levenshtein(original.storage, updated.storage, areEqual)
@@ -18,7 +17,6 @@ function storageEntryMatches(originalVar, updatedVar, originalTypes, updatedType
   const originalType = originalTypes[originalVar.type],
         updatedType = updatedTypes[updatedVar.type];
 
-  // TODO: Compare complex types (structs and enums)
   const typeMatches = (originalType.id === updatedType.id);
   const nameMatches = (originalVar.label === updatedVar.label);
   

--- a/packages/lib/src/validations/Layout.js
+++ b/packages/lib/src/validations/Layout.js
@@ -33,11 +33,6 @@ function storageEntryMatches(originalVar, updatedVar, originalTypes, updatedType
   }
 }
 
-function typeMatches(originalType, updatedType, originalTypes, updatedTypes) {
-  // TODO: Compare complex types (structs and enums)
-  return originalType.id === updatedType.id;
-}
-
 // Adapted from https://gist.github.com/andrei-m/982927 by Andrei Mackenzie
 function levenshtein(originalStorage, updatedStorage, areEqualFn) {
   const a = originalStorage,
@@ -87,8 +82,10 @@ function walk(matrix, originalStorage, updatedStorage, areMatchFn) {
   while (i > 0 || j > 0) {
     const cost = matrix[i][j];
     const isAppend = j >= matrix.length;
+    const isPop = i >= matrix[0].length;
     const insertionCost = isAppend ? 0 : INSERTION_COST;
     const matchResult = i > 0 && j > 0 && areMatchFn(a[i-1], b[j-1]);
+    
     if (i > 0 && j > 0 && cost === matrix[i-1][j-1] && matchResult === 'equal') {
       operations.unshift({ action: 'equal', updated: b[j-1], original: a[i-1] });
       i--;
@@ -97,7 +94,7 @@ function walk(matrix, originalStorage, updatedStorage, areMatchFn) {
       operations.unshift({ action: (isAppend ? 'append' : 'insert'), updated: b[j-1] });
       j--;
     } else if (i > 0 && cost === matrix[i-1][j] + DELETION_COST) {
-      operations.unshift({ action: 'delete', original: a[i-1] });
+      operations.unshift({ action: (isPop ? 'pop' : 'delete'), original: a[i-1] });
       i--;
     } else if (i > 0 && j > 0 && cost === matrix[i-1][j-1] + SUBSTITUTION_COST) {
       operations.unshift({ action: matchResult, updated: b[j-1], original: a[i-1] });

--- a/packages/lib/src/validations/Layout.js
+++ b/packages/lib/src/validations/Layout.js
@@ -85,19 +85,21 @@ function walk(matrix, originalStorage, updatedStorage, areMatchFn) {
     const isPop = i >= matrix[0].length;
     const insertionCost = isAppend ? 0 : INSERTION_COST;
     const matchResult = i > 0 && j > 0 && areMatchFn(a[i-1], b[j-1]);
+    const updated = j > 0 && { index: j-1, ...b[j-1] }
+    const original = i > 0 && { index: i-1, ...a[i-1] }
     
     if (i > 0 && j > 0 && cost === matrix[i-1][j-1] && matchResult === 'equal') {
-      operations.unshift({ action: 'equal', updated: b[j-1], original: a[i-1] });
+      operations.unshift({ action: 'equal', updated, original });
       i--;
       j--;
     } else if (j > 0 && cost === matrix[i][j-1] + insertionCost) {
-      operations.unshift({ action: (isAppend ? 'append' : 'insert'), updated: b[j-1] });
+      operations.unshift({ action: (isAppend ? 'append' : 'insert'), updated });
       j--;
     } else if (i > 0 && cost === matrix[i-1][j] + DELETION_COST) {
-      operations.unshift({ action: (isPop ? 'pop' : 'delete'), original: a[i-1] });
+      operations.unshift({ action: (isPop ? 'pop' : 'delete'), original });
       i--;
     } else if (i > 0 && j > 0 && cost === matrix[i-1][j-1] + SUBSTITUTION_COST) {
-      operations.unshift({ action: matchResult, updated: b[j-1], original: a[i-1] });
+      operations.unshift({ action: matchResult, updated, original });
       i--; 
       j--;
     } else {

--- a/packages/lib/src/validations/Layout.js
+++ b/packages/lib/src/validations/Layout.js
@@ -19,7 +19,7 @@ function storageEntryMatches(originalVar, updatedVar, originalTypes, updatedType
 
   const typeMatches = (originalType.id === updatedType.id);
   const nameMatches = (originalVar.label === updatedVar.label);
-  
+
   if (typeMatches && nameMatches) {
     return 'equal'
   } else if (typeMatches) {

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import path from 'path';
+import process from 'process';
 import { getBuildArtifacts } from "../utils/BuildArtifacts";
 
 export function getStorageLayout(contract, artifacts) {
@@ -55,11 +57,12 @@ class StorageLayout {
   }
 
   visitVariables(contractNode) {
+    const sourcePath = path.relative(process.cwd(), this.getNode(contractNode.scope, 'SourceUnit').absolutePath)
     const varNodes = contractNode.nodes.filter(node => node.stateVariable && !node.constant)
     varNodes.forEach(node => {
       const typeInfo = this.getTypeInfo(node.typeName)
       this.registerType(typeInfo)
-      const storageInfo = { contract: contractNode.name, ... this.getStorageInfo(node, typeInfo) }
+      const storageInfo = { contract: contractNode.name, path: sourcePath, ... this.getStorageInfo(node, typeInfo) }
       this.storage.push(storageInfo)
     })
   }
@@ -93,7 +96,8 @@ class StorageLayout {
     return {
       label: varNode.name,
       astId: varNode.id,
-      type: typeInfo.id
+      type: typeInfo.id,
+      src: varNode.src
     }
   }
 

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -1,0 +1,165 @@
+export function getStorageLayout(contract) {
+  const layout = new StorageLayout(contract)
+  const { types, storage } = layout.run()
+  return { types, storage }
+}
+
+class StorageLayout {
+  constructor (contract) {
+    this.contract = contract
+    this.nodes = {}
+    this.types = {}
+    this.storage = []
+  }
+
+  run() {
+    this.collectNodes(this.contract.ast)
+    const contractNode = this.getContractNode()
+    this.visitVariables(contractNode)
+    return this
+  }
+
+  collectNodes(node) {
+    if (this.nodes[node.id]) return;
+    this.nodes[node.id] = node
+    if (node.nodes) node.nodes.forEach(this.collectNodes.bind(this))
+  }
+
+  visitVariables(contractNode) {
+    const varNodes = contractNode.nodes.filter(node => node.stateVariable && !node.constant)
+    varNodes.forEach(node => {
+      const typeInfo = this.getTypeInfo(node.typeName)
+      this.registerType(typeInfo)
+      const storageInfo = { contract: contractNode.name, ... this.getStorageInfo(node, typeInfo) }
+      this.storage.push(storageInfo)
+    })
+  }
+
+  registerType(typeInfo) {
+    this.types[typeInfo.id] = typeInfo
+  }
+
+  getContractNode() {
+    return this.contract.ast.nodes.find(node => 
+      node.nodeType === 'ContractDefinition' && 
+      node.name === this.contract.contractName
+    )
+  }
+
+  getStorageInfo(varNode, typeInfo) {
+    return {
+      label: varNode.name,
+      astId: varNode.id,
+      type: typeInfo.id
+    }
+  }
+
+  getTypeInfo(node) {
+    switch (node.nodeType) {
+      case 'ElementaryTypeName': return this.getElementaryTypeInfo(node);
+      case 'ArrayTypeName': return this.getArrayTypeInfo(node);
+      case 'Mapping': return this.getMappingTypeInfo(node);
+      case 'UserDefinedTypeName': return this.getUserDefinedTypeInfo(node);
+      default: throw Error(`Cannot get type info for unknown node type ${node.nodeType}`);
+    }
+  }
+
+  getUserDefinedTypeInfo({ referencedDeclaration, typeDescriptions }) {
+    const referencedNode = this.nodes[referencedDeclaration];
+    if (!referencedNode) {
+      throw Error(`Could not find referenced AST node ${referencedDeclaration} for type ${typeDescriptions.typeString}`)
+    } 
+
+    switch (referencedNode.nodeType) {
+      case 'ContractDefinition': return this.getContractTypeInfo(referencedNode)
+      case 'StructDefinition': return this.getStructTypeInfo(referencedNode)
+      case 'EnumDefinition': return this.getEnumTypeInfo(referencedNode)
+      default: return { id: typeDescriptions.typeIdentifier, label: typeDescriptions.typeString }
+    }
+  }
+
+  getElementaryTypeInfo({ typeDescriptions }) {
+    const id = typeDescriptions.typeIdentifier.startsWith('t_string')
+      ? 't_string' 
+      : typeDescriptions.typeIdentifier;
+
+    return { 
+      id,
+      kind: 'elementary',
+      label: typeDescriptions.typeString
+    }
+  }
+  
+  getArrayTypeInfo({ baseType, length, }) {
+    const { id: baseTypeId, label: baseTypeLabel } = this.getTypeInfo(baseType)
+    const lengthDescriptor = length ? length.value : 'dyn'
+    const lengthLabel = length ? length.value : ''
+    return { 
+      id: `t_array:${lengthDescriptor}<${baseTypeId}>`,
+      valueType: baseTypeId,
+      length: lengthDescriptor,
+      kind: 'array',
+      label: `${baseTypeLabel}[${lengthLabel}]`
+    }
+  }
+
+  getMappingTypeInfo({ valueType }) {
+    // We ignore the keyTypeId, since it's always hashed and takes up the same amount of space; we only care about the last value type
+    const { id: valueTypeId, label: valueTypeLabel } = this.getValueTypeInfo(valueType)
+    return {
+      id: `t_mapping<${valueTypeId}>`, 
+      valueType: valueTypeId,
+      label: `mapping(key => ${valueTypeLabel})`,
+      kind: 'mapping'
+    }
+  }
+
+  getContractTypeInfo() {
+    // Process a reference to a contract as an address, since we only care about storage size
+    return { 
+      id: 't_address', 
+      kind: 'elementary',
+      label: 'address' 
+    } 
+  }
+
+  getStructTypeInfo(referencedNode) {
+    // Identify structs by contract and name
+    const contractName = this.nodes[referencedNode.scope].name
+    const id = `t_struct<${contractName}.${referencedNode.name}>`
+    if (this.types[id]) return this.types[id]
+
+    // Store members info in type description
+    const members = referencedNode.members
+      .filter(member => member.nodeType === 'VariableDeclaration')
+      .map(member => {
+        const typeInfo = this.getTypeInfo(member.typeName)
+        this.registerType(typeInfo)
+        return this.getStorageInfo(member, typeInfo)
+      })
+
+    return {
+      id,
+      members,
+      kind: 'struct',
+      label: referencedNode.canonicalName
+    }
+  }
+
+  getEnumTypeInfo(referencedNode) {
+    // Store canonical name and members for an enum
+    // Note that enum definition nodes do not have a `scope` property we can use to retrieve the contract node
+    return {
+      id: `t_enum<${referencedNode.canonicalName}>`,
+      kind: 'enum',
+      label: referencedNode.canonicalName,
+      members: referencedNode.members.map(m => m.name)
+    }
+  }
+
+  getValueTypeInfo(node) {
+    return (node.nodeType === 'Mapping')
+      ? this.getValueTypeInfo(node.valueType)
+      : this.getTypeInfo(node)
+  }  
+}

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -182,7 +182,11 @@ class StorageLayout {
     const id = `t_struct<${referencedNode.canonicalName}>`
     if (this.types[id]) return this.types[id]
 
-    // Store members info in type description
+    // We shortcircuit type registration in this scenario to handle recursive structs
+    const typeInfo = { id, kind: 'struct', label: referencedNode.canonicalName }
+    this.registerType(typeInfo)
+
+    // Store members info in type info
     const members = referencedNode.members
       .filter(member => member.nodeType === 'VariableDeclaration')
       .map(member => {
@@ -191,12 +195,8 @@ class StorageLayout {
         return this.getStorageInfo(member, typeInfo)
       })
 
-    return {
-      id,
-      members,
-      kind: 'struct',
-      label: referencedNode.canonicalName
-    }
+    Object.assign(typeInfo, { members })
+    return typeInfo
   }
 
   getEnumTypeInfo(referencedDeclaration) {

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -10,6 +10,21 @@ export function getStorageLayout(contract, artifacts) {
   return { types, storage }
 }
 
+export function getStructsOrEnums({ storage, types }) {
+  return storage.filter(variable => containsStructOrEnum(variable.type, types))
+}
+
+function containsStructOrEnum(typeName, types) {
+  const type = types[typeName]
+  if (type.kind === 'struct' || type.kind === 'enum') {
+    return true;
+  } else if (type.valueType) {
+    return containsStructOrEnum(type.valueType, types)
+  } else {
+    return false;
+  }
+}
+
 const CONTRACT_TYPE_INFO =  { 
   id: 't_address', 
   kind: 'elementary',

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -123,12 +123,11 @@ class StorageLayout {
   }
 
   getElementaryTypeInfo({ typeDescriptions }) {
-    const id = typeDescriptions.typeIdentifier.startsWith('t_string')
-      ? 't_string' 
-      : typeDescriptions.typeIdentifier;
-
+    const identifier = typeDescriptions.typeIdentifier
+      .replace(/_storage(_ptr)?$/, '')
+    
     return { 
-      id,
+      id: identifier,
       kind: 'elementary',
       label: typeDescriptions.typeString
     }

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -10,6 +10,18 @@ export function getStorageLayout(contract, artifacts) {
   return { types, storage }
 }
 
+const CONTRACT_TYPE_INFO =  { 
+  id: 't_address', 
+  kind: 'elementary',
+  label: 'address' 
+};
+
+const FUNCTION_TYPE_INFO = {
+  id: 't_function', 
+  kind: 'elementary',
+  label: 'function' 
+};
+
 class StorageLayout {
   constructor (contract, artifacts) {
     this.artifacts = artifacts
@@ -163,20 +175,12 @@ class StorageLayout {
 
   getContractTypeInfo() {
     // Process a reference to a contract as an address, since we only care about storage size
-    return { 
-      id: 't_address', 
-      kind: 'elementary',
-      label: 'address' 
-    } 
+    return { ... CONTRACT_TYPE_INFO }
   }
 
   getFunctionTypeInfo() {
     // Process a reference to a function disregarding types, since we only care how much space it takes
-    return { 
-      id: 't_function', 
-      kind: 'elementary',
-      label: 'function' 
-    } 
+    return { ... FUNCTION_TYPE_INFO }
   }
 
   getStructTypeInfo(referencedDeclaration) {

--- a/packages/lib/test/mocks/mock-dependency/contracts/DependencyStorageMock.sol
+++ b/packages/lib/test/mocks/mock-dependency/contracts/DependencyStorageMock.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.24;
+
+contract DependencyStorageMock {
+  enum MyEnum { State1, State2 }
+  struct MyStruct { uint256 value; }
+}

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -18,13 +18,13 @@ contract('Layout', () => {
     )
   }
 
-  function assertChanges(result, changes) {
-    result.changes.should.have.lengthOf(changes.length)
-    result.changes.forEach((change, index) => {
-      const expected = changes[index]
-      change.action.should.eq(expected.action)
-      if (expected.updated) change.updated.should.include(expected.updated)
-      if (expected.original) change.original.should.include(expected.original)
+  function assertChanges(result, expectedChanges) {
+    result.should.have.lengthOf(expectedChanges.length)
+    result.forEach((change, index) => {
+      const expectedChange = expectedChanges[index]
+      change.action.should.eq(expectedChange.action)
+      if (expectedChange.updated) change.updated.should.include(expectedChange.updated)
+      if (expectedChange.original) change.original.should.include(expectedChange.original)
     })
   }
 
@@ -36,14 +36,14 @@ contract('Layout', () => {
   it('reports inserted var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithInsertedVar');
     assertChanges(result, [
-      { updated: { label: 'c', contract: 'StorageMockSimpleWithInsertedVar', type: 't_uint256' }, action: 'insertion' }
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithInsertedVar', type: 't_uint256' }, action: 'insert' }
     ])
   });
 
   it('reports unshifted var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithUnshiftedVar');
     assertChanges(result, [
-      { updated: { label: 'c', contract: 'StorageMockSimpleWithUnshiftedVar', type: 't_uint256' }, action: 'insertion' }
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithUnshiftedVar', type: 't_uint256' }, action: 'insert' }
     ])
   });
 
@@ -57,7 +57,7 @@ contract('Layout', () => {
   it('reports renamed var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithRenamedVar');
     assertChanges(result, [
-      { action: 'substitution',
+      { action: 'rename',
         original: { label: 'b', type: 't_uint256' },
         updated:  { label: 'c', type: 't_uint256' }  }
     ])
@@ -66,7 +66,7 @@ contract('Layout', () => {
   it('reports type changed', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithTypeChanged');
     assertChanges(result, [
-      { action: 'substitution',
+      { action: 'typechange',
         original: { label: 'b', type: 't_uint256' },
         updated:  { label: 'b', type: 't_string' }  }
     ])

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -36,21 +36,21 @@ contract('Layout', () => {
   it('reports inserted var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithInsertedVar');
     assertChanges(result, [
-      { updated: { label: 'c', contract: 'StorageMockSimpleWithInsertedVar', type: 't_uint256' }, action: 'insert' }
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithInsertedVar', type: 't_uint256', index: 1 }, action: 'insert' }
     ])
   });
 
   it('reports unshifted var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithUnshiftedVar');
     assertChanges(result, [
-      { updated: { label: 'c', contract: 'StorageMockSimpleWithUnshiftedVar', type: 't_uint256' }, action: 'insert' }
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithUnshiftedVar', type: 't_uint256', index: 0 }, action: 'insert' }
     ])
   });
 
   it('reports appended var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithAddedVar');
     assertChanges(result, [
-      { updated: { label: 'c', contract: 'StorageMockSimpleWithAddedVar', type: 't_uint256' }, action: 'append' }
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithAddedVar', type: 't_uint256', index: 2 }, action: 'append' }
     ])
   });
 
@@ -75,7 +75,7 @@ contract('Layout', () => {
   it('reports deleted var', function () {
     const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithDeletedVar');
     assertChanges(result, [
-      { original: { label: 'a', contract: 'StorageMockSimpleOriginal', type: 't_uint256' }, action: 'delete' }
+      { original: { label: 'a', contract: 'StorageMockSimpleOriginal', type: 't_uint256', index: 0 }, action: 'delete' }
     ])
   });
 

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -72,4 +72,18 @@ contract('Layout', () => {
     ])
   });
 
+  it('reports deleted var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithDeletedVar');
+    assertChanges(result, [
+      { original: { label: 'a', contract: 'StorageMockSimpleOriginal', type: 't_uint256' }, action: 'delete' }
+    ])
+  });
+
+  it('reports popped var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithPoppedVar');
+    assertChanges(result, [
+      { original: { label: 'b', contract: 'StorageMockSimpleOriginal', type: 't_uint256' }, action: 'pop' }
+    ])
+  });
+
 })

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -1,0 +1,75 @@
+'use strict'
+require('../../setup')
+
+const should = require('chai').should()
+
+import _ from 'lodash'
+
+import Contracts from '../../../src/utils/Contracts'
+import { getStorageLayout } from '../../../src/validations/Storage'
+import { compareStorageLayouts } from '../../../src/validations/Layout'
+
+contract('Layout', () => {
+  
+  function compare(originalContractName, updatedContractName) {
+    return compareStorageLayouts(
+      getStorageLayout(Contracts.getFromLocal(originalContractName)),
+      getStorageLayout(Contracts.getFromLocal(updatedContractName))
+    )
+  }
+
+  function assertChanges(result, changes) {
+    result.changes.should.have.lengthOf(changes.length)
+    result.changes.forEach((change, index) => {
+      const expected = changes[index]
+      change.action.should.eq(expected.action)
+      if (expected.updated) change.updated.should.include(expected.updated)
+      if (expected.original) change.original.should.include(expected.original)
+    })
+  }
+
+  it('reports no changes', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleUnchanged');
+    assertChanges(result, [])
+  });
+
+  it('reports inserted var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithInsertedVar');
+    assertChanges(result, [
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithInsertedVar', type: 't_uint256' }, action: 'insertion' }
+    ])
+  });
+
+  it('reports unshifted var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithUnshiftedVar');
+    assertChanges(result, [
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithUnshiftedVar', type: 't_uint256' }, action: 'insertion' }
+    ])
+  });
+
+  it('reports appended var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithAddedVar');
+    assertChanges(result, [
+      { updated: { label: 'c', contract: 'StorageMockSimpleWithAddedVar', type: 't_uint256' }, action: 'append' }
+    ])
+  });
+
+  it('reports renamed var', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithRenamedVar');
+    assertChanges(result, [
+      { action: 'substitution',
+        original: { label: 'b', type: 't_uint256' },
+        updated:  { label: 'c', type: 't_uint256' }  }
+    ])
+  });
+
+  it('reports type changed', function () {
+    const result = compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithTypeChanged');
+    assertChanges(result, [
+      { action: 'substitution',
+        original: { label: 'b', type: 't_uint256' },
+        updated:  { label: 'b', type: 't_string' }  }
+    ])
+  });
+
+})

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -255,19 +255,22 @@ contract('Storage', () => {
     })
   })
   
-  for (const contractName of ['StorageMockWithReferences', 'StorageMockWithTransitiveReferences']) {
+  for (const contractName of ['StorageMockWithReferences', 'StorageMockWithTransitiveReferences', 'StorageMockWithNodeModulesReferences']) {
     describe(`on references to other files in ${contractName}`, function () {
       load(contractName)
+
+      const structScope = contractName === 'StorageMockWithNodeModulesReferences' ? 'DependencyStorageMock' : 'StorageMockWithStructs';
+      const enumScope = contractName === 'StorageMockWithNodeModulesReferences' ? 'DependencyStorageMock' : 'StorageMockWithEnums';
       
       checkStorage([ 
-        { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
-        { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
+        { label: 'my_enum', type: `t_enum<${enumScope}.MyEnum>` },
+        { label: 'my_struct', type: `t_struct<${structScope}.MyStruct>` },
         { label: 'my_contract', type: 't_address' }
       ])
       
       checkTypes({
-        't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
-        't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum', members: ['State1', 'State2'] }
+        [`t_struct<${structScope}.MyStruct>`]: { kind: 'struct', label: `${structScope}.MyStruct` },
+        [`t_enum<${enumScope}.MyEnum>`]: { kind: 'enum', label: `${enumScope}.MyEnum`, members: ['State1', 'State2'] }
       })
     })
   }

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -134,6 +134,34 @@ contract('Storage', () => {
     })
   })
 
+  describe('on functions', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithFunctions')
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_fun', type: 't_function' },
+        { label: 'my_fun_dynarray', type: 't_array:dyn<t_function>' },
+        { label: 'my_fun_staticarray', type: 't_array:10<t_function>' },
+        { label: 'my_fun_mapping', type: 't_mapping<t_function>' }
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_array:10<t_function>': { label: 'function[10]' },
+        't_array:dyn<t_function>': { label: 'function[]' },
+        't_mapping<t_function>': { valueType: 't_function', kind: 'mapping', label: 'mapping(key => function)' },
+        't_function': { label: 'function' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
   describe('on contracts', function () {
     beforeEach(function () {
       this.getStorageLayout('StorageMockWithContracts')
@@ -296,7 +324,7 @@ contract('Storage', () => {
     })
   })
 
-  for (const contractName of ['StorageMockWithReferences', 'StorageMockWithRecursiveReferences']) {
+  for (const contractName of ['StorageMockWithReferences', 'StorageMockWithTransitiveReferences']) {
     describe(`on references to other files in ${contractName}`, function () {
       beforeEach(function () {
         this.getStorageLayout(contractName)

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -42,7 +42,7 @@ contract('Storage', () => {
     load('SimpleStorageMock')
     
     it('tracks src and path', function () {
-      this.storage[0].src.should.eq('134:32:17')
+      this.storage[0].src.should.match(/^134:32/)
       this.storage[0].path.should.match(/StorageMocks\.sol$/)
       this.storage[0].path.should.not.match(/^\//)
     })

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -7,7 +7,7 @@ const util = require('util')
 import _ from 'lodash'
 
 import Contracts from '../../../src/utils/Contracts'
-import { getStorageLayout } from '../../../src/validations/Storage'
+import { getStorageLayout, getStructsOrEnums } from '../../../src/validations/Storage'
 
 contract('Storage', () => {
   
@@ -304,4 +304,23 @@ contract('Storage', () => {
     
     checkTypes({ 't_uint256': { label: 'uint256' } })
   })
+
+  describe('#getStructsOrEnums', function () {
+    it('returns all structs and enums', function () {
+      const storageInfo = getStorageLayout(Contracts.getFromLib('StorageMockMixed'))
+      const result = getStructsOrEnums(storageInfo)
+      const resultVarNames = result.map(variable => variable.label)
+
+      resultVarNames.should.be.deep.eq([
+        'my_struct',
+        'my_struct_dynarray',
+        'my_struct_staticarray',
+        'my_struct_mapping',
+        'my_enum',
+        'my_enum_dynarray',
+        'my_enum_staticarray',
+        'my_enum_mapping',
+      ])
+    })
+  });
 })

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -41,6 +41,12 @@ contract('Storage', () => {
   describe('on simple storage variables', function () {
     load('SimpleStorageMock')
     
+    it('tracks src and path', function () {
+      this.storage[0].src.should.eq('134:32:17')
+      this.storage[0].path.should.match(/StorageMocks\.sol$/)
+      this.storage[0].path.should.not.match(/^\//)
+    })
+
     checkStorage([ 
       { label: 'my_public_uint256', contract: 'SimpleStorageMock', type: 't_uint256' },
       { label: 'my_internal_string', contract: 'SimpleStorageMock', type: 't_string' },

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -11,239 +11,177 @@ import { getStorageLayout } from '../../../src/validations/Storage'
 
 contract('Storage', () => {
   
-  before('set auxiliary functions', function () {
-    this.getStorageLayout = (name) => {
+  function load(name) {
+    beforeEach(`loading contract ${name}`, function () {
       const contractClass = Contracts.getFromLocal(name)
       const { types, storage } = getStorageLayout(contractClass)
       this.types = types
       this.storage = storage
-    }
-
-    this.assertStorage = (expectedStorage) => {
+    })
+  }
+  
+  function checkStorage(expectedStorage) {
+    it('returns storage layout', function () {
       this.storage.should.have.lengthOf(expectedStorage.length, `storage should be:\n${expectedStorage.map(util.inspect).join('\n')}\n\n      but was:\n${this.storage.map(util.inspect).join('\n')}\n\n`)
       expectedStorage.forEach((node, index) => {
         this.storage[index].should.include(node)
       })
-    }
-
-    this.assertTypes = (expectedTypes) => {
+    })
+  }
+  
+  function checkTypes(expectedTypes) {
+    it('returns types information', function () {
       _.forEach(expectedTypes, (value, id) => {
         should.exist(this.types[id], `expected types to include key ${id} but was:\n${util.inspect(this.types)}\n`)
         this.types[id].should.deep.include(value)
       })
-    }
-  })
-
+    })
+  }
+  
   describe('on simple storage variables', function () {
-    beforeEach(function () {
-      this.getStorageLayout('SimpleStorageMock')
-    })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_public_uint256', contract: 'SimpleStorageMock', type: 't_uint256' },
-        { label: 'my_internal_string', contract: 'SimpleStorageMock', type: 't_string' },
-        { label: 'my_private_uint8', contract: 'SimpleStorageMock', type: 't_uint8' },
-        { label: 'my_private_uint16', contract: 'SimpleStorageMock', type: 't_int8' },
-        { label: 'my_private_bool', contract: 'SimpleStorageMock', type: 't_bool' },
-        { label: 'my_private_uint', contract: 'SimpleStorageMock', type: 't_uint256' },
-        { label: 'my_private_address', contract: 'SimpleStorageMock', type: 't_address' } 
-      ]
-
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        t_uint256: { label: 'uint256' },
-        t_string: { label: 'string' },
-        t_uint8: { label: 'uint8' },
-        t_int8: { label: 'int8' },
-        t_bool: { label: 'bool' },
-        t_address: { label: 'address' } 
-      }
-
-      this.assertTypes(expectedTypes)
+    load('SimpleStorageMock')
+    
+    checkStorage([ 
+      { label: 'my_public_uint256', contract: 'SimpleStorageMock', type: 't_uint256' },
+      { label: 'my_internal_string', contract: 'SimpleStorageMock', type: 't_string' },
+      { label: 'my_private_uint8', contract: 'SimpleStorageMock', type: 't_uint8' },
+      { label: 'my_private_uint16', contract: 'SimpleStorageMock', type: 't_int8' },
+      { label: 'my_private_bool', contract: 'SimpleStorageMock', type: 't_bool' },
+      { label: 'my_private_uint', contract: 'SimpleStorageMock', type: 't_uint256' },
+      { label: 'my_private_address', contract: 'SimpleStorageMock', type: 't_address' } 
+    ]);
+    
+    checkTypes({ 
+      t_uint256: { label: 'uint256' },
+      t_string: { label: 'string' },
+      t_uint8: { label: 'uint8' },
+      t_int8: { label: 'int8' },
+      t_bool: { label: 'bool' },
+      t_address: { label: 'address' } 
     })
   })
-
+  
   describe('on constants', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithConstants')
-    })
-
-    it('does not identify constants as storage variables', function () {
-      this.assertStorage([])
-    })
+    load('StorageMockWithConstants')
+    checkStorage([])
   })
-
+  
   describe('on arrays', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithArrays')
-    })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_public_uint256_dynarray', type: 't_array:dyn<t_uint256>' },
-        { label: 'my_internal_string_dynarray', type: 't_array:dyn<t_string>' },
-        { label: 'my_private_address_dynarray', type: 't_array:dyn<t_address>' },
-        { label: 'my_public_int8_staticarray', type: 't_array:10<t_int8>' },
-        { label: 'my_internal_bool_staticarray', type: 't_array:20<t_bool>' },
-        { label: 'my_private_uint_staticarray', type: 't_array:30<t_uint256>' }
-      ]
-
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_array:dyn<t_uint256>': { label: 'uint256[]' },
-        't_array:dyn<t_string>': { label: 'string[]' },
-        't_array:dyn<t_address>': { label: 'address[]' },
-        't_array:10<t_int8>': { label: 'int8[10]' },
-        't_array:20<t_bool>': { label: 'bool[20]' },
-        't_array:30<t_uint256>': { label: 'uint256[30]' }
-      }
-      this.assertTypes(expectedTypes)
+    load('StorageMockWithArrays')
+    
+    checkStorage([ 
+      { label: 'my_public_uint256_dynarray', type: 't_array:dyn<t_uint256>' },
+      { label: 'my_internal_string_dynarray', type: 't_array:dyn<t_string>' },
+      { label: 'my_private_address_dynarray', type: 't_array:dyn<t_address>' },
+      { label: 'my_public_int8_staticarray', type: 't_array:10<t_int8>' },
+      { label: 'my_internal_bool_staticarray', type: 't_array:20<t_bool>' },
+      { label: 'my_private_uint_staticarray', type: 't_array:30<t_uint256>' }
+    ])
+    
+    checkTypes({ 
+      't_array:dyn<t_uint256>': { label: 'uint256[]' },
+      't_array:dyn<t_string>': { label: 'string[]' },
+      't_array:dyn<t_address>': { label: 'address[]' },
+      't_array:10<t_int8>': { label: 'int8[10]' },
+      't_array:20<t_bool>': { label: 'bool[20]' },
+      't_array:30<t_uint256>': { label: 'uint256[30]' }
     })
   })
-
+  
   describe('on mappings', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithMappings')
-    })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_mapping', type: 't_mapping<t_string>' },
-        { label: 'my_nested_mapping', type: 't_mapping<t_address>' },
-        { label: 'my_mapping_with_arrays', type: 't_mapping<t_array:dyn<t_bool>>' }
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_mapping<t_string>': { valueType: 't_string', kind: 'mapping', label: 'mapping(key => string)' },
-        't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
-        't_mapping<t_array:dyn<t_bool>>': { valueType: 't_array:dyn<t_bool>', kind: 'mapping', label: 'mapping(key => bool[])' }
-      }
-
-      this.assertTypes(expectedTypes)
+    load('StorageMockWithMappings')
+    
+    checkStorage([ 
+      { label: 'my_mapping', type: 't_mapping<t_string>' },
+      { label: 'my_nested_mapping', type: 't_mapping<t_address>' },
+      { label: 'my_mapping_with_arrays', type: 't_mapping<t_array:dyn<t_bool>>' }
+    ])
+    
+    checkTypes({ 
+      't_mapping<t_string>': { valueType: 't_string', kind: 'mapping', label: 'mapping(key => string)' },
+      't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
+      't_mapping<t_array:dyn<t_bool>>': { valueType: 't_array:dyn<t_bool>', kind: 'mapping', label: 'mapping(key => bool[])' }
     })
   })
-
+  
   describe('on functions', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithFunctions')
-    })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_fun', type: 't_function' },
-        { label: 'my_fun_dynarray', type: 't_array:dyn<t_function>' },
-        { label: 'my_fun_staticarray', type: 't_array:10<t_function>' },
-        { label: 'my_fun_mapping', type: 't_mapping<t_function>' }
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_array:10<t_function>': { label: 'function[10]' },
-        't_array:dyn<t_function>': { label: 'function[]' },
-        't_mapping<t_function>': { valueType: 't_function', kind: 'mapping', label: 'mapping(key => function)' },
-        't_function': { label: 'function' }
-      }
-
-      this.assertTypes(expectedTypes)
+    load('StorageMockWithFunctions')
+    
+    checkStorage([ 
+      { label: 'my_fun', type: 't_function' },
+      { label: 'my_fun_dynarray', type: 't_array:dyn<t_function>' },
+      { label: 'my_fun_staticarray', type: 't_array:10<t_function>' },
+      { label: 'my_fun_mapping', type: 't_mapping<t_function>' }
+    ])
+    
+    checkTypes({ 
+      't_array:10<t_function>': { label: 'function[10]' },
+      't_array:dyn<t_function>': { label: 'function[]' },
+      't_mapping<t_function>': { valueType: 't_function', kind: 'mapping', label: 'mapping(key => function)' },
+      't_function': { label: 'function' }
     })
   })
-
+  
   describe('on contracts', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithContracts')
-    })
-
+    load('StorageMockWithContracts')
+    
     it('replaces contract identifier with address', function () {
       this.storage[0].type.should.eq('t_address')
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_contract', type: 't_address' },
-        { label: 'my_contract_dynarray', type: 't_array:dyn<t_address>' },
-        { label: 'my_contract_staticarray', type: 't_array:10<t_address>' },
-        { label: 'my_contract_mapping', type: 't_mapping<t_address>' },
-        { label: 'my_contract_dynarray_mapping', type: 't_mapping<t_array:dyn<t_address>>' },
-        { label: 'my_contract_staticarray_mapping', type: 't_mapping<t_array:10<t_address>>' }
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_address': { kind: 'elementary', label: 'address' },
-        't_array:dyn<t_address>': { valueType: 't_address', length: 'dyn', kind: 'array', label: 'address[]' },
-        't_array:10<t_address>':  { valueType: 't_address', length: '10', kind: 'array', label: 'address[10]' },
-        't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
-        't_mapping<t_array:dyn<t_address>>': { valueType: 't_array:dyn<t_address>', kind: 'mapping', label: 'mapping(key => address[])' },
-        't_mapping<t_array:10<t_address>>': { valueType: 't_array:10<t_address>', kind: 'mapping', label: 'mapping(key => address[10])' }
-      }
-
-      this.assertTypes(expectedTypes)
+    
+    checkStorage([ 
+      { label: 'my_contract', type: 't_address' },
+      { label: 'my_contract_dynarray', type: 't_array:dyn<t_address>' },
+      { label: 'my_contract_staticarray', type: 't_array:10<t_address>' },
+      { label: 'my_contract_mapping', type: 't_mapping<t_address>' },
+      { label: 'my_contract_dynarray_mapping', type: 't_mapping<t_array:dyn<t_address>>' },
+      { label: 'my_contract_staticarray_mapping', type: 't_mapping<t_array:10<t_address>>' }
+    ])
+    
+    checkTypes({ 
+      't_address': { kind: 'elementary', label: 'address' },
+      't_array:dyn<t_address>': { valueType: 't_address', length: 'dyn', kind: 'array', label: 'address[]' },
+      't_array:10<t_address>':  { valueType: 't_address', length: '10', kind: 'array', label: 'address[10]' },
+      't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
+      't_mapping<t_array:dyn<t_address>>': { valueType: 't_array:dyn<t_address>', kind: 'mapping', label: 'mapping(key => address[])' },
+      't_mapping<t_array:10<t_address>>': { valueType: 't_array:10<t_address>', kind: 'mapping', label: 'mapping(key => address[10])' }
     })
   })
-
+  
   describe('on enums', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithEnums')
-    })
-
+    load('StorageMockWithEnums')
+    
     it('uses enum canonical name as type id', function () {
       this.storage[0].type.should.eq('t_enum<StorageMockWithEnums.MyEnum>')
     })
-
+    
     it('tracks enum members in type definition', function () {
       const members = this.types['t_enum<StorageMockWithEnums.MyEnum>'].members
       members.should.deep.eq(['State1', 'State2'])
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
-        { label: 'my_enum_dynarray', type: 't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>' },
-        { label: 'my_enum_staticarray', type: 't_array:10<t_enum<StorageMockWithEnums.MyEnum>>' },
-        { label: 'my_enum_mapping', type: 't_mapping<t_enum<StorageMockWithEnums.MyEnum>>' },
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum' },
-        't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: 'dyn', kind: 'array', label: 'StorageMockWithEnums.MyEnum[]' },
-        't_array:10<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: '10', kind: 'array', label: 'StorageMockWithEnums.MyEnum[10]' },
-        't_mapping<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', label: 'mapping(key => StorageMockWithEnums.MyEnum)', kind: 'mapping' }
-      }
-
-      this.assertTypes(expectedTypes)
+    
+    checkStorage([ 
+      { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
+      { label: 'my_enum_dynarray', type: 't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>' },
+      { label: 'my_enum_staticarray', type: 't_array:10<t_enum<StorageMockWithEnums.MyEnum>>' },
+      { label: 'my_enum_mapping', type: 't_mapping<t_enum<StorageMockWithEnums.MyEnum>>' },
+    ])
+    
+    checkTypes({ 
+      't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum' },
+      't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: 'dyn', kind: 'array', label: 'StorageMockWithEnums.MyEnum[]' },
+      't_array:10<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: '10', kind: 'array', label: 'StorageMockWithEnums.MyEnum[10]' },
+      't_mapping<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', label: 'mapping(key => StorageMockWithEnums.MyEnum)', kind: 'mapping' }
     })
   })
-
+  
   describe('on structs', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithStructs')
-    })
-
+    load('StorageMockWithStructs')
+    
     it('uses struct canonical name as type id', function () {
       this.storage[0].type.should.eq('t_struct<StorageMockWithStructs.MyStruct>')
     })
-
+    
     it('tracks struct members in type definition', function () {
       const members = this.types['t_struct<StorageMockWithStructs.MyStruct>'].members
       members.should.have.lengthOf(3)
@@ -251,35 +189,25 @@ contract('Storage', () => {
       members[1].should.include({ label: 'struct_string', type: 't_string' })
       members[2].should.include({ label: 'struct_address', type: 't_address' })
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
-        { label: 'my_struct_dynarray', type: 't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>' },
-        { label: 'my_struct_staticarray', type: 't_array:10<t_struct<StorageMockWithStructs.MyStruct>>' },
-        { label: 'my_struct_mapping', type: 't_mapping<t_struct<StorageMockWithStructs.MyStruct>>' },
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
-        't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: 'dyn', kind: 'array', label: 'StorageMockWithStructs.MyStruct[]' },
-        't_array:10<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: '10', kind: 'array', label: 'StorageMockWithStructs.MyStruct[10]' },
-        't_mapping<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', label: 'mapping(key => StorageMockWithStructs.MyStruct)', kind: 'mapping' }
-      }
-
-      this.assertTypes(expectedTypes)
+    
+    checkStorage([ 
+      { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
+      { label: 'my_struct_dynarray', type: 't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>' },
+      { label: 'my_struct_staticarray', type: 't_array:10<t_struct<StorageMockWithStructs.MyStruct>>' },
+      { label: 'my_struct_mapping', type: 't_mapping<t_struct<StorageMockWithStructs.MyStruct>>' },
+    ])
+    
+    checkTypes({ 
+      't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
+      't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: 'dyn', kind: 'array', label: 'StorageMockWithStructs.MyStruct[]' },
+      't_array:10<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: '10', kind: 'array', label: 'StorageMockWithStructs.MyStruct[10]' },
+      't_mapping<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', label: 'mapping(key => StorageMockWithStructs.MyStruct)', kind: 'mapping' }
     })
   })
-
+  
   describe('on complex structs', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithComplexStructs')
-    })
-
+    load('StorageMockWithComplexStructs')
+    
     it('tracks struct members in type definition', function () {
       const members = this.types['t_struct<StorageMockWithComplexStructs.MyStruct>'].members
       members.should.have.lengthOf(3)
@@ -287,101 +215,68 @@ contract('Storage', () => {
       members[1].should.include({ label: 'mapping_enums', type: 't_mapping<t_enum<StorageMockWithEnums.MyEnum>>' })
       members[2].should.include({ label: 'other_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' })
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'my_struct', type: 't_struct<StorageMockWithComplexStructs.MyStruct>' },
-        { label: 'my_other_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' }
-      ]
-      
-      this.assertStorage(expectedStorage)
-    })
+    
+    checkStorage([ 
+      { label: 'my_struct', type: 't_struct<StorageMockWithComplexStructs.MyStruct>' },
+      { label: 'my_other_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' }
+    ])
   })
-
+  
   describe('on recursive structs', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockWithRecursiveStructs')
-    })
-
+    load('StorageMockWithRecursiveStructs')
+    
     it('tracks struct members in type definition', function () {
       const members = this.types['t_struct<StorageMockWithRecursiveStructs.MyStruct>'].members
       members.should.have.lengthOf(1)
       members[0].should.include({ label: 'other_structs', type: 't_array:dyn<t_struct<StorageMockWithRecursiveStructs.OtherStruct>>' })
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [{ label: 'my_struct', type: 't_struct<StorageMockWithRecursiveStructs.MyStruct>' }]
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 
-        't_struct<StorageMockWithRecursiveStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.MyStruct' },
-        't_struct<StorageMockWithRecursiveStructs.OtherStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.OtherStruct' }
-      }
-
-      this.assertTypes(expectedTypes)
+    
+    checkStorage([{ label: 'my_struct', type: 't_struct<StorageMockWithRecursiveStructs.MyStruct>' }])
+    
+    checkTypes({ 
+      't_struct<StorageMockWithRecursiveStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.MyStruct' },
+      't_struct<StorageMockWithRecursiveStructs.OtherStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.OtherStruct' }
     })
   })
-
+  
   for (const contractName of ['StorageMockWithReferences', 'StorageMockWithTransitiveReferences']) {
     describe(`on references to other files in ${contractName}`, function () {
-      beforeEach(function () {
-        this.getStorageLayout(contractName)
-      })
-
-      it('returns storage', function () {
-        const expectedStorage = [ 
-          { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
-          { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
-          { label: 'my_contract', type: 't_address' }
-        ]
-
-        this.assertStorage(expectedStorage)
-      })
-
-      it('returns types info', function () {
-        const expectedTypes = { 
-          't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
-          't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum', members: ['State1', 'State2'] }
-        }
-
-        this.assertTypes(expectedTypes)
+      load(contractName)
+      
+      checkStorage([ 
+        { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
+        { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
+        { label: 'my_contract', type: 't_address' }
+      ])
+      
+      checkTypes({
+        't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
+        't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum', members: ['State1', 'State2'] }
       })
     })
-  };
-
+  }
+  
   describe('on inheritance chain', function () {
-    beforeEach(function () {
-      this.getStorageLayout('StorageMockChainChild')
-    })
-
+    load('StorageMockChainChild')
+    
     it('assigns slots according to linearization', async function () {
       const StorageMockChainChild = Contracts.getFromLib('StorageMockChainChild')
       const instance = await StorageMockChainChild.new();
       const slots = await instance.slots();
       slots.map(slot => slot.toNumber()).should.deep.eq([0, 1, 3, 5, 7])
     })
-
-    it('returns storage', function () {
-      const expectedStorage = [ 
-        { label: 'base',  type: 't_uint256', contract: 'StorageMockChainBase' },
-        { label: 'a1',    type: 't_uint256', contract: 'StorageMockChainA1' },
-        { label: 'a2',    type: 't_uint256', contract: 'StorageMockChainA1' },
-        { label: 'a3',    type: 't_uint256', contract: 'StorageMockChainA2' },
-        { label: 'a4',    type: 't_uint256', contract: 'StorageMockChainA2' },
-        { label: 'b1',    type: 't_uint256', contract: 'StorageMockChainB' },
-        { label: 'b2',    type: 't_uint256', contract: 'StorageMockChainB' },
-        { label: 'child', type: 't_uint256', contract: 'StorageMockChainChild' }
-      ]
-
-      this.assertStorage(expectedStorage)
-    })
-
-    it('returns types info', function () {
-      const expectedTypes = { 't_uint256': { label: 'uint256' } }
-      this.assertTypes(expectedTypes)
-    })
+    
+    checkStorage([ 
+      { label: 'base',  type: 't_uint256', contract: 'StorageMockChainBase' },
+      { label: 'a1',    type: 't_uint256', contract: 'StorageMockChainA1' },
+      { label: 'a2',    type: 't_uint256', contract: 'StorageMockChainA1' },
+      { label: 'a3',    type: 't_uint256', contract: 'StorageMockChainA2' },
+      { label: 'a4',    type: 't_uint256', contract: 'StorageMockChainA2' },
+      { label: 'b1',    type: 't_uint256', contract: 'StorageMockChainB' },
+      { label: 'b2',    type: 't_uint256', contract: 'StorageMockChainB' },
+      { label: 'child', type: 't_uint256', contract: 'StorageMockChainChild' }
+    ])
+    
+    checkTypes({ 't_uint256': { label: 'uint256' } })
   })
-  
 })

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -1,0 +1,299 @@
+'use strict'
+require('../../setup')
+
+const should = require('chai').should()
+const util = require('util')
+
+import _ from 'lodash'
+
+import Contracts from '../../../src/utils/Contracts'
+import { getStorageLayout } from '../../../src/validations/Storage'
+
+contract('Storage', () => {
+  
+  before('set auxiliary functions', function () {
+    this.getStorageLayout = (name) => {
+      const contractClass = Contracts.getFromLocal(name)
+      const { types, storage } = getStorageLayout(contractClass)
+      this.types = types
+      this.storage = storage
+    }
+
+    this.assertStorage = (expectedStorage) => {
+      this.storage.should.have.lengthOf(expectedStorage.length, `storage should have:\n${expectedStorage.map(util.inspect).join('\n')}\n\n      but was:\n${this.storage.map(util.inspect).join('\n')}\n`)
+      expectedStorage.forEach((node, index) => {
+        this.storage[index].should.include(node)
+      })
+    }
+
+    this.assertTypes = (expectedTypes) => {
+      _.forEach(expectedTypes, (value, id) => {
+        should.exist(this.types[id], `expected types to include key ${id} but was:\n${util.inspect(this.types)}\n`)
+        this.types[id].should.include(value)
+      })
+    }
+  })
+
+  describe('on simple storage variables', function () {
+    beforeEach(function () {
+      this.getStorageLayout('SimpleStorageMock')
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_public_uint256', contract: 'SimpleStorageMock', type: 't_uint256' },
+        { label: 'my_internal_string', contract: 'SimpleStorageMock', type: 't_string' },
+        { label: 'my_private_uint8', contract: 'SimpleStorageMock', type: 't_uint8' },
+        { label: 'my_private_uint16', contract: 'SimpleStorageMock', type: 't_int8' },
+        { label: 'my_private_bool', contract: 'SimpleStorageMock', type: 't_bool' },
+        { label: 'my_private_uint', contract: 'SimpleStorageMock', type: 't_uint256' },
+        { label: 'my_private_address', contract: 'SimpleStorageMock', type: 't_address' } 
+      ]
+
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        t_uint256: { label: 'uint256' },
+        t_string: { label: 'string' },
+        t_uint8: { label: 'uint8' },
+        t_int8: { label: 'int8' },
+        t_bool: { label: 'bool' },
+        t_address: { label: 'address' } 
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on constants', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithConstants')
+    })
+
+    it('does not identify constants as storage variables', function () {
+      this.assertStorage([])
+    })
+  })
+
+  describe('on arrays', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithArrays')
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_public_uint256_dynarray', type: 't_array:dyn<t_uint256>' },
+        { label: 'my_internal_string_dynarray', type: 't_array:dyn<t_string>' },
+        { label: 'my_private_address_dynarray', type: 't_array:dyn<t_address>' },
+        { label: 'my_public_int8_staticarray', type: 't_array:10<t_int8>' },
+        { label: 'my_internal_bool_staticarray', type: 't_array:20<t_bool>' },
+        { label: 'my_private_uint_staticarray', type: 't_array:30<t_uint256>' }
+      ]
+
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_array:dyn<t_uint256>': { label: 'uint256[]' },
+        't_array:dyn<t_string>': { label: 'string[]' },
+        't_array:dyn<t_address>': { label: 'address[]' },
+        't_array:10<t_int8>': { label: 'int8[10]' },
+        't_array:20<t_bool>': { label: 'bool[20]' },
+        't_array:30<t_uint256>': { label: 'uint256[30]' }
+      }
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on mappings', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithMappings')
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_mapping', type: 't_mapping<t_string>' },
+        { label: 'my_nested_mapping', type: 't_mapping<t_address>' },
+        { label: 'my_mapping_with_arrays', type: 't_mapping<t_array:dyn<t_bool>>' }
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_mapping<t_string>': { valueType: 't_string', kind: 'mapping', label: 'mapping(key => string)' },
+        't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
+        't_mapping<t_array:dyn<t_bool>>': { valueType: 't_array:dyn<t_bool>', kind: 'mapping', label: 'mapping(key => bool[])' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on contracts', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithContracts')
+    })
+
+    it('replaces contract identifier with address', function () {
+      this.storage[0].type.should.eq('t_address')
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_contract', type: 't_address' },
+        { label: 'my_contract_dynarray', type: 't_array:dyn<t_address>' },
+        { label: 'my_contract_staticarray', type: 't_array:10<t_address>' },
+        { label: 'my_contract_mapping', type: 't_mapping<t_address>' },
+        { label: 'my_contract_dynarray_mapping', type: 't_mapping<t_array:dyn<t_address>>' },
+        { label: 'my_contract_staticarray_mapping', type: 't_mapping<t_array:10<t_address>>' }
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_address': { kind: 'elementary', label: 'address' },
+        't_array:dyn<t_address>': { valueType: 't_address', length: 'dyn', kind: 'array', label: 'address[]' },
+        't_array:10<t_address>':  { valueType: 't_address', length: '10', kind: 'array', label: 'address[10]' },
+        't_mapping<t_address>': { valueType: 't_address', kind: 'mapping', label: 'mapping(key => address)' },
+        't_mapping<t_array:dyn<t_address>>': { valueType: 't_array:dyn<t_address>', kind: 'mapping', label: 'mapping(key => address[])' },
+        't_mapping<t_array:10<t_address>>': { valueType: 't_array:10<t_address>', kind: 'mapping', label: 'mapping(key => address[10])' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on enums', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithEnums')
+    })
+
+    it('uses enum canonical name as type id', function () {
+      this.storage[0].type.should.eq('t_enum<StorageMockWithEnums.MyEnum>')
+    })
+
+    it('tracks enum members in type definition', function () {
+      const members = this.types['t_enum<StorageMockWithEnums.MyEnum>'].members
+      members.should.deep.eq(['State1', 'State2'])
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_enum', type: 't_enum<StorageMockWithEnums.MyEnum>' },
+        { label: 'my_enum_dynarray', type: 't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>' },
+        { label: 'my_enum_staticarray', type: 't_array:10<t_enum<StorageMockWithEnums.MyEnum>>' },
+        { label: 'my_enum_mapping', type: 't_mapping<t_enum<StorageMockWithEnums.MyEnum>>' },
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_enum<StorageMockWithEnums.MyEnum>': { kind: 'enum', label: 'StorageMockWithEnums.MyEnum' },
+        't_array:dyn<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: 'dyn', kind: 'array', label: 'StorageMockWithEnums.MyEnum[]' },
+        't_array:10<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', length: '10', kind: 'array', label: 'StorageMockWithEnums.MyEnum[10]' },
+        't_mapping<t_enum<StorageMockWithEnums.MyEnum>>': { valueType: 't_enum<StorageMockWithEnums.MyEnum>', label: 'mapping(key => StorageMockWithEnums.MyEnum)', kind: 'mapping' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on structs', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithStructs')
+    })
+
+    it('uses struct canonical name as type id', function () {
+      this.storage[0].type.should.eq('t_struct<StorageMockWithStructs.MyStruct>')
+    })
+
+    it('tracks struct members in type definition', function () {
+      const members = this.types['t_struct<StorageMockWithStructs.MyStruct>'].members
+      members.should.have.lengthOf(3)
+      members[0].should.include({ label: 'struct_uint256', type: 't_uint256' })
+      members[1].should.include({ label: 'struct_string', type: 't_string' })
+      members[2].should.include({ label: 'struct_address', type: 't_address' })
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' },
+        { label: 'my_struct_dynarray', type: 't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>' },
+        { label: 'my_struct_staticarray', type: 't_array:10<t_struct<StorageMockWithStructs.MyStruct>>' },
+        { label: 'my_struct_mapping', type: 't_mapping<t_struct<StorageMockWithStructs.MyStruct>>' },
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_struct<StorageMockWithStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithStructs.MyStruct' },
+        't_array:dyn<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: 'dyn', kind: 'array', label: 'StorageMockWithStructs.MyStruct[]' },
+        't_array:10<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', length: '10', kind: 'array', label: 'StorageMockWithStructs.MyStruct[10]' },
+        't_mapping<t_struct<StorageMockWithStructs.MyStruct>>': { valueType: 't_struct<StorageMockWithStructs.MyStruct>', label: 'mapping(key => StorageMockWithStructs.MyStruct)', kind: 'mapping' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+  describe('on complex structs', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithComplexStructs')
+    })
+
+    it('tracks struct members in type definition', function () {
+      const members = this.types['t_struct<StorageMockWithComplexStructs.MyStruct>'].members
+      members.should.have.lengthOf(3)
+      members[0].should.include({ label: 'uint256_dynarray', type: 't_array:dyn<t_uint256>' })
+      members[1].should.include({ label: 'mapping_enums', type: 't_mapping<t_enum<StorageMockWithEnums.MyEnum>>' })
+      members[2].should.include({ label: 'other_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' })
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [ 
+        { label: 'my_struct', type: 't_struct<StorageMockWithComplexStructs.MyStruct>' },
+        { label: 'my_other_struct', type: 't_struct<StorageMockWithStructs.MyStruct>' }
+      ]
+      
+      this.assertStorage(expectedStorage)
+    })
+  })
+
+  describe.skip('on recursive structs', function () {
+    beforeEach(function () {
+      this.getStorageLayout('StorageMockWithRecursiveStructs')
+    })
+
+    it('tracks struct members in type definition', function () {
+      const members = this.types['t_struct<StorageMockWithRecursiveStructs.MyStruct>'].members
+      members.should.have.lengthOf(1)
+      members[0].should.include({ label: 'other_stucts', type: 't_array:dyn<t_struct<StorageMockWithRecursiveStructs.OtherStruct>>' })
+    })
+
+    it('returns storage', function () {
+      const expectedStorage = [{ label: 'my_struct', type: 't_struct<StorageMockWithRecursiveStructs.MyStruct>' }]
+      this.assertStorage(expectedStorage)
+    })
+
+    it('returns types info', function () {
+      const expectedTypes = { 
+        't_struct<StorageMockWithRecursiveStructs.MyStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.MyStruct' },
+        't_struct<StorageMockWithRecursiveStructs.OtherStruct>': { kind: 'struct', label: 'StorageMockWithRecursiveStructs.OtherStruct' }
+      }
+
+      this.assertTypes(expectedTypes)
+    })
+  })
+
+})

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -60,6 +60,22 @@ contract('Storage', () => {
       t_address: { label: 'address' } 
     })
   })
+
+  describe('on bytes', function () {
+    load('StorageMockWithBytes')
+    
+    checkStorage([ 
+      { label: 'my_bytes', contract: 'StorageMockWithBytes', type: 't_bytes' },
+      { label: 'my_bytes8', contract: 'StorageMockWithBytes', type: 't_bytes8' },
+      { label: 'my_bytes32', contract: 'StorageMockWithBytes', type: 't_bytes32' }
+    ]);
+    
+    checkTypes({ 
+      t_bytes: { label: 'bytes' },
+      t_bytes8: { label: 'bytes8' },
+      t_bytes32: { label: 'bytes32' }
+    })
+  })
   
   describe('on constants', function () {
     load('StorageMockWithConstants')

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -298,7 +298,7 @@ contract('Storage', () => {
     })
   })
 
-  describe.skip('on recursive structs', function () {
+  describe('on recursive structs', function () {
     beforeEach(function () {
       this.getStorageLayout('StorageMockWithRecursiveStructs')
     })
@@ -306,7 +306,7 @@ contract('Storage', () => {
     it('tracks struct members in type definition', function () {
       const members = this.types['t_struct<StorageMockWithRecursiveStructs.MyStruct>'].members
       members.should.have.lengthOf(1)
-      members[0].should.include({ label: 'other_stucts', type: 't_array:dyn<t_struct<StorageMockWithRecursiveStructs.OtherStruct>>' })
+      members[0].should.include({ label: 'other_structs', type: 't_array:dyn<t_struct<StorageMockWithRecursiveStructs.OtherStruct>>' })
     })
 
     it('returns storage', function () {


### PR DESCRIPTION
This is a new iteration of #92, which github is not allowing me to reopen.

---

When running zos-push, validate that the storage layout is compatible with the previous version of the contract, and abort push otherwise. All warnings are displayed to the user, eg:

```
$ zos push
Validating contract AnotherImplV1 before push
Variable 'uint256 value22' in contract ImplV1 was renamed to foo in contracts/mocks/ImplV1.sol:1.
Note that the new variable foo will have the value of value22 after upgrading. If this is not the desired behavior, add a new variable foo at the end of your contract instead.
New variable 'uint256 bar' was added in contract ImplV1 in contracts/mocks/ImplV1.sol:1
This pushes all variables after bar to a higher position in storage, causing the updated contract to read incorrect initial values. Only add new variables at the end of your contract to prevent this issue.
```

Storage layout is extracted from the contract's AST by the Storage class in lib, and is stored along with other contract data (such as bytecode hash) in the zos.network.json file. It is then retrieved for comparison on the next zos push. The format is a tuple `(storage, types)`, similar to the format discussed in ethereum/solidity#4017, where `storage` contains the array of variables, with references to the `types` dictionary with detailed info on each type.

Comparison is handled by the Layout class in lib, and uses a modified levenshtein algorithm for calculating the minimum change between both storages. Changes are identified as additions (either at the end or mid-contract, with additions at the end computed at zero cost for the algorithm), deletions (end or mid-contract), or substitutions (renames, typechanges, or both).

Fixes #37 
Spawns issues #112, #113, and #114

TBD: Should we add a feature toggle to disable it until the 3 issues above are ready?