### PR TITLE
upgradeToAndCall now delegatecalls instead of externally calling.

### DIFF
--- a/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/packages/lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -98,7 +98,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    */
   function upgradeToAndCall(address newImplementation, bytes data) payable external ifAdmin {
     _upgradeTo(newImplementation);
-    require(address(this).call.value(msg.value)(data));
+    require(newImplementation.delegatecall(data));
   }
 
   /**


### PR DESCRIPTION
Fixes issue [zOS2L-O01] of the Nomic audit (part of #205).

There were no tests for this, but I'm not sure what they'd look like, since we'd be testing the existence of the transparent proxy mechanism: maybe have the call query `admin()` and check that it reverts if the proxy is not its own admin, and doesn't otherwise?