### PR TITLE
Run integration tests on latest version

### DIFF
--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
-import { Contracts, Logger, flattenSourceCode } from 'zos-lib';
+import { Contracts, Logger, flattenSourceCode, getStorageLayout, getBuildArtifacts, compareStorageLayouts, getStructsOrEnums } from 'zos-lib';
 import StatusComparator from '../status/StatusComparator'
 import StatusChecker from "../status/StatusChecker";
 import Verifier from '../Verifier'
 import { allPromisesOrError } from '../../utils/async';
-import { getStorageLayout, getBuildArtifacts, compareStorageLayouts, getStructsOrEnums } from 'zos-lib/src';
 import { logUncheckedVars, logStorageLayoutDiffs } from '../../interface/Validations';
 
 const log = new Logger('NetworkController');

--- a/tests/cli-app/files/package.json.v1
+++ b/tests/cli-app/files/package.json.v1
@@ -7,8 +7,8 @@
   "license": "MIT",
   "dependencies": {
     "truffle": "^4.1.14",
-    "zos": "^1.4.2",
-    "zos-lib": "^1.4.1",
+    "zos": "2.0.0-alpha.0",
+    "zos-lib": "2.0.0-alpha.0",
     "openzeppelin-zos": "1.9.0",
     "bignumber.js": "^7.2.0",
     "truffle-hdwallet-provider": "0.0.6"

--- a/tests/cli-app/files/package.json.v2
+++ b/tests/cli-app/files/package.json.v2
@@ -7,8 +7,8 @@
   "license": "MIT",
   "dependencies": {
     "truffle": "^4.1.14",
-    "zos": "^1.4.2",
-    "zos-lib": "^1.4.1",
+    "zos": "2.0.0-alpha.0",
+    "zos-lib": "2.0.0-alpha.0",
     "openzeppelin-zos": "1.9.4",
     "bignumber.js": "^7.2.0",
     "truffle-hdwallet-provider": "0.0.6"

--- a/tests/cli-app/test/integration.test.js
+++ b/tests/cli-app/test/integration.test.js
@@ -58,19 +58,19 @@ describe(`cli-app on ${network}`, function () {
   })
 
   it('pushes to network', function () {
-    run(`npx zos push --network ${network} --from ${this.from} --deploy-stdlib --skip-compile`)
+    run(`npx zos push --network ${network} --from ${this.from} --deploy-libs --skip-compile`)
   })
 
   it('creates an instance', function () {
     run(`npx zos create Foo --network ${network}`)
-    truffleExec(`run.js Foo 0 say --network ${network}`).should.eq('Foo')
+    truffleExec(`run.js cli-app/Foo 0 say --network ${network}`).should.eq('Foo')
   })
 
   it('creates an instance from a dependency', function () {
-    run(`npx zos create MintableERC721Token --init --args "${this.from},MyToken,TKN" --network ${network} --from ${this.from}`)
-    const tokenAddress = getProxyAddress(network, 'MintableERC721Token', 0)
+    run(`npx zos create openzeppelin-zos/MintableERC721Token --init --args "${this.from},MyToken,TKN" --network ${network} --from ${this.from}`)
+    const tokenAddress = getProxyAddress(network, 'openzeppelin-zos/MintableERC721Token', 0)
     run(`npx zos create WithToken --init --args "${tokenAddress}" --network ${network} --from ${this.from}`)
-    truffleExec(`run.js WithToken 0 say --network ${network} --from ${this.from}`).should.eq('TKN')
+    truffleExec(`run.js cli-app/WithToken 0 say --network ${network} --from ${this.from}`).should.eq('TKN')
   })
 
   it('modifies and pushes a contract', function () {
@@ -85,7 +85,7 @@ describe(`cli-app on ${network}`, function () {
 
   it('upgrades an instance', function () {
     run(`npx zos update Foo --network ${network} --from ${this.from}`)
-    truffleExec(`run.js Foo 0 say --network ${network} --from ${this.from}`).should.eq('FooV2')
+    truffleExec(`run.js cli-app/Foo 0 say --network ${network} --from ${this.from}`).should.eq('FooV2')
   })
 
   it('installs new version of a dependency', function () {
@@ -97,9 +97,9 @@ describe(`cli-app on ${network}`, function () {
   it('upgrades a dependency', function () {
     copy('WithTokenV2.sol', 'contracts/WithToken.sol')
     run(`npx truffle compile`)
-    run(`npx zos push --deploy-stdlib --network ${network} --from ${this.from} --skip-compile`)
-    run(`npx zos update MintableERC721Token --network ${network} --from ${this.from}`)
+    run(`npx zos push --deploy-libs --network ${network} --from ${this.from} --skip-compile`)
+    run(`npx zos update openzeppelin-zos/MintableERC721Token --network ${network} --from ${this.from}`)
     run(`npx zos update WithToken --network ${network} --from ${this.from}`)
-    truffleExec(`run.js WithToken 0 isERC165 --network ${network}`).should.eq('true')
+    truffleExec(`run.js cli-app/WithToken 0 isERC165 --network ${network}`).should.eq('true')
   })
 });


### PR DESCRIPTION
Integration tests were being run on version 1.4.2, instead of the latest
code in each commit. This commit changes the dependency to target
2.0.0-alpha.0 instead.

Include fixes for integration tests
- Rename flag deploy-stdlib to deploy-libs
- Fix zos-lib import in CLI
- Use latest version of packages in integration tests
- Use fully qualified name of contracts in tests