### PR TITLE
Add new check command

### DIFF
--- a/packages/cli/src/commands/check.js
+++ b/packages/cli/src/commands/check.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import Truffle from '../models/truffle/Truffle'
+import check from '../scripts/check';
+
+const name = 'check'
+const signature = `${name} [contract]`
+const description = 'checks your contracts for potential issues'
+
+const register = program => program
+  .command(signature, { noHelp: true })
+  .usage('[contract] [options]')
+  .description(description)
+  .option('--skip-compile', 'skips contract compilation')
+  .action(action)
+
+async function action(contractAlias, options) {
+  if (!options.skipCompile) await Truffle.compile();
+  check({ contractAlias });
+}
+
+export default { name, signature, description, register, action }

--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -1,5 +1,6 @@
 import add from './add'
 import bump from './bump'
+import check from './check'
 import create from './create'
 import freeze from './freeze'
 import init from './init'
@@ -16,6 +17,7 @@ import verify from './verify'
 export default {
   add,
   bump,
+  check,
   create,
   freeze,
   init,

--- a/packages/cli/src/models/files/ZosPackageFile.js
+++ b/packages/cli/src/models/files/ZosPackageFile.js
@@ -142,8 +142,8 @@ export default class ZosPackageFile {
     delete this.data.dependencies[name];
   }
 
-  addContract(alias, name) {
-    this.data.contracts[alias] = name
+  addContract(alias, name = undefined) {
+    this.data.contracts[alias] = name || alias;
   }
 
   unsetContract(alias) {

--- a/packages/cli/src/scripts/add.js
+++ b/packages/cli/src/scripts/add.js
@@ -6,7 +6,7 @@ export default function add({ contractsData, packageFile = undefined }) {
 
   const controller = ControllerFor(packageFile)
   contractsData.forEach(({ name, alias }) => {
-    controller.validateImplementation(name)
+    controller.checkCanAdd(name)
     controller.add(alias || name, name)
   })
   controller.writePackage()

--- a/packages/cli/src/scripts/check.js
+++ b/packages/cli/src/scripts/check.js
@@ -1,0 +1,10 @@
+import ControllerFor from '../models/local/ControllerFor';
+import { Logger } from 'zos-lib';
+
+const log = new Logger('Check');
+
+export default function check({ contractAlias, packageFile = undefined }) {
+  const controller = ControllerFor(packageFile)
+  const success = contractAlias ? controller.validate(contractAlias) : controller.validateAll();
+  if (success) log.info('No issues were found');
+}

--- a/packages/cli/test/commands/check.test.js
+++ b/packages/cli/test/commands/check.test.js
@@ -1,0 +1,18 @@
+'use strict'
+require('../setup')
+
+import {stubCommands, itShouldParse} from './share';
+
+contract('check command', function() {
+
+  stubCommands()
+
+  itShouldParse('should call check script with an alias', 'check', 'zos check Impl --skip-compile', function(check) {
+    check.should.have.been.calledWithExactly({ contractAlias: 'Impl' })
+  })
+  
+  itShouldParse('should call check script for all contracts', 'check', 'zos check --skip-compile', function(check) {
+    check.should.have.been.calledWithExactly({ contractAlias: undefined })
+  })
+  
+})

--- a/packages/cli/test/commands/share.js
+++ b/packages/cli/test/commands/share.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import * as addAll from '../../src/scripts/add-all';
 import * as add from '../../src/scripts/add';
 import * as bump from '../../src/scripts/bump';
+import * as check from '../../src/scripts/check';
 import * as compare from '../../src/scripts/compare';
 import * as create from '../../src/scripts/create';
 import * as freeze from '../../src/scripts/freeze';
@@ -47,6 +48,7 @@ exports.stubCommands = function () {
     this.addAll = sinon.stub(addAll, 'default')
     this.add = sinon.stub(add, 'default')
     this.bump = sinon.stub(bump, 'default')
+    this.check = sinon.stub(check, 'default')
     this.compare = sinon.stub(compare, 'default')
     this.create = sinon.stub(create, 'default')
     this.freeze = sinon.stub(freeze, 'default')
@@ -75,6 +77,7 @@ exports.stubCommands = function () {
     this.addAll.restore()
     this.add.restore()
     this.bump.restore()
+    this.check.restore()
     this.compare.restore()
     this.create.restore()
     this.freeze.restore()

--- a/packages/cli/test/scripts/check.test.js
+++ b/packages/cli/test/scripts/check.test.js
@@ -1,0 +1,81 @@
+'use strict'
+require('../setup')
+
+import _ from 'lodash';
+
+import CaptureLogs from '../helpers/captureLogs';
+import check from '../../src/scripts/check';
+import ZosPackageFile from "../../src/models/files/ZosPackageFile";
+
+const expect = require('chai').expect;
+
+contract('check script', function() {
+  beforeEach('setup', async function() {
+    this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+  });
+
+  beforeEach('capturing log output', function () {
+    this.logs = new CaptureLogs();
+  });
+
+  afterEach(function () {
+    this.logs.restore();
+  });
+
+  describe('on single contract', function () {
+    it('outputs no issues found', function() {
+      const contractAlias = 'ImplV1'
+      this.packageFile.addContract(contractAlias)
+      check({ contractAlias, packageFile: this.packageFile })
+      this.logs.infos[0].should.match(/No issues/)
+    });
+
+    it('outputs a warning on contract found by alias', function() {
+      const contractAlias = 'MyContract'
+      this.packageFile.addContract(contractAlias, 'WithDelegateCall')
+      check({ contractAlias, packageFile: this.packageFile })
+      this.logs.infos.should.be.empty
+      this.logs.warns[0].should.match(/delegatecall/)
+    });
+
+    it('outputs a warning on contract found by name', function() {
+      this.packageFile.addContract('MyContract', 'WithDelegateCall')
+      check({ contractAlias: 'WithDelegateCall', packageFile: this.packageFile })
+      this.logs.infos.should.be.empty
+      this.logs.warns[0].should.match(/delegatecall/)
+    });
+
+    it('outputs a warning on contract not added', function() {
+      check({ contractAlias: 'WithDelegateCall', packageFile: this.packageFile })
+      this.logs.infos.should.be.empty
+      this.logs.warns[0].should.match(/delegatecall/)
+    });
+
+    it('fails if contract not found', function() {
+      expect(() => check({ contractAlias: 'NotExists', packageFile: this.packageFile })).to.throw();
+    });
+  });
+
+  describe('on all contracts', function () {
+    it('outputs no issues found', function () {
+      this.packageFile.addContract('ImplV1')
+      check({ packageFile: this.packageFile })
+      this.logs.infos[0].should.match(/No issues/)
+    });
+
+    it('outputs multiple warnings', function () {
+      this.packageFile.addContract('WithDelegateCall')
+      this.packageFile.addContract('WithSelfDestruct')
+      this.packageFile.addContract('ImplV1')
+      check({ packageFile: this.packageFile })
+      this.logs.infos.should.be.empty;
+      this.logs.warns[0].should.match(/delegatecall/);
+      this.logs.warns[1].should.match(/selfdestruct/);
+    });
+
+    it('outputs no issues found if no contracts added', function () {
+      check({ packageFile: this.packageFile })
+      this.logs.infos[0].should.match(/No issues/)
+    });
+  });
+});

--- a/packages/lib/src/utils/Contracts.js
+++ b/packages/lib/src/utils/Contracts.js
@@ -75,8 +75,10 @@ export default {
   },
 
   artifactsDefaults() {
-    if (!artifacts) throw Error("Could not retrieve truffle defaults")
-    return artifacts.options || {}
+    if (typeof(artifacts) === 'undefined' || !artifacts) {
+      return {};
+    }
+    return artifacts.options || {};
   },
 
   _getFromPath(path) {
@@ -98,5 +100,5 @@ export default {
     contract.defaults({ from: web3.eth.accounts[0], ... defaults })
     contract.synchronization_timeout = syncTimeout
     return contract
-  }
+  },
 }


### PR DESCRIPTION
Adds a new check command that outputs validation errors for all contracts in the project, or allows for a single contract to be specified.

Depends on pull request from branch feature/validate-contract-on-push. Merge after that one.