### PR TITLE
Pinned the Solidity doc links to v0.4.24

### DIFF
--- a/packages/lib/contracts/application/App.sol
+++ b/packages/lib/contracts/application/App.sol
@@ -32,7 +32,7 @@ contract App is Ownable {
     Package package;
     uint64[3] version;
   }
-  
+
   /**
    * @dev Maps from dependency name to a tuple of package and version
    */
@@ -62,10 +62,10 @@ contract App is Ownable {
   function getPackage(string packageName) public view returns (Package, uint64[3]) {
     ProviderInfo storage info = providers[packageName];
     return (info.package, info.version);
-  } 
+  }
 
   /**
-   * @dev Sets a package in a specific version as a dependency for this application. 
+   * @dev Sets a package in a specific version as a dependency for this application.
    * Requires the version to be present in the package.
    * @param packageName Name of the package to set or overwrite.
    * @param package Address of the package to register.
@@ -133,7 +133,7 @@ contract App is Ownable {
    * @param contractName Name of the contract.
    * @param data Data to send as msg.data to the corresponding implementation to initialize the proxied contract.
    * It should include the signature and the parameters of the function to be called, as described in
-   * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
    * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
    * @return Address of the new proxy.
    */
@@ -163,7 +163,7 @@ contract App is Ownable {
    * @param contractName Name of the contract.
    * @param data Data to send as msg.data in the low level call.
    * It should include the signature and the parameters of the function to be called, as described in
-   * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
    */
   function upgradeAndCall(AdminUpgradeabilityProxy proxy, string packageName, string contractName, bytes data) payable public onlyOwner {
     address implementation = getImplementation(packageName, contractName);

--- a/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -44,7 +44,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * @param _implementation address of the initial implementation.
    * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
    * It should include the signature and the parameters of the function to be called, as described in
-   * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
    * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
    */
   constructor(address _implementation, bytes _data) UpgradeabilityProxy(_implementation, _data) public payable {
@@ -94,7 +94,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * @param newImplementation Address of the new implementation.
    * @param data Data to send as msg.data in the low level call.
    * It should include the signature and the parameters of the function to be called, as described in
-   * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
    */
   function upgradeToAndCall(address newImplementation, bytes data) payable external ifAdmin {
     _upgradeTo(newImplementation);

--- a/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -28,7 +28,7 @@ contract UpgradeabilityProxy is Proxy {
    * @param _implementation Address of the initial implementation.
    * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
    * It should include the signature and the parameters of the function to be called, as described in
-   * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
    * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
    */
   constructor(address _implementation, bytes _data) public payable {


### PR DESCRIPTION
Despite the ABI not going to change for a while, we should still link to the docsite relevant to our compiler version (`develop` has v0.5.0 information).