### PR TITLE
Removed dependency names can no longer be reused.

### DIFF
--- a/packages/vouching/test/contracts/Vouching.test.js
+++ b/packages/vouching/test/contracts/Vouching.test.js
@@ -288,6 +288,15 @@ contract('Vouching', function ([_, tokenOwner, vouchingOwner, developer, transfe
           amount.should.be.bignumber.equal(0);
         });
 
+        it('reverts when a removed dependency\'s name is reutilized', async function () {
+          await this.vouching.remove(dependencyName, { from: developer });
+          await assertRevert(
+            this.vouching.create(
+              dependencyName, developer, anotherDependencyAddress, stakeAmount, { from: developer }
+            )
+          );
+        });
+
         it('emits a DependencyRemoved event', async function () {
           const result = await this.vouching.remove(dependencyName, { from: developer });
           assertEvent.inLogs(result.logs, 'DependencyRemoved', {


### PR DESCRIPTION
Fixes #202.

I considered leaving a sentinel value to signal a name had been taken, but both `owner` and `address` need to be obviously zeroed out, and `stake` can be 0 (if `minimalStake` is 0), so I opted for adding an extra field. This should have a minimal impact on gas costs, since `used` is packed alongside `owner`, emitting a single `SSTORE`/`SLOAD` opcode when accessing (this was verified experimentally).

I'm not 100% sure on the name (maybe `nameTaken`?), but this is an internal detail and not part of the API.