### PR TITLE
Index names in Vouching events using name hash

### DIFF
--- a/packages/vouching/contracts/Vouching.sol
+++ b/packages/vouching/contracts/Vouching.sol
@@ -8,10 +8,16 @@ import "openzeppelin-zos/contracts/Initializable.sol";
 
 contract Vouching is Initializable {
   event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
-  event DependencyCreated(string name, address indexed owner, address indexed dependencyAddress, uint256 initialStake);
-  event Vouched(string name, uint256 amount);
-  event Unvouched(string name, uint256 amount);
-  event DependencyRemoved(string name);
+  event DependencyCreated(
+    bytes32 indexed nameHash,
+    string name,
+    address indexed owner,
+    address indexed dependencyAddress,
+    uint256 initialStake
+  );
+  event Vouched(bytes32 indexed nameHash, uint256 amount);
+  event Unvouched(bytes32 indexed nameHash, uint256 amount);
+  event DependencyRemoved(bytes32 indexed nameHash);
 
   using SafeMath for uint256;
   using SafeERC20 for ERC20;
@@ -63,7 +69,7 @@ contract Vouching is Initializable {
 
     _token.safeTransferFrom(owner, this, initialStake);
 
-    emit DependencyCreated(name, owner, dependencyAddress, initialStake);
+    emit DependencyCreated(keccak256(name), name, owner, dependencyAddress, initialStake);
   }
 
   function transferOwnership(string name, address newOwner) external onlyDependencyOwner(name) {
@@ -75,7 +81,7 @@ contract Vouching is Initializable {
   function vouch(string name, uint256 amount) external onlyDependencyOwner(name) {
     _registry[name].stake = _registry[name].stake.add(amount);
     _token.safeTransferFrom(msg.sender, this, amount);
-    emit Vouched(name, amount);
+    emit Vouched(keccak256(name), amount);
   }
 
   function unvouch(string name, uint256 amount) external onlyDependencyOwner(name) {
@@ -85,7 +91,7 @@ contract Vouching is Initializable {
     _registry[name].stake = remainingStake;
     _token.safeTransfer(msg.sender, amount);
 
-    emit Unvouched(name, amount);
+    emit Unvouched(keccak256(name), amount);
   }
 
   function remove(string name) external onlyDependencyOwner(name) {
@@ -93,7 +99,7 @@ contract Vouching is Initializable {
     uint256 reimbursedAmount = _registry[name].stake.sub(_minimumStake);
     delete _registry[name];
     _token.safeTransfer(msg.sender, reimbursedAmount);
-    emit DependencyRemoved(name);
+    emit DependencyRemoved(keccak256(name));
   }
 
 }

--- a/packages/vouching/test/Vouching.test.js
+++ b/packages/vouching/test/Vouching.test.js
@@ -105,6 +105,7 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
           dependencyName, developer, dependencyAddress, stakeAmount, { from: developer }
         );
         const dependencyCreatedEvent = expectEvent.inLogs(result.logs, 'DependencyCreated', {
+          nameHash: web3.sha3(dependencyName),
           name: dependencyName,
           owner: developer,
           dependencyAddress: dependencyAddress
@@ -195,7 +196,7 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
         it('emits Vouched event', async function () {
           const result = await this.vouching.vouch(dependencyName, stakeAmount, { from: developer });
           const vouchedEvent = expectEvent.inLogs(result.logs, 'Vouched', {
-            name: dependencyName
+            nameHash: web3.sha3(dependencyName)
           });
           vouchedEvent.args.amount.should.be.bignumber.equal(stakeAmount);
         });
@@ -249,7 +250,7 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
         it('emits Unvouched event', async function () {
           const result = await this.vouching.unvouch(dependencyName, safeUnstakeAmount, { from: developer });
           const unvouchedEvent = expectEvent.inLogs(result.logs, 'Unvouched', {
-            name: dependencyName
+            nameHash: web3.sha3(dependencyName)
           });
           unvouchedEvent.args.amount.should.be.bignumber.equal(safeUnstakeAmount);
         });
@@ -291,7 +292,9 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
 
         it('emits a DependencyRemoved event', async function () {
           const result = await this.vouching.remove(dependencyName, { from: developer });
-          expectEvent.inLogs(result.logs, 'DependencyRemoved', { name: dependencyName });
+          expectEvent.inLogs(result.logs, 'DependencyRemoved', {
+            nameHash: web3.sha3(dependencyName)
+          });
         });
       });
     });

--- a/packages/vouching/test/Vouching.test.js
+++ b/packages/vouching/test/Vouching.test.js
@@ -12,7 +12,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
-contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transferee, 
+contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transferee,
         dependencyAddress, anotherDependencyAddress, jurisdictionOwner, validatorOwner, organization]) {
   const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
   const lotsaZEP = new BigNumber('10e18');
@@ -35,17 +35,17 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
       this.jurisdiction = await BasicJurisdiction.new({ from: jurisdictionOwner });
       const initializeJurisdictionData = encodeCall('initialize', [], []);
       await this.jurisdiction.sendTransaction({ data: initializeJurisdictionData, from: jurisdictionOwner });
-      
+
       // Initialize ZepToken
       this.token = await ZepToken.new({ from: tokenOwner });
       const initializeZepData = encodeCall('initialize', ['address', 'uint256'], [this.jurisdiction.address, attributeID]);
       await this.token.sendTransaction({ data: initializeZepData, from: tokenOwner });
-      
+
       // Initialize Validator
       this.validator = await ZEPValidator.new({ from: validatorOwner });
       const initializeValidatorData = encodeCall('initialize', ['address', 'uint256'], [this.jurisdiction.address, attributeID]);
       await this.validator.sendTransaction({ data: initializeValidatorData, from: validatorOwner });
-    
+
       await this.jurisdiction.addValidator(this.validator.address, "ZEP Validator", { from: jurisdictionOwner });
       await this.jurisdiction.addAttributeType(attributeID, false, false, ZERO_ADDRESS, 0, 0, 0, "can transfer", { from: jurisdictionOwner });
       await this.jurisdiction.addValidatorApproval(this.validator.address, attributeID, { from: jurisdictionOwner });
@@ -90,7 +90,7 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
 
       it('transfers the initial stake tokens to the vouching contract', async function () {
         const initialBalance = await this.token.balanceOf(this.vouching.address);
-        
+
         await this.vouching.create(
           dependencyName, developer, dependencyAddress, stakeAmount, { from: developer }
         );
@@ -296,6 +296,34 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
             nameHash: web3.sha3(dependencyName)
           });
         });
