### PR TITLE
Preserve App, Package and Directory addresses

### DIFF
--- a/examples/lib-complex/index.js
+++ b/examples/lib-complex/index.js
@@ -20,7 +20,7 @@ async function setupApp(txParams) {
   // On-chain, single entry point of the entire application.
   log.info(`<< Setting up App >> network: ${network}`)
   const initialVersion = '0.0.1'
-  return await AppProject.deploy('complex-example', initialVersion, txParams)
+  return await AppProject.fetchOrDeploy('complex-example', initialVersion, txParams, {})
 }
 
 async function deployVersion1(project, owner) {

--- a/packages/cli/src/models/dependency/Dependency.js
+++ b/packages/cli/src/models/dependency/Dependency.js
@@ -29,7 +29,7 @@ export default class Dependency {
 
   async deploy(txParams) {
     const version = semver.coerce(this.version).toString()
-    const project = await LibProject.deploy(version, txParams)
+    const project = await LibProject.fetchOrDeploy(version, txParams, {})
     await Promise.all(
       _.map(this.getPackageFile().contracts, (contractName, contractAlias) => {
         const contractClass = Contracts.getFromNodeModules(this.name, contractName)

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -72,13 +72,17 @@ export default class NetworkBaseController {
       log.info(`Creating new version ${requestedVersion}`);
       const provider = await this.newVersion(requestedVersion);
       this.networkFile.contracts = {};
-      this._registerVersion(requestedVersion, provider.address);
+      this._registerVersion(requestedVersion, provider);
     }
   }
 
-  _registerVersion(version, providerAddress) {
-    this.networkFile.provider = { address: providerAddress };
-    this.networkFile.version = version;
+  _registerPackage({ address }) {
+    this.networkFile.package = { address }
+  }
+
+  _registerVersion(version, { address }) {
+    this.networkFile.provider = { address }
+    this.networkFile.version = version
   }
 
   async newVersion(versionName) {

--- a/packages/cli/src/models/network/NetworkLibController.js
+++ b/packages/cli/src/models/network/NetworkLibController.js
@@ -13,11 +13,18 @@ export default class NetworkLibController extends NetworkBaseController {
   }
 
   async deploy() {
-    this.project = await LibProject.deploy(this.currentVersion, this.txParams)
-    const thepackage = await this.project.getProjectPackage()
-    this.networkFile.package = { address: thepackage.address }
-    const provider = await this.project.getCurrentDirectory();
-    this._registerVersion(this.currentVersion, provider.address)
+    try {
+      this.project = await LibProject.deploy(this.currentVersion, this.txParams)
+      this._registerPackage(await this.project.getProjectPackage())
+      this._registerVersion(this.currentVersion, await this.project.getCurrentDirectory())
+    } catch(deployError) {
+      this._tryRegisterPartialDeploy(deployError)
+    }
+  }
+
+  _tryRegisterPartialDeploy({ thepackage, directory }) {
+    if (thepackage) this._registerPackage(thepackage)
+    if (directory) this._registerVersion(this.currentVersion, directory)
   }
 
   async fetch() {

--- a/packages/cli/src/scripts/status.js
+++ b/packages/cli/src/scripts/status.js
@@ -25,7 +25,7 @@ async function appInfo(controller) {
     return false;
   }
 
-  await controller.fetch();
+  await controller.fetchOrDeploy();
   log.info(`Application is deployed at ${controller.appAddress}`);
   log.info(`- Package ${controller.packageFile.name} is at ${controller.networkFile.packageAddress}`);
   return true;
@@ -37,7 +37,7 @@ async function libInfo(controller) {
     return false;
   }
 
-  await controller.fetch();
+  await controller.fetchOrDeploy();
   log.info(`Library package is deployed at ${controller.packageAddress}`);
   return true;
 }

--- a/packages/cli/test/models/Dependency.test.js
+++ b/packages/cli/test/models/Dependency.test.js
@@ -72,17 +72,18 @@ contract('Dependency', function() {
     beforeEach(function() {
       this.dependency = new Dependency('mock-stdlib', '1.1.0')
       this.txParams = {}
+      this.addresses = {}
       delete this.dependency._packageFile
     })
 
     describe('#deploy', function() {
       it('deploys a dependency', function() {
         const libDeployStub = sinon
-          .stub(LibProject, 'deploy')
+          .stub(LibProject, 'fetchOrDeploy')
           .returns({ setImplementation: () => {} })
         this.dependency.deploy(this.txParams)
 
-        libDeployStub.should.have.been.calledWithExactly('1.1.0', this.txParams)
+        libDeployStub.should.have.been.calledWithExactly('1.1.0', this.txParams, this.addresses)
         sinon.restore()
       })
     })

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -55,7 +55,7 @@ contract('push script', function([_, owner]) {
       address.should.be.nonzeroAddress;
 
       const app = await App.fetch(address);
-      const hasPackage = await app.hasPackage(this.networkFile.packageFile.name)
+      const hasPackage = await app.hasPackage(this.networkFile.packageFile.name, defaultVersion)
       hasPackage.should.be.true
     });
   };

--- a/packages/lib/src/app/App.js
+++ b/packages/lib/src/app/App.js
@@ -40,9 +40,9 @@ export default class App {
     return { package: thepackage, version }
   }
 
-  async hasPackage(name) {
+  async hasPackage(name, version = undefined) {
     const [address, _version] = await this.appContract.getPackage(name)
-    return !isZeroAddress(address)
+    return !isZeroAddress(address) && _version === version
   }
 
   async setPackage(name, packageAddress, version) {

--- a/packages/lib/src/project/LibProject.js
+++ b/packages/lib/src/project/LibProject.js
@@ -1,5 +1,6 @@
 import BasePackageProject from "./BasePackageProject";
 import Package from "../package/Package";
+import { DeployError as LibDeployError } from '../utils/errors/DeployError';
 
 export default class LibProject extends BasePackageProject {
   static async fetch(packageAddress, version = '0.1.0', txParams) {
@@ -8,11 +9,17 @@ export default class LibProject extends BasePackageProject {
   }
 
   static async deploy(version = '0.1.0', txParams = {}) {
-    const thepackage = await Package.deploy(txParams)
-    const directory = await thepackage.newVersion(version)
-    const project = new this(thepackage, version, txParams)
-    project.directory = directory
-    return project
+    let thepackage, directory
+    try {
+      thepackage = await Package.deploy(txParams)
+      directory = await thepackage.newVersion(version)
+      const project = new this(thepackage, version, txParams)
+      project.directory = directory
+
+      return project
+    } catch(deployError) {
+      throw new LibDeployError(error.message, thepackage, directory)
+    }
   }
 
   constructor(thepackage, version = '0.1.0', txParams = {}) {

--- a/packages/lib/src/utils/errors/DeployError.js
+++ b/packages/lib/src/utils/errors/DeployError.js
@@ -1,0 +1,17 @@
+'use strict'
+
+export class DeployError extends Error {
+  constructor(message, thepackage, directory) {
+    super(message)
+    this.package = thepackage
+    this.directory = directory
+  }
+}
+
+export class AppDeployError extends DeployError {
+  constructor(message, thepackage, directory, app) {
+    super(message, thepackage, directory)
+    this.app = app
+  }
+}
+

--- a/packages/lib/src/utils/errors/DeployError.js
+++ b/packages/lib/src/utils/errors/DeployError.js
@@ -1,17 +1,9 @@
 'use strict'
 
 export class DeployError extends Error {
-  constructor(message, thepackage, directory) {
+  constructor(message, props) {
     super(message)
-    this.package = thepackage
-    this.directory = directory
-  }
-}
-
-export class AppDeployError extends DeployError {
-  constructor(message, thepackage, directory, app) {
-    super(message, thepackage, directory)
-    this.app = app
+    Object.keys(props).forEach(prop => this[prop] = props[prop])
   }
 }
 

--- a/packages/lib/test/src/app/App.test.js
+++ b/packages/lib/test/src/app/App.test.js
@@ -51,12 +51,12 @@ contract('App', function (accounts) {
     beforeEach('setting package', setPackage)
 
     it('returns true if exists', async function () {
-      const hasPackage = await this.app.hasPackage(packageName)
+      const hasPackage = await this.app.hasPackage(packageName, version)
       hasPackage.should.be.true
     })
 
     it('returns false if not exists', async function () {
-      const hasPackage = await this.app.hasPackage('NOTEXISTS')
+      const hasPackage = await this.app.hasPackage('NOTEXISTS', version)
       hasPackage.should.be.false
     })
   })

--- a/packages/lib/test/src/project/AppProject.test.js
+++ b/packages/lib/test/src/project/AppProject.test.js
@@ -16,14 +16,15 @@ contract('AppProject', function (accounts) {
   const newVersion = '0.3.0'
 
   beforeEach('deploying', async function () {
-    this.project = await AppProject.deploy(name, version, { from: owner })
+    this.project = await AppProject.fetchOrDeploy(name, version, { from: owner }, {})
     this.adminAddress = this.project.getApp().address
   });
 
-  shouldBehaveLikePackageProject({ 
+  shouldBehaveLikePackageProject({
     fetch: async function () {
-      this.project = await AppProject.fetch(this.project.getApp().address, name, { from: owner })
-    }, 
+      this.appAddress = this.project.getApp().address
+      this.project = await AppProject.fetchOrDeploy(name, version, { from: owner }, { appAddress: this.appAddress })
+    },
     onNewVersion: function () {
       it('registers the new package version in the app', async function () {
         const app = this.project.getApp()
@@ -37,7 +38,7 @@ contract('AppProject', function (accounts) {
       it('has a name', async function () {
         this.project.name.should.eq(name)
       })
-    } 
+    }
   });
   
   shouldManageProxies({

--- a/packages/lib/test/src/project/LibProject.test.js
+++ b/packages/lib/test/src/project/LibProject.test.js
@@ -9,13 +9,13 @@ contract('LibProject', function (accounts) {
   const version = '0.2.0'
 
   beforeEach('deploying', async function () {
-    this.project = await LibProject.deploy(version, { from: owner })
+    this.project = await LibProject.fetchOrDeploy(version, { from: owner }, {})
   });
 
-  shouldBehaveLikePackageProject({ 
+  shouldBehaveLikePackageProject({
     fetch: async function () {
       const thepackage = await this.project.getProjectPackage()
-      this.project = await LibProject.fetch(thepackage.address, version, { from: owner })
-    } 
+      this.project = await LibProject.fetchOrDeploy(version, { from: owner }, { packageAddress: thepackage.address })
+    }
   })
 })


### PR DESCRIPTION
Fixes #35
- [x] Implement an app, package and directory address tracker in lib and cli.
- [x] Pick up already deployed contracts addresses on  future `push` runs.