### PR TITLE
Check isConstructor for running initializable

### DIFF
--- a/packages/lib/contracts/Initializable.sol
+++ b/packages/lib/contracts/Initializable.sol
@@ -10,8 +10,8 @@ pragma solidity ^0.4.24;
  * invoked. This applies both to deploying an Initializable contract, as well
  * as extending an Initializable contract via inheritance.
  * WARNING: When used with inheritance, manual care must be taken to not invoke
- * a parent initializer twice, because this is not dealt with automatically as
- * with constructors.
+ * a parent initializer twice, or ensure that all initializers are idempotent, 
+ * because this is not dealt with automatically as with constructors.
  */
 contract Initializable {
 
@@ -29,7 +29,7 @@ contract Initializable {
    * @dev Modifier to use in the initializer function of a contract.
    */
   modifier initializer() {
-    require(initializing || !initialized, "Contract instance has already been initialized");
+    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
 
     bool wasInitializing = initializing;
     initializing = true;
@@ -38,5 +38,17 @@ contract Initializable {
     _;
 
     initializing = wasInitializing;
+  }
+
+  /// @dev Returns true if and only if the function is running in the constructor
+  function isConstructor() private view returns (bool) {
+    // extcodesize checks the size of the code stored in an address, and 
+    // address returns the current address. Since the code is still not
+    // deployed when running a constructor, any checks on its code size will
+    // yield zero, making it an effective way to detect if a contract is
+    // under construction or not.
+    uint256 cs;
+    assembly { cs := extcodesize(address) }
+    return cs == 0;
   }
 }


### PR DESCRIPTION
This change is required from oz-zos to handle certain scenarios
with multiple inheritance. Original commit by @frangio is:

https://github.com/OpenZeppelin/openzeppelin-zos/commit/6e0ace1914f120fb24b2c1b648b08e4084011209#diff-0e8e787a34109f83dafec072d3664194