+      });
+    });
+
+    describe('event filtering', function () {
+      it('allows filtering by dependency name', async function () {
+        const resultFirst = await this.vouching.create(
+          'dep1', developer, anotherDependencyAddress, stakeAmount, { from: developer }
+        );
+        const resultSecond = await this.vouching.create(
+          'dep2', developer, thirdDependencyAddress, stakeAmount, { from: developer }
+        );
+
+        resultFirst.receipt.logs[1].topics[1].should.be.equal(web3.sha3('dep1'));
+        resultSecond.receipt.logs[1].topics[1].should.be.equal(web3.sha3('dep2'));
+
+        const filter = web3.eth.filter({
+          address: this.vouching.address,
+          topics: [
+            null, web3.sha3('dep1'), null, null
+          ]
+        });
+
+        filter.watch((error, log) => {
+          log.topics[1].should.be.equal(web3.sha3('dep1'))
+        })
+
+        await this.vouching.vouch('dep1', stakeAmount, { from: developer });
+        await this.vouching.vouch('dep2', stakeAmount, { from: developer });
       });
     });
   });

--- a/packages/vouching/test/Vouching.test.js
+++ b/packages/vouching/test/Vouching.test.js
@@ -302,10 +302,10 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
     describe('event filtering', function () {
       it('allows filtering by dependency name', async function () {
         const resultFirst = await this.vouching.create(
-          'dep1', developer, anotherDependencyAddress, stakeAmount, { from: developer }
+          'dep1', developer, dependencyAddress, stakeAmount, { from: developer }
         );
         const resultSecond = await this.vouching.create(
-          'dep2', developer, thirdDependencyAddress, stakeAmount, { from: developer }
+          'dep2', developer, anotherDependencyAddress, stakeAmount, { from: developer }
         );
 
         resultFirst.receipt.logs[1].topics[1].should.be.equal(web3.sha3('dep1'));


### PR DESCRIPTION
This PR includes a possible implementation that tackles #132 . I'm opening it to start discussing the issue over real code.

Here I'm basically indexing by the keccak256 hash of the `name` argument. The actual name (not the hash) is logged in the `DependencyCreated` event. Tests were updated as well.

Not entirely sure of the efficiency of the implementation though, since we'd be hashing the `name` everytime the contract fires an event. I'm eager to hear reviews and comments on this.

~EDIT: note that I'm merging into `vouching`~