### PR TITLE
Add skip-compile option to push options

### DIFF
--- a/packages/cli/src/bin/options.js
+++ b/packages/cli/src/bin/options.js
@@ -16,6 +16,7 @@ program.Command.prototype.withNetworkOptions = function () {
 program.Command.prototype.withPushOptions = function () {
   return this
     .option('--push [network]', 'push all changes to the specified network')
+    .option('--skip-compile', 'skips contract compilation')
     .option('-f, --from <from>', 'specify the transaction sender address for --push')
     .withNetworkTimeoutOption()
 };

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -14,7 +14,6 @@ const register = program => program
   .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
   .description(description)
   .option('--all', 'add all contracts in your build directory')
-  .option('--skip-compile', 'skips contract compilation')
   .withPushOptions()
   .action(action)
 


### PR DESCRIPTION
Related to https://github.com/zeppelinos/zos/issues/67, this PR doesn't fix it though, as there is nothing to fix, but adds the `skip-compile` option to the `withPushOptions` function, to have the posibility to whether run `truffle compile` or not.