### PR TITLE
Fix status checker, comparator and fetcher

### DIFF
--- a/packages/cli/src/models/dependency/Dependency.js
+++ b/packages/cli/src/models/dependency/Dependency.js
@@ -40,6 +40,7 @@ export default class Dependency {
   }
 
   async install() {
+    console.log('about to install', [this.nameAndVersion], process.cwd())
     await npm.install([this.nameAndVersion], { save: true, cwd: process.cwd() })
   }
 

--- a/packages/cli/src/models/dependency/Dependency.js
+++ b/packages/cli/src/models/dependency/Dependency.js
@@ -40,7 +40,6 @@ export default class Dependency {
   }
 
   async install() {
-    console.log('about to install', [this.nameAndVersion], process.cwd())
     await npm.install([this.nameAndVersion], { save: true, cwd: process.cwd() })
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -235,29 +235,24 @@ export default class ZosNetworkFile {
 
   removeProxy(thepackage, alias, address) {
     const fullname = toContractFullName(thepackage, alias)
-    const index = this.indexOfProxy(fullname, address)
+    const index = this._indexOfProxy(fullname, address)
     if(index < 0) return
     this.data.proxies[fullname].splice(index, 1)
-    if(this.proxiesOf(fullname).length === 0) delete this.data.proxies[fullname]
+    if(this._proxiesOf(fullname).length === 0) delete this.data.proxies[fullname]
   }
 
   updateProxy({ package: proxyPackageName, contract: proxyContractName, address: proxyAddress }, fn) {
     const fullname = toContractFullName(proxyPackageName, proxyContractName)
-    const index = this.indexOfProxy(fullname, proxyAddress)
+    const index = this._indexOfProxy(fullname, proxyAddress)
     if (index === -1) throw Error(`Proxy ${fullname} at ${proxyAddress} not found in network file`)
     this.data.proxies[fullname][index] = fn(this.data.proxies[fullname][index]);
   }
 
-  proxyFromIndex(thepackage, alias, index) {
-    const fullname = toContractFullName(thepackage, alias)
-    return this.proxiesOf(fullname)[index]
-  }
-
-  indexOfProxy(fullname, address) {
+  _indexOfProxy(fullname, address) {
     return _.findIndex(this.data.proxies[fullname], { address })
   }
 
-  proxiesOf(fullname) {
+  _proxiesOf(fullname) {
     return this.data.proxies[fullname] || []
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -71,7 +71,7 @@ export default class ZosNetworkFile {
 
   getDependency(name) {
     if (!this.data.dependencies) return null
-    return this.data.dependencies[name]
+    return this.data.dependencies[name] || {}
   }
 
   hasDependency(name) {

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -213,10 +213,6 @@ export default class ZosNetworkFile {
     this.data.contracts[alias].bodyBytecodeHash = bodyBytecodeHash
   }
 
-  removeContract(alias) {
-    delete this.data.contracts[alias]
-  }
-
   unsetContract(alias) {
     delete this.data.contracts[alias];
   }

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -217,14 +217,15 @@ export default class ZosNetworkFile {
     delete this.data.contracts[alias]
   }
 
+  unsetContract(alias) {
+    delete this.data.contracts[alias];
+  }
+
   setProxies(packageName, alias, value) {
     const fullname = toContractFullName(packageName, alias)
     this.data.proxies[fullname] = value
   }
 
-  unsetContract(alias) {
-    delete this.data.contracts[alias];
-  }
 
   addProxy(thepackage, alias, info) {
     const fullname = toContractFullName(thepackage, alias)
@@ -245,6 +246,11 @@ export default class ZosNetworkFile {
     const index = this.indexOfProxy(fullname, proxyAddress)
     if (index === -1) throw Error(`Proxy ${fullname} at ${proxyAddress} not found in network file`)
     this.data.proxies[fullname][index] = fn(this.data.proxies[fullname][index]);
+  }
+
+  proxyFromIndex(thepackage, alias, index) {
+    const fullname = toContractFullName(thepackage, alias)
+    return this.proxiesOf(fullname)[index]
   }
 
   indexOfProxy(fullname, address) {

--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -232,11 +232,27 @@ export default class ZosNetworkFile {
     this.data.proxies[fullname].push(info)
   }
 
-  updateProxy({ package: proxyPackage, contract: proxyContract, address: proxyAddress }, fn) {
-    const fullname = toContractFullName(proxyPackage, proxyContract)
-    const index = _.findIndex(this.data.proxies[fullname], { address: proxyAddress })
-    if (index === -1) throw Error(`Proxy ${fullname} at ${proxyAddress} not found in network file`)    
+  removeProxy(thepackage, alias, address) {
+    const fullname = toContractFullName(thepackage, alias)
+    const index = this.indexOfProxy(fullname, address)
+    if(index < 0) return
+    this.data.proxies[fullname].splice(index, 1)
+    if(this.proxiesOf(fullname).length === 0) delete this.data.proxies[fullname]
+  }
+
+  updateProxy({ package: proxyPackageName, contract: proxyContractName, address: proxyAddress }, fn) {
+    const fullname = toContractFullName(proxyPackageName, proxyContractName)
+    const index = this.indexOfProxy(fullname, proxyAddress)
+    if (index === -1) throw Error(`Proxy ${fullname} at ${proxyAddress} not found in network file`)
     this.data.proxies[fullname][index] = fn(this.data.proxies[fullname][index]);
+  }
+
+  indexOfProxy(fullname, address) {
+    return _.findIndex(this.data.proxies[fullname], { address })
+  }
+
+  proxiesOf(fullname) {
+    return this.data.proxies[fullname] || []
   }
 
   write() {

--- a/packages/cli/src/models/status/StatusChecker.js
+++ b/packages/cli/src/models/status/StatusChecker.js
@@ -239,8 +239,12 @@ export default class StatusChecker {
         name: event.args.providerName,
         version: event.args.version,
         package: event.args.package
-      }));
+      }))
+      .reduce((dependencies, dependency) => {
+        dependencies[dependency.name] = dependency
+        return dependencies
+      }, {})
 
-      return _.uniqWith(filteredEvents, _.isEqual)
+      return Object.values(filteredEvents)
   }
 }

--- a/packages/cli/src/models/status/StatusChecker.js
+++ b/packages/cli/src/models/status/StatusChecker.js
@@ -136,18 +136,18 @@ export default class StatusChecker {
       this._checkProxyAlias(matchingProxy, alias, address, implementation)
       this._checkProxyImplementation(matchingProxy, alias, address, implementation)
     } else {
-      this.visitor.onMissingRemoteProxy('none', 'one', { alias, address, implementation })
+      this.visitor.onMissingRemoteProxy('none', 'one', { packageName: this.packageName, alias, address, implementation })
     }
   }
 
   _checkProxyAlias(proxy, alias, address, implementation) {
-    const expected = proxy.contract
-    if (alias !== expected) this.visitor.onMismatchingProxyAlias(expected, alias, { alias, address, implementation })
+    const { contract: expected } = proxy
+    if (alias !== expected) this.visitor.onMismatchingProxyAlias(expected, alias, proxy)
   }
 
   _checkProxyImplementation(proxy, alias, address, implementation) {
-    const expected = proxy.implementation
-    if (implementation !== expected) this.visitor.onMismatchingProxyImplementation(expected, implementation, { alias, address, implementation })
+    const { implementation: expected, package: packageName } = proxy
+    if (implementation !== expected) this.visitor.onMismatchingProxyImplementation(expected, implementation, proxy)
   }
 
   _checkUnregisteredLocalProxies(proxiesInfo) {
@@ -155,8 +155,8 @@ export default class StatusChecker {
     this.networkFile.getProxies()
       .filter(proxy => !foundAddresses.includes(proxy.address))
       .forEach(proxy => {
-        const { alias, address, implementation } = proxy
-        this.visitor.onUnregisteredLocalProxy('one', 'none', { alias, address, implementation })
+        const { contract: alias, package: packageName, address, implementation } = proxy
+        this.visitor.onUnregisteredLocalProxy('one', 'none', { packageName, alias, address, implementation })
       })
   }
 

--- a/packages/cli/src/models/status/StatusChecker.js
+++ b/packages/cli/src/models/status/StatusChecker.js
@@ -207,10 +207,9 @@ export default class StatusChecker {
 
   async _fetchOnChainProxies() {
     const implementationsInfo = await this._fetchOnChainImplementations()
-    const app = this._project.getApp()
-    const factory = app.factory
     const filter = new EventsFilter()
-    const proxyEvents = await filter.call(factory.factoryContract, 'ProxyCreated')
+    const app = this._project.getApp()
+    const proxyEvents = await filter.call(app.appContract, 'ProxyCreated')
     const proxiesInfo = []
     await Promise.all(proxyEvents.map(async event => {
       const address = event.args.proxy
@@ -231,7 +230,7 @@ export default class StatusChecker {
   async _fetchOnChainPackages() {
     const filter = new EventsFilter()
     const app = this._project.getApp()
-    const allEvents = await filter.call(app.contract, 'PackageChanged')
+    const allEvents = await filter.call(app.appContract, 'PackageChanged')
     const filteredEvents = allEvents
       .filter(event => event.args.package !== ZERO_ADDRESS)
       .filter(event => event.args.providerName !== this.packageName)

--- a/packages/cli/src/models/status/StatusComparator.js
+++ b/packages/cli/src/models/status/StatusComparator.js
@@ -25,10 +25,6 @@ export default class StatusComparator {
     this._addReport(expected, observed, 'Provider address does not match')
   }
 
-  onMismatchingStdlib(expected, observed) {
-    this._addReport(expected, observed, 'Stdlib address does not match')
-  }
-
   onUnregisteredLocalContract(expected, observed, { alias, address }) {
     this._addReport(expected, observed, `A contract ${alias} at ${address} is not registered`)
   }
@@ -53,11 +49,11 @@ export default class StatusComparator {
     this._addReport(expected, observed, `Missing registered proxy of ${alias} at ${address} pointing to ${implementation}`)
   }
 
-  onMismatchingProxyAlias(expected, observed, { alias, address, implementation }) {
+  onMismatchingProxyAlias(expected, observed, { address, implementation }) {
     this._addReport(expected, observed, `Alias of proxy at ${address} pointing to ${implementation} does not match`)
 
   }
-  onMismatchingProxyImplementation(expected, observed, { alias, address, implementation }) {
+  onMismatchingProxyImplementation(expected, observed, { alias, address }) {
     this._addReport(expected, observed, `Pointed implementation of ${alias} proxy at ${address} does not match`)
   }
 
@@ -67,6 +63,22 @@ export default class StatusComparator {
 
   onMultipleProxyImplementations(expected, observed, { implementation }) {
     this._addReport(expected, observed, `The same implementation address ${implementation} was registered under many aliases`)
+  }
+
+  onMissingDependency(expected, observed, { name, address }) {
+    this._addReport(expected, observed, `Missing registered dependency ${name} at ${address}`)
+  }
+
+  onMismatchingDependencyAddress(expected, observed, { name, address }) {
+    this._addReport(expected, observed, `Package address of ${name} does not match`)
+  }
+
+  onMismatchingDependencyVersion(expected, observed, { name, version }) {
+    this._addReport(expected, observed, `Package version of ${name} does not match`)
+  }
+
+  onUnregisteredDependency(expected, observed, { name, package: packageAddress }) {
+    this._addReport(expected, observed, `Dependency with name ${name} at address ${packageAddress} is not registered`)
   }
 
   _addReport(expected, observed, description) {

--- a/packages/cli/src/models/status/StatusFetcher.js
+++ b/packages/cli/src/models/status/StatusFetcher.js
@@ -29,7 +29,7 @@ export default class StatusFetcher {
 
   onUnregisteredLocalContract(expected, observed, { alias, address }) {
     log.info(`Removing unregistered local contract ${alias} ${address}`)
-    this.networkFile.removeContract(alias)
+    this.networkFile.unsetContract(alias)
   }
 
   onMissingRemoteContract(expected, observed, { alias, address }) {

--- a/packages/cli/src/models/status/StatusFetcher.js
+++ b/packages/cli/src/models/status/StatusFetcher.js
@@ -77,17 +77,15 @@ export default class StatusFetcher {
     this.networkFile.addProxy(packageName, alias, { address, version: 'unknown', implementation })
   }
 
-  onMismatchingProxyAlias(expected, observed, { package: packageName, contract: alias, address, version, implementation }) {
-    log.info(`Changing alias of proxy at ${address} pointing to ${implementation} from ${expected} to ${observed}`)
+  onMismatchingProxyAlias(expected, observed, { packageName, address, version, implementation }) {
+    log.info(`Changing alias of package ${packageName} proxy at ${address} pointing to ${implementation} from ${expected} to ${observed}`)
     this.networkFile.removeProxy(packageName, expected, address)
     this.networkFile.addProxy(packageName, observed, { address, version, implementation })
   }
 
-  onMismatchingProxyImplementation(expected, observed, proxy) {
-    const { packageName, version, alias, address, implementation } = proxy
-    const proxyInfo = { address, version, implementation }
+  onMismatchingProxyImplementation(expected, observed, { packageName, address, version, implementation, alias }) {
     log.info(`Changing implementation of proxy ${alias} at ${address} from ${expected} to ${observed}`)
-    this.networkFile.updateProxy({ package: packageName, contract: alias, address }, (proxy) => ({ ...proxyInfo, implementation: observed }))
+    this.networkFile.updateProxy({ package: packageName, contract: alias, address }, (proxy) => ({ ...proxy, implementation: observed }))
   }
 
   onUnregisteredProxyImplementation(expected, observed, { address, implementation }) {

--- a/packages/cli/test/models/StatusFetcher.test.js
+++ b/packages/cli/test/models/StatusFetcher.test.js
@@ -1,22 +1,28 @@
 'use strict'
 require('../setup')
 
-import { Contracts, App } from 'zos-lib'
+import { Contracts } from 'zos-lib'
 
 import push from '../../src/scripts/push'
 import linkStdlib from '../../src/scripts/link'
 import StatusChecker from '../../src/models/status/StatusChecker'
 import StatusFetcher from '../../src/models/status/StatusFetcher'
 import ZosPackageFile from '../../src/models/files/ZosPackageFile'
-import {bodyCode, bytecodeDigest, constructorCode} from '../../src/utils/contracts'
-import PackageAtVersion from '../../src/models/lib/PackageAtVersion';
+import { bodyCode, bytecodeDigest, constructorCode } from '../../src/utils/contracts'
 
 const ImplV1 = Contracts.getFromLocal('ImplV1')
 const AnotherImplV1 = Contracts.getFromLocal('AnotherImplV1')
 
-contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
+contract('StatusFetcher', function([_, owner, anotherAddress]) {
   const network = 'test'
   const txParams = { from: owner }
+
+  function init(fileName) {
+    this.packageFile = new ZosPackageFile(fileName)
+    this.networkFile = this.packageFile.networkFile(network)
+    this.fetcher = new StatusFetcher(this.networkFile)
+    this.checker = new StatusChecker(this.fetcher, this.networkFile, txParams)
+  }
 
   describe('app', function () {
     beforeEach('initializing network file and status checker', async function () {
@@ -25,7 +31,8 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
   
     beforeEach('deploying an app', async function () {
       await push({ network, txParams, networkFile: this.networkFile })
-      this.app = await App.fetch(this.networkFile.appAddress, txParams)
+      this.project = await this.checker.setProject()
+      this.directory = await this.project.getCurrentDirectory()
     })
 
     testVersion();
@@ -33,7 +40,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
     testPackage();
     testProvider();
     testProxies();
-    testStdlib();
+    //testStdlib();
   });
 
   describe('lib', function () {
@@ -43,19 +50,13 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
   
     beforeEach('deploying a lib', async function () {
       await push({ network, txParams, networkFile: this.networkFile })
-      this.app = await PackageAtVersion.fetch(this.networkFile.packageAddress, "1.1.0", txParams)
+      this.project = await this.checker.setProject()
+      this.directory = await this.project.getCurrentDirectory()
     })
-
+  
     testImplementations();
     testProvider();
   });
-
-  function init(fileName) {
-    this.packageFile = new ZosPackageFile(fileName)
-    this.networkFile = this.packageFile.networkFile(network)
-    this.fetcher = new StatusFetcher(this.networkFile)
-    this.checker = new StatusChecker(this.fetcher, this.networkFile, txParams)
-  }
 
   function testVersion () {
     describe('version', function () {
@@ -63,7 +64,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
         const newVersion = '2.0.0'
 
         beforeEach(async function () {
-          await this.app.newVersion(newVersion)
+          await this.project.newVersion(newVersion)
         })
 
         it('updates the version', async function () {
@@ -95,7 +96,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
         it('updates the package address', async function () {
           await this.checker.checkPackage()
 
-          this.networkFile.packageAddress.should.have.be.equal(this.app.package.address)
+          this.networkFile.packageAddress.should.have.be.equal(this.project.package.address)
         })
       })
 
@@ -115,14 +116,15 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
     describe('provider', function () {
       describe('when the network file shows a different provider address than the one set in the App contract', function () {
         beforeEach(async function () {
-          await this.app.newVersion('2.0.0')
+          await this.project.newVersion('2.0.0')
           this.networkFile.version = '2.0.0'
+          this.directory = await this.project.getCurrentDirectory()
         })
 
         it('updates the provider address', async function () {
           await this.checker.checkProvider()
 
-          this.networkFile.providerAddress.should.have.be.equal(this.app.currentDirectory().address)
+          this.networkFile.providerAddress.should.have.be.equal(this.directory.address)
         })
       })
 
@@ -143,7 +145,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
       describe('when the network file does not specify any stdlib', function () {
         describe('when the App contract has a stdlib set', function () {
           beforeEach(async function () {
-            await this.app.setStdlib(anotherAddress)
+            await this.project.setStdlib(anotherAddress)
           })
 
           it('updates the address of the stdlib', async function () {
@@ -172,7 +174,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the App contract has the same stdlib set', function () {
           beforeEach('set stdlib in App contract', async function () {
-            await this.app.setStdlib(stdlibAddress)
+            await this.project.setStdlib(stdlibAddress)
           })
 
           it('does not update the address of the stdlib', async function () {
@@ -186,7 +188,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the App contract has another stdlib set', function () {
           beforeEach('set stdlib in App contract', async function () {
-            await this.app.setStdlib(anotherAddress)
+            await this.project.setStdlib(anotherAddress)
           })
 
           it('updates the address of the stdlib', async function () {
@@ -198,7 +200,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the App contract has no stdlib set', function () {
           beforeEach('unset App stdlib', async function () {
-            await this.app.setStdlib(0x0)
+            await this.project.setStdlib(0x0)
           })
 
           it('deletes the stdlib', async function () {
@@ -225,7 +227,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
         describe('when the directory of the current version has one contract', function () {
           describe('when the contract alias and contract name are the same', function () {
             beforeEach('registering new implementation in AppDirectory', async function () {
-              this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
+              this.impl = await this.project.setImplementation(ImplV1, 'ImplV1')
             })
 
             it('adds that contract', async function () {
@@ -241,7 +243,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
           describe('when the contract alias and contract name are different', function () {
             beforeEach('registering new implementation in AppDirectory', async function () {
-              this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+              this.impl = await this.project.setImplementation(ImplV1, 'Impl')
             })
 
             it('adds that contract', async function () {
@@ -258,8 +260,8 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the directory of the current version has many contracts', function () {
           beforeEach('registering two new implementations in AppDirectory', async function () {
-            this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
-            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
+            this.impl = await this.project.setImplementation(ImplV1, 'ImplV1')
+            this.anotherImpl = await this.project.setImplementation(AnotherImplV1, 'AnotherImplV1')
           })
 
           it('adds those contracts', async function () {
@@ -279,9 +281,9 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
           beforeEach('registering two new implementations in AppDirectory', async function () {
-            await this.app.setImplementation(ImplV1, 'Impl')
-            await this.app.unsetImplementation('Impl', txParams)
-            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
+            await this.project.setImplementation(ImplV1, 'Impl')
+            await this.project.unsetImplementation('Impl', txParams)
+            this.anotherImpl = await this.project.setImplementation(AnotherImplV1, 'AnotherImplV1')
           })
 
           it('reports one diff per contract', async function () {
@@ -316,7 +318,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
         describe('when the directory of the current version has one of those contract', function () {
           describe('when the directory has the same address and same bytecode for that contract', function () {
             beforeEach('registering new implementation in AppDirectory', async function () {
-              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+              await this.directory.setImplementation('Impl', this.impl.address, txParams)
             })
 
             it('removes the unregistered contract without changing the registered one', async function () {
@@ -334,7 +336,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
           describe('when the directory has another address for that contract', function () {
             beforeEach('registering new implementation in AppDirectory', async function () {
-              await this.app.currentDirectory().setImplementation('Impl', this.anotherImpl.address, txParams)
+              await this.directory.setImplementation('Impl', this.anotherImpl.address, txParams)
             })
 
             it('removes the unregistered contract and updates the address of the registered one', async function () {
@@ -353,7 +355,7 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
           describe('when the bytecode for that contract is different', function () {
             beforeEach('registering new implementation in AppDirectory', async function () {
               this.networkFile.setContractBodyBytecodeHash('Impl', '0x0')
-              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+              await this.directory.setImplementation('Impl', this.impl.address, txParams)
             })
 
             it('removes the unregistered contract and updates the bytecode of the registered one', async function () {
@@ -372,8 +374,8 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the directory of the current version has both contracts', function () {
           beforeEach('registering new implementation in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+            await this.directory.setImplementation('Impl', this.impl.address, txParams)
+            await this.directory.setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
           })
 
           it('does not update the contracts list', async function () {
@@ -394,9 +396,9 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
 
         describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
           beforeEach('registering two new implementations in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-            await this.app.unsetImplementation('Impl', txParams)
-            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+            await this.directory.setImplementation('Impl', this.impl.address, txParams)
+            await this.project.unsetImplementation('Impl', txParams)
+            await this.directory.setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
           })
 
           it('adds the missing contract', async function () {
@@ -423,10 +425,10 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
         this.networkFile.addContract('Impl', this.impl)
         this.networkFile.addContract('AnotherImpl', this.anotherImpl)
 
-        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-        await this.app.currentDirectory().unsetImplementation('Impl', txParams)
-        await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+        await this.directory.setImplementation('Impl', this.impl.address)
+        await this.directory.unsetImplementation('Impl')
+        await this.directory.setImplementation('AnotherImpl', this.anotherImpl.address)
+        await this.directory.setImplementation('Impl', this.impl.address)
       })
 
       describe('when the network file does not have any proxies', function () {
@@ -434,132 +436,135 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
           it('does not modoify the proxies list', async function () {
             await this.checker.checkProxies()
 
-            this.networkFile.proxyAliases.should.be.empty
+            this.networkFile.getProxies().should.be.empty
           })
         })
 
         describe('when the app has one proxy registered', function () {
           beforeEach('registering new implementation in AppDirectory', async function () {
-            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+            this.proxy = await this.project.createProxy(ImplV1, { contractName: 'Impl', initMethod: 'initialize', initArgs: [42] })
           })
 
           it('adds that proxy', async function () {
             await this.checker.checkProxies()
 
-            this.networkFile.proxyAliases.should.have.lengthOf(1)
-            this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-            this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+            this.networkFile.getProxies().should.have.lengthOf(1)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
           })
         })
 
         describe('when the app has many proxies registered', function () {
           beforeEach('registering new implementation in AppDirectory', async function () {
-            this.implProxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-            this.anotherImplProxy = await this.app.createProxy(AnotherImplV1, 'AnotherImpl', 'initialize', [1])
+            this.implProxy = await this.project.createProxy(ImplV1, { contractName: 'Impl', initMethod: 'initialize', initArgs: [42] })
+            this.anotherImplProxy = await this.project.createProxy(AnotherImplV1, { contractName: 'AnotherImpl', initMethod: 'initialize', initArgs: [1] })
           })
 
           it('adds those proxies', async function () {
             await this.checker.checkProxies()
 
-            this.networkFile.proxyAliases.should.have.lengthOf(2)
-            this.networkFile.proxy('Impl', 0).address.should.be.equal(this.implProxy.address)
-            this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-            this.networkFile.proxy('AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
-            this.networkFile.proxy('AnotherImpl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxy('AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
+            this.networkFile.getProxies().should.have.lengthOf(2)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.implProxy.address)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).version.should.be.equal('unknown')
+            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
           })
         })
       })
 
       describe('when the network file has two proxies', function () {
         beforeEach('adding a proxy', async function () {
-          this.networkFile.setProxies('Impl', [
-            { implementation: this.impl.address, address: '0x1', version: '1.0' },
-            { implementation: this.impl.address, address: '0x2', version: '1.0' }
-          ])
+          const implementations = [
+            { implementation: this.impl.address, address: '0x1', version: '1.0.0' },
+            { implementation: this.impl.address, address: '0x2', version: '1.0.0' }
+          ];
+          this.networkFile.setProxies(this.packageFile.name,'Impl', implementations)
         })
 
         describe('when the app does not have any proxy registered', function () {
           it('removes those proxies', async function () {
             await this.checker.checkProxies()
 
-            this.networkFile.proxyAliases.should.be.empty
+            this.networkFile.getProxies().should.be.empty
           })
         })
 
         describe('when the app has one proxy registered', function () {
           beforeEach('creating a proxy', async function () {
-            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+            this.proxy = await this.project.createProxy(ImplV1, { contractName: 'Impl', initMethod: 'initialize', initArgs: [42] })
           })
 
           describe('when it matches one proxy address', function () {
             describe('when it matches the alias and the implementation address', function () {
               beforeEach('changing network file', async function () {
-                this.networkFile.setProxies('Impl', [
-                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                  { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
-                ])
+                const implementations = [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0.0' },
+                  { implementation: this.impl.address, address: this.proxy.address, version: '1.0.0' },
+                ]
+                this.networkFile.setProxies(this.packageFile.name, 'Impl', implementations)
               })
 
               it('removes the unregistered proxy', async function () {
                 await this.checker.checkProxies()
 
-                this.networkFile.proxyAliases.should.have.lengthOf(1)
-                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+                this.networkFile.getProxies().should.have.lengthOf(1)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
               })
             })
 
             describe('when it matches the alias but not the implementation address', function () {
               beforeEach('changing network file', async function () {
-                this.networkFile.setProxies('Impl', [
-                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                  { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
-                ])
+                const implementations = [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0.0' },
+                  { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0.0' },
+                ]
+                this.networkFile.setProxies(this.packageFile.name, 'Impl', implementations)
               })
 
               it('removes the unregistered proxy and updates the implementation of the registered one', async function () {
                 await this.checker.checkProxies()
 
-                this.networkFile.proxyAliases.should.have.lengthOf(1)
-                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+                this.networkFile.getProxies().should.have.lengthOf(1)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
               })
             })
 
             describe('when it matches the implementation address but not the alias', function () {
               beforeEach('changing network file', async function () {
-                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
+                this.networkFile.setProxies(this.packageFile.name, 'Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0.0' }])
+                this.networkFile.setProxies(this.packageFile.name, 'AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0.0' }])
               })
 
               it('removes the unregistered proxy and updates the alias of the registered one', async function () {
                 await this.checker.checkProxies()
 
-                this.networkFile.proxyAliases.should.have.lengthOf(1)
-                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+                this.networkFile.getProxies().should.have.lengthOf(1)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
               })
             })
 
             describe('when it does not match the alias and the implementation address', function () {
               beforeEach('changing network file', async function () {
-                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
+                this.networkFile.setProxies(this.packageFile.name, 'Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0.0' }])
+                this.networkFile.setProxies(this.packageFile.name, 'AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0.0' }])
               })
 
               it('removes the unregistered proxy and updates the alias and implementation of the registered one', async function () {
                 await this.checker.checkProxies()
 
-                this.networkFile.proxyAliases.should.have.lengthOf(1)
-                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+                this.networkFile.getProxies().should.have.lengthOf(1)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
+                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
               })
             })
           })
@@ -569,10 +574,10 @@ contract.skip('StatusFetcher', function([_, owner, anotherAddress]) {
             it('removes the unregistered proxies and adds the registered onen', async function () {
               await this.checker.checkProxies()
 
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              this.networkFile.getProxies().should.have.lengthOf(1)
+              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
+              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
             })
           })
         })

--- a/packages/cli/test/models/StatusFetcher.test.js
+++ b/packages/cli/test/models/StatusFetcher.test.js
@@ -471,11 +471,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
           it('adds that proxy', async function () {
             await this.checker.checkProxies()
+            const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
             this.networkFile.getProxies().should.have.lengthOf(1)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+            proxyInfo.address.should.be.equal(this.proxy.address)
+            proxyInfo.version.should.be.equal('unknown')
+            proxyInfo.implementation.should.be.equal(this.impl.address)
           })
         })
 
@@ -487,14 +488,16 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
           it('adds those proxies', async function () {
             await this.checker.checkProxies()
+            const implProxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
+            const anotherImplProxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'AnotherImpl' })[0]
 
             this.networkFile.getProxies().should.have.lengthOf(2)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.implProxy.address)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxyFromIndex(this.packageFile.name, 'AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
+            implProxyInfo.address.should.be.equal(this.implProxy.address)
+            implProxyInfo.version.should.be.equal('unknown')
+            implProxyInfo.implementation.should.be.equal(this.impl.address)
+            anotherImplProxyInfo.address.should.be.equal(this.anotherImplProxy.address)
+            anotherImplProxyInfo.version.should.be.equal('unknown')
+            anotherImplProxyInfo.implementation.should.be.equal(this.anotherImpl.address)
           })
         })
       })
@@ -533,11 +536,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
               it('removes the unregistered proxy', async function () {
                 await this.checker.checkProxies()
+                const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
                 this.networkFile.getProxies().should.have.lengthOf(1)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+                proxyInfo.address.should.be.equal(this.proxy.address)
+                proxyInfo.version.should.be.equal('1.0.0')
+                proxyInfo.implementation.should.be.equal(this.impl.address)
               })
             })
 
@@ -552,11 +556,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
               it('removes the unregistered proxy and updates the implementation of the registered one', async function () {
                 await this.checker.checkProxies()
+                const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
                 this.networkFile.getProxies().should.have.lengthOf(1)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+                proxyInfo.address.should.be.equal(this.proxy.address)
+                proxyInfo.version.should.be.equal('1.0.0')
+                proxyInfo.implementation.should.be.equal(this.impl.address)
               })
             })
 
@@ -568,11 +573,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
               it('removes the unregistered proxy and updates the alias of the registered one', async function () {
                 await this.checker.checkProxies()
+                const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
                 this.networkFile.getProxies().should.have.lengthOf(1)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+                proxyInfo.address.should.be.equal(this.proxy.address)
+                proxyInfo.version.should.be.equal('1.0.0')
+                proxyInfo.implementation.should.be.equal(this.impl.address)
               })
             })
 
@@ -584,11 +590,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
               it('removes the unregistered proxy and updates the alias and implementation of the registered one', async function () {
                 await this.checker.checkProxies()
+                const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
                 this.networkFile.getProxies().should.have.lengthOf(1)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('1.0.0')
-                this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+                proxyInfo.address.should.be.equal(this.proxy.address)
+                proxyInfo.version.should.be.equal('1.0.0')
+                proxyInfo.implementation.should.be.equal(this.impl.address)
               })
             })
           })
@@ -597,11 +604,12 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
 
             it('removes the unregistered proxies and adds the registered onen', async function () {
               await this.checker.checkProxies()
+              const proxyInfo = this.networkFile.getProxies({ package: this.packageFile.name, contract: 'Impl' })[0]
 
               this.networkFile.getProxies().should.have.lengthOf(1)
-              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).version.should.be.equal('unknown')
-              this.networkFile.proxyFromIndex(this.packageFile.name, 'Impl', 0).implementation.should.be.equal(this.impl.address)
+              proxyInfo.address.should.be.equal(this.proxy.address)
+              proxyInfo.version.should.be.equal('unknown')
+              proxyInfo.implementation.should.be.equal(this.impl.address)
             })
           })
         })

--- a/packages/lib/src/app/App.js
+++ b/packages/lib/src/app/App.js
@@ -14,23 +14,25 @@ const log = new Logger('App')
 export default class App {
 
   static async fetch(address, txParams = {}) {
-    const appContract = await this.getContractClass().at(address)    
-    return new this(appContract, txParams)
+    const appContract = await this.getContractClass().at(address)
+    const factory = await UpgradeabilityProxyFactory.fetch(await appContract.factory())
+    return new this(appContract, factory, txParams)
   }
 
   static async deploy(txParams = {}) {
     log.info('Deploying new App...')
     const appContract = await deployContract(this.getContractClass(), [], txParams)
     log.info(`Deployed App at ${appContract.address}`)
-    return new this(appContract, txParams)
+    return new this(appContract, factory, txParams)
   }
 
   static getContractClass() {
     return Contracts.getFromLib('App')
   }
 
-  constructor(appContract, txParams = {}) {
+  constructor(appContract, factory, txParams = {}) {
     this.appContract = appContract
+    this.factory = factory
     this.txParams = txParams
   }
 

--- a/packages/lib/src/app/App.js
+++ b/packages/lib/src/app/App.js
@@ -15,24 +15,22 @@ export default class App {
 
   static async fetch(address, txParams = {}) {
     const appContract = await this.getContractClass().at(address)
-    const factory = await UpgradeabilityProxyFactory.fetch(await appContract.factory())
-    return new this(appContract, factory, txParams)
+    return new this(appContract, txParams)
   }
 
   static async deploy(txParams = {}) {
     log.info('Deploying new App...')
     const appContract = await deployContract(this.getContractClass(), [], txParams)
     log.info(`Deployed App at ${appContract.address}`)
-    return new this(appContract, factory, txParams)
+    return new this(appContract, txParams)
   }
 
   static getContractClass() {
     return Contracts.getFromLib('App')
   }
 
-  constructor(appContract, factory, txParams = {}) {
+  constructor(appContract, txParams = {}) {
     this.appContract = appContract
-    this.factory = factory
     this.txParams = txParams
   }
 


### PR DESCRIPTION
I'm creating this pull request because Github won't let me reopen https://github.com/zeppelinos/zos/pull/99  :cat: 

---

- Adapt `StatusChecker`, `StatusComparator` and `StatusFetcher` classes to work with the new contracts architecture and lib models implemented by @spalladino to support multiple dependencies.
- Implement multiple dependencies checker, fetcher and comparator functions.