### PR TITLE
Added a storage gap at the end of Initializable's storage layout.

### DIFF
--- a/packages/lib/contracts/Initializable.sol
+++ b/packages/lib/contracts/Initializable.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.4.24;
  * invoked. This applies both to deploying an Initializable contract, as well
  * as extending an Initializable contract via inheritance.
  * WARNING: When used with inheritance, manual care must be taken to not invoke
- * a parent initializer twice, or ensure that all initializers are idempotent, 
+ * a parent initializer twice, or ensure that all initializers are idempotent,
  * because this is not dealt with automatically as with constructors.
  */
 contract Initializable {
@@ -42,7 +42,7 @@ contract Initializable {
 
   /// @dev Returns true if and only if the function is running in the constructor
   function isConstructor() private view returns (bool) {
-    // extcodesize checks the size of the code stored in an address, and 
+    // extcodesize checks the size of the code stored in an address, and
     // address returns the current address. Since the code is still not
     // deployed when running a constructor, any checks on its code size will
     // yield zero, making it an effective way to detect if a contract is
@@ -51,4 +51,6 @@ contract Initializable {
     assembly { cs := extcodesize(address) }
     return cs == 0;
   }
+
+  uint256[50] private ______gap;
 }

--- a/packages/lib/contracts/Initializable.sol
+++ b/packages/lib/contracts/Initializable.sol
@@ -52,5 +52,6 @@ contract Initializable {
     return cs == 0;
   }
 
+  // Reserved storage space to allow for layout changes in the future.
   uint256[50] private ______gap;
 }

--- a/packages/lib/test/contracts/upgradeability/AdminUpgradeabilityProxy.test.js
+++ b/packages/lib/test/contracts/upgradeability/AdminUpgradeabilityProxy.test.js
@@ -130,8 +130,12 @@ contract('AdminUpgradeabilityProxy', ([_, admin, anotherAccount]) => {
           })
 
           it('uses the storage of the proxy', async function () {
-            // fetch the x value of Migratable at position 0 of the storage
-            const storedValue = await Proxy.at(this.proxyAddress).getStorageAt(1);
+            // storage layout should look as follows:
+            //  - 0: Initializable storage
+            //  - 1-50: Initailizable reserved storage (50 slots)
+            //  - 51: initializerRan
+            //  - 52: x
+            const storedValue = await Proxy.at(this.proxyAddress).getStorageAt(52);
             storedValue.should.be.bignumber.eq(42);
           })
         })


### PR DESCRIPTION
Created from the discussion in https://github.com/OpenZeppelin/openzeppelin-zos/pull/29

This is the same gap all `openzeppelin-zos` contracts have. My editor also removed some trailing whitespace, but I can undo that if you have strong feelings about it :stuck_out_tongue: 