### PR TITLE
Removed unnecessary import.

### DIFF
--- a/packages/lib/contracts/application/Package.sol
+++ b/packages/lib/contracts/application/Package.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import "./ImplementationProvider.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**


### PR DESCRIPTION
Package.sol imports ImplementatioProvider.sol and doesn't use it (probably did before). Now it simply tracks contract addresses within its Version structs.

App.sol know about ImplementationProviders, while Package.sol does not. 