### PR TITLE
Re-throw App or Lib deployment errors

### DIFF
--- a/packages/cli/src/models/network/NetworkLibController.js
+++ b/packages/cli/src/models/network/NetworkLibController.js
@@ -4,8 +4,8 @@ import NetworkBaseController from './NetworkBaseController';
 import { LibProjectDeployer } from './ProjectDeployer';
 
 export default class NetworkLibController extends NetworkBaseController {
-  getDeployer() {
-    return new LibProjectDeployer(this);
+  getDeployer(requestedVersion) {
+    return new LibProjectDeployer(this, requestedVersion);
   }
 
   async createProxy() {
@@ -13,17 +13,14 @@ export default class NetworkLibController extends NetworkBaseController {
   }
 
   _checkVersion() {
-    const requestedVersion = this.packageFile.version
-    const currentVersion = this.networkFile.version
-
-    if (requestedVersion !== currentVersion) {
+    if (this.packageVersion !== this.currentVersion) {
       this.networkFile.frozen = false
     }
     super._checkVersion()
   }
 
   async freeze() {
-    await this.fetchOrDeploy()
+    await this.fetchOrDeploy(this.currentVersion)
     await this.project.freeze()
     this.networkFile.frozen = true
   }

--- a/packages/cli/src/models/network/ProjectDeployer.js
+++ b/packages/cli/src/models/network/ProjectDeployer.js
@@ -56,6 +56,7 @@ export class LibProjectDeployer extends BasePackageProjectDeployer {
       return this.project
     } catch(deployError) {
       this._tryRegisterPartialDeploy(deployError)
+      if (!this.project) throw deployError
     }
   }
 }
@@ -71,6 +72,7 @@ export class AppProjectDeployer extends BasePackageProjectDeployer {
       return this.project
     } catch (deployError) {
       this._tryRegisterPartialDeploy(deployError)
+      if (!this.project) throw deployError
     }
   }
 

--- a/packages/cli/src/models/network/ProjectDeployer.js
+++ b/packages/cli/src/models/network/ProjectDeployer.js
@@ -2,15 +2,12 @@ import { AppProject, LibProject, SimpleProject } from "zos-lib";
 import _ from 'lodash';
 
 class BaseProjectDeployer {
-  constructor(controller) {
+  constructor(controller, requestedVersion) {
     this.controller = controller
     this.packageFile = controller.packageFile
     this.networkFile = controller.networkFile
     this.txParams = controller.txParams
-  }
-
-  get currentVersion() {
-    return this.controller.currentVersion
+    this.requestedVersion = requestedVersion
   }
 }
 
@@ -21,7 +18,7 @@ class BasePackageProjectDeployer extends BaseProjectDeployer {
 
   _tryRegisterPartialDeploy({ thepackage, directory }) {
     if (thepackage) this._registerPackage(thepackage)
-    if (directory) this._registerVersion(this.currentVersion, directory)
+    if (directory) this._registerVersion(this.requestedVersion, directory)
   }
 
   _registerPackage({ address }) {
@@ -37,7 +34,7 @@ class BasePackageProjectDeployer extends BaseProjectDeployer {
 export class SimpleProjectDeployer extends BaseProjectDeployer {
   async fetchOrDeploy() {
     this.project = new SimpleProject(this.packageFile.name, this.txParams)
-    this.networkFile.version = this.currentVersion
+    this.networkFile.version = this.requestedVersion
     _.forEach(this.networkFile.contracts, (contractInfo, contractAlias) => {
       this.project.registerImplementation(contractAlias, contractInfo)
     })
@@ -50,9 +47,9 @@ export class LibProjectDeployer extends BasePackageProjectDeployer {
   async fetchOrDeploy() {
     try {
       const packageAddress = this.packageAddress
-      this.project = await LibProject.fetchOrDeploy(this.currentVersion, this.txParams, { packageAddress })
+      this.project = await LibProject.fetchOrDeploy(this.requestedVersion, this.txParams, { packageAddress })
       this._registerPackage(await this.project.getProjectPackage())
-      this._registerVersion(this.currentVersion, await this.project.getCurrentDirectory())
+      this._registerVersion(this.requestedVersion, await this.project.getCurrentDirectory())
       return this.project
     } catch(deployError) {
       this._tryRegisterPartialDeploy(deployError)
@@ -65,10 +62,10 @@ export class AppProjectDeployer extends BasePackageProjectDeployer {
   async fetchOrDeploy() {
     try {
       const { appAddress, packageAddress } = this
-      this.project = await AppProject.fetchOrDeploy(this.packageFile.name, this.currentVersion, this.txParams, { appAddress, packageAddress })
+      this.project = await AppProject.fetchOrDeploy(this.packageFile.name, this.requestedVersion, this.txParams, { appAddress, packageAddress })
       this._registerApp(this.project.getApp())
       this._registerPackage(await this.project.getProjectPackage())
-      this._registerVersion(this.currentVersion, await this.project.getCurrentDirectory())
+      this._registerVersion(this.requestedVersion, await this.project.getCurrentDirectory())
       return this.project
     } catch (deployError) {
       this._tryRegisterPartialDeploy(deployError)

--- a/packages/cli/src/scripts/status.js
+++ b/packages/cli/src/scripts/status.js
@@ -27,7 +27,7 @@ async function appInfo(controller) {
     return false;
   }
 
-  await controller.fetchOrDeploy();
+  await controller.fetchOrDeploy(controller.currentVersion);
   log.info(`Application is deployed at ${controller.appAddress}`);
   log.info(`- Package ${controller.packageFile.name} is at ${controller.networkFile.packageAddress}`);
   return true;
@@ -39,7 +39,7 @@ async function libInfo(controller) {
     return false;
   }
 
-  await controller.fetchOrDeploy();
+  await controller.fetchOrDeploy(controller.currentVersion);
   log.info(`Library package is deployed at ${controller.packageAddress}`);
   return true;
 }


### PR DESCRIPTION
In case the deployment or fetch of an App/Lib failed, we were registering the partial deploy but the flow continued as if everything has worked fine, adding a check to re-throw if necessary

Fixes https://github.com/zeppelinos/zos/issues/172 as well