### PR TITLE
New publish command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prepare": "rm -rf lib && babel src --out-dir lib",
     "test": "./scripts/test.sh",
-    "gen-docs": "babel-node docs/bin/docs.js"
+    "gen-docs": "babel-node docs/bin/docs.js",
+    "watch": "babel src -w -d lib"
   },
   "bin": {
     "zos": "./lib/bin/zos-cli.js"

--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -5,6 +5,7 @@ import create from './create'
 import freeze from './freeze'
 import init from './init'
 import link from './link'
+import publish from './publish'
 import push from './push'
 import remove from './remove'
 import session from './session'
@@ -22,6 +23,7 @@ export default {
   freeze,
   init,
   link,
+  publish,
   push,
   remove,
   session,

--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -11,7 +11,7 @@ const register = program => program
   .command(signature, { noHelp: true })
   .usage('<project-name> [version]')
   .description(description)
-  .option('--full', 'create an application, package, and implementation directory contracts to manage your project')
+  .option('--publish', 'automatically publishes your application upon pushing it to a network')
   .option('--force', 'overwrite existing project if there is one')
   .option('--link <stdlib>', 'link to a standard library')
   .option('--no-install', 'skip installing stdlib dependencies locally')
@@ -19,10 +19,10 @@ const register = program => program
   .action(action)
 
 async function action(name, version, options) {
-  const { full, force, link, install: installLibs } = options
+  const { publish, force, link, install: installLibs } = options
 
   const libs = link ? link.split(',') : []
-  await init({ name, version, libs, installLibs, force, full })
+  await init({ name, version, libs, installLibs, force, publish })
   await push.tryAction(options)
 }
 

--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -11,7 +11,7 @@ const register = program => program
   .command(signature, { noHelp: true })
   .usage('<project-name> [version]')
   .description(description)
-  .option('--publish', 'automatically publishes your application upon pushing it to a network')
+  .option('--publish', 'automatically publishes your project upon pushing it to a network')
   .option('--force', 'overwrite existing project if there is one')
   .option('--link <stdlib>', 'link to a standard library')
   .option('--no-install', 'skip installing stdlib dependencies locally')

--- a/packages/cli/src/commands/publish.js
+++ b/packages/cli/src/commands/publish.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import publish from '../scripts/publish'
+import runWithTruffle from '../utils/runWithTruffle'
+import _ from 'lodash';
+
+const name = 'publish'
+const signature = `${name}`
+const description = 'publishes your project to the selected network'
+
+const register = program => program
+  .command(signature, { noHelp: true })
+  .usage('--network <network> [options]')
+  .description(description)
+  .withNetworkOptions()
+  .action(action)
+
+async function action(options) {
+  await runWithTruffle(async (opts) => await publish(opts), options)
+}
+
+export default { name, signature, description, register, action }

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -16,14 +16,13 @@ const register = program => program
   .option('-d, --deploy-libs', 'deploys libraries to the network if there is no existing deployment')
   .option('--reset', 'redeploys all contracts (not only the ones that changed)')
   .option('-f, --force', 'ignores validation errors and deploys contracts')
-  .option('--full', 'deploys an application, package, and implementation directory contracts to manage your project')
   .withNetworkOptions()
   .action(action)
 
 async function action(options) {
-  const { skipCompile, deployLibs, force, reset: reupload, full } = options
+  const { skipCompile, deployLibs, force, reset: reupload } = options
   await runWithTruffle(
-    async (opts) => await push({ force, deployLibs, reupload, full, ... opts }),
+    async (opts) => await push({ force, deployLibs, reupload, ... opts }),
     { compile: !skipCompile, ... options }
   )
 }

--- a/packages/cli/src/models/files/ZosPackageFile.js
+++ b/packages/cli/src/models/files/ZosPackageFile.js
@@ -67,11 +67,7 @@ export default class ZosPackageFile {
   }
 
   get isLightweight() {
-    return !this.isFull
-  }
-
-  get isFull() {
-    return this.isLib || !!this.data.full
+    return !this.data.publish && !this.isLib
   }
 
   contract(alias) {
@@ -103,8 +99,8 @@ export default class ZosPackageFile {
     this.data.lib = lib
   }
 
-  set full(full) {
-    this.data.full = !!full
+  set publish(publish) {
+    this.data.publish = !!publish
   }
 
   set name(name) {

--- a/packages/cli/src/models/local/LocalAppController.js
+++ b/packages/cli/src/models/local/LocalAppController.js
@@ -3,9 +3,9 @@ import NetworkAppController from '../network/NetworkAppController';
 import Dependency from '../dependency/Dependency';
 
 export default class LocalAppController extends LocalBaseController {
-  init(name, version, force = false, full = false) {
+  init(name, version, force = false, publish = false) {
     super.init(name, version, force)
-    if (full) this.packageFile.full = full
+    if (publish) this.packageFile.publish = publish
   }
 
   async linkLibs(libs, installLibs = false) {

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import NetworkBaseController from './NetworkBaseController';
-import { Contracts, Logger, AppProject, FileSystem as fs, Proxy } from 'zos-lib';
+import { Contracts, Logger, AppProject, FileSystem as fs, Proxy, awaitConfirmations, hasBytecode } from 'zos-lib';
 import { toContractFullName } from '../../utils/naming';
 import Dependency from '../dependency/Dependency';
 import { allPromisesOrError } from '../../utils/async';
@@ -32,11 +32,22 @@ export default class NetworkAppController extends NetworkBaseController {
       log.info(`Project is already published to ${this.network}`);
       return;
     }
+    
     log.info(`Publishing project to ${this.network}...`);
-    await this.fetchOrDeploy(this.currentVersion); // loads a SimpleProject as this.project
+    const simpleProject = await this.fetchOrDeploy(this.currentVersion);
     const deployer = new AppProjectDeployer(this, this.packageVersion);
-    this.project = await deployer.fromSimpleProject(this.project);
+    this.project = await deployer.fromSimpleProject(simpleProject);
     log.info(`Publish to ${this.network} successful`);
+
+    const proxies = this._fetchOwnedProxies();
+    if (proxies.length !== 0) {
+      log.info(`Awaiting confirmations before transferring proxies to published project (this may take a few minutes)`);
+      const app = this.project.getApp();
+      await awaitConfirmations(app.contract.transactionHash);
+      await hasBytecode(app.address);
+      await this._changeProxiesAdmin(proxies, app.address, simpleProject);
+      log.info(`${proxies.length} proxies have been successfully transferred`);
+    }
   }
 
   async push(reupload = false, force = false) {
@@ -97,16 +108,17 @@ export default class NetworkAppController extends NetworkBaseController {
   async setProxiesAdmin(packageName, contractAlias, proxyAddress, newAdmin) {
     const proxies = this._fetchOwnedProxies(packageName, contractAlias, proxyAddress)
     if (proxies.length === 0) return [];
-    await this.fetchOrDeploy(this.currentVersion)
-
-    await allPromisesOrError(
-      _.map(proxies, async (proxy) => {
-        await this.project.changeProxyAdmin(proxy.address, newAdmin)
-        this.networkFile.updateProxy(proxy, proxy => ({ ... proxy, admin: newAdmin }))
-      })
-    );
-
+    await this.fetchOrDeploy(this.currentVersion);
+    await this._changeProxiesAdmin(proxies, newAdmin);
     return proxies;
+  }
+
+  async _changeProxiesAdmin(proxies, newAdmin, project = null) {
+    if (!project) project = this.project;
+    await allPromisesOrError(_.map(proxies, async (proxy) => {
+      await project.changeProxyAdmin(proxy.address, newAdmin);
+      this.networkFile.updateProxy(proxy, proxy => ({ ...proxy, admin: newAdmin }));
+    }));
   }
 
   async upgradeProxies(packageName, contractAlias, proxyAddress, initMethod, initArgs) {

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -260,10 +260,4 @@ export default class NetworkAppController extends NetworkBaseController {
       fs.writeJson(path, data)
     }
   }
-
-  async freeze() {
-    await this.fetchOrDeploy(this.currentVersion)
-    await this.project.freeze()
-    this.networkFile.frozen = true
-  }
 }

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -28,8 +28,11 @@ export default class NetworkAppController extends NetworkBaseController {
   }
 
   async toFullApp() {
-    if (this.appAddress) return;
-    log.info(`Publishing App and Package contracts to ${this.network}...`);
+    if (this.appAddress) {
+      log.info(`Project is already published to ${this.network}`);
+      return;
+    }
+    log.info(`Publishing project to ${this.network}...`);
     await this.fetchOrDeploy(this.currentVersion); // loads a SimpleProject as this.project
     const deployer = new AppProjectDeployer(this, this.packageVersion);
     this.project = await deployer.fromSimpleProject(this.project);

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -329,4 +329,9 @@ export default class NetworkBaseController {
     this.networkFile.write()
   }
 
+  async freeze() {
+    await this.fetchOrDeploy(this.currentVersion)
+    await this.project.freeze()
+    this.networkFile.frozen = true
+  }
 }

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -46,6 +46,7 @@ export default class NetworkBaseController {
 
   async fetchOrDeploy(requestedVersion) {
     this.project = await this.getDeployer(requestedVersion).fetchOrDeploy()
+    return this.project
   }
 
   async compareCurrentStatus() {

--- a/packages/cli/src/models/network/NetworkLibController.js
+++ b/packages/cli/src/models/network/NetworkLibController.js
@@ -11,24 +11,4 @@ export default class NetworkLibController extends NetworkBaseController {
   async createProxy() {
     throw Error('Cannot create proxy for library project')
   }
-
-  _checkVersion() {
-    if (this.packageVersion !== this.currentVersion) {
-      this.networkFile.frozen = false
-    }
-    super._checkVersion()
-  }
-
-  async freeze() {
-    await this.fetchOrDeploy(this.currentVersion)
-    await this.project.freeze()
-    this.networkFile.frozen = true
-  }
-
-  async uploadContracts(reupload, changedLibraries) {
-    if (this.networkFile.frozen) {
-      throw Error('Cannot upload contracts for a frozen release. Run zos bump to create a new version first.');
-    }
-    await super.uploadContracts(reupload, changedLibraries);
-  }
 }

--- a/packages/cli/src/scripts/index.js
+++ b/packages/cli/src/scripts/index.js
@@ -7,6 +7,7 @@ import freeze from './freeze'
 import init from './init'
 import initLib from './init-lib'
 import link from './link'
+import publish from './publish'
 import pull from './pull'
 import push from './push'
 import remove from './remove'
@@ -27,6 +28,7 @@ export default {
   init,
   initLib,
   link,
+  publish,
   pull,
   push,
   remove,

--- a/packages/cli/src/scripts/init.js
+++ b/packages/cli/src/scripts/init.js
@@ -1,11 +1,11 @@
 import LocalAppController from  '../models/local/LocalAppController'
 import ZosPackageFile from "../models/files/ZosPackageFile"
 
-export default async function init({ name, version, full = false, libs = [], installLibs = false, force = false, packageFile = new ZosPackageFile() }) {
+export default async function init({ name, version, publish = false, libs = [], installLibs = false, force = false, packageFile = new ZosPackageFile() }) {
   if (!name) throw Error('A project name must be provided to initialize the project.')
   
   const controller = new LocalAppController(packageFile)
-  controller.init(name, version, force, full)
+  controller.init(name, version, force, publish)
   if (libs.length !== 0) await controller.linkLibs(libs, installLibs)
   controller.writePackage()
 }

--- a/packages/cli/src/scripts/publish.js
+++ b/packages/cli/src/scripts/publish.js
@@ -1,11 +1,14 @@
 import ControllerFor from "../models/network/ControllerFor";
+import ScriptError from '../models/errors/ScriptError';
 
 export default async function publish({ network, txParams = {}, networkFile = undefined }) {
   const controller = ControllerFor(network, txParams, networkFile);
   
   try {
     await controller.toFullApp();
-  } finally {
-    controller.writeNetworkPackage();
+    controller.writeNetworkPackageIfNeeded();
+  } catch(error) {
+    const cb = () => controller.writeNetworkPackageIfNeeded();
+    throw new ScriptError(error.message, cb);
   }
 }

--- a/packages/cli/src/scripts/publish.js
+++ b/packages/cli/src/scripts/publish.js
@@ -1,0 +1,11 @@
+import ControllerFor from "../models/network/ControllerFor";
+
+export default async function publish({ network, txParams = {}, networkFile = undefined }) {
+  const controller = ControllerFor(network, txParams, networkFile);
+  
+  try {
+    await controller.toFullApp();
+  } finally {
+    controller.writeNetworkPackage();
+  }
+}

--- a/packages/cli/src/scripts/push.js
+++ b/packages/cli/src/scripts/push.js
@@ -2,12 +2,11 @@ import stdout from '../utils/stdout';
 import ControllerFor from "../models/network/ControllerFor";
 import ScriptError from '../models/errors/ScriptError'
 
-export default async function push({ network, deployLibs, full = false, reupload = false, force = false, txParams = {}, networkFile = undefined }) {
+export default async function push({ network, deployLibs, reupload = false, force = false, txParams = {}, networkFile = undefined }) {
   const controller = ControllerFor(network, txParams, networkFile);
 
   try {
     if (deployLibs && !controller.isLib) await controller.deployLibs();
-    if (full) await controller.toFullApp();
     await controller.push(reupload, force);
     stdout(controller.isLib ? controller.packageAddress : controller.appAddress);
     controller.writeNetworkPackageIfNeeded()

--- a/packages/cli/test/commands/add.test.js
+++ b/packages/cli/test/commands/add.test.js
@@ -16,7 +16,7 @@ contract('add command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos add --all --push test --skip-compile', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/bump.test.js
+++ b/packages/cli/test/commands/bump.test.js
@@ -12,7 +12,7 @@ contract('bump command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos bump 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -9,15 +9,15 @@ contract('init command', function() {
 
   itShouldParse('should call init script with name, version and lib', 'init', 'zos init MyApp 0.2.0 --force --no-install --link mock-stdlib@1.1.0,mock-stdlib2@1.2.0', function(init) {
     const libs = ['mock-stdlib@1.1.0', 'mock-stdlib2@1.2.0']
-    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', libs, installLibs: false, force: true, full: undefined })
+    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', libs, installLibs: false, force: true, publish: undefined })
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos init MyApp 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
-  itShouldParse('should call init script with light flag', 'init', 'zos init MyApp 0.2.0 --full', function(init) {
-    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', full: true, force: undefined, installLibs: undefined, libs: [] })
+  itShouldParse('should call init script with light flag', 'init', 'zos init MyApp 0.2.0 --publish', function(init) {
+    init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', publish: true, force: undefined, installLibs: undefined, libs: [] })
   })
 
 })

--- a/packages/cli/test/commands/link.test.js
+++ b/packages/cli/test/commands/link.test.js
@@ -13,7 +13,7 @@ contract('link command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/publish.test.js
+++ b/packages/cli/test/commands/publish.test.js
@@ -1,0 +1,14 @@
+'use strict'
+require('../setup')
+
+import {stubCommands, itShouldParse} from './share';
+
+contract('publish command', function() {
+
+  stubCommands()
+
+  itShouldParse('should call publish script with network', 'publish', 'zos publish --network test', function(publish) {
+    publish.should.have.been.calledWithExactly({ network: 'test', txParams: {} })
+  })
+
+})

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -7,8 +7,8 @@ contract('push command', function() {
 
   stubCommands()
 
-  itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f --full', function(push) {
-    push.should.have.been.calledWithExactly({ force: true, deployLibs: true, reupload: true, full: true, network: 'test', txParams: {} })
+  itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f', function(push) {
+    push.should.have.been.calledWithExactly({ force: true, deployLibs: true, reupload: true, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/remove.test.js
+++ b/packages/cli/test/commands/remove.test.js
@@ -12,7 +12,7 @@ contract('remove command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos remove Impl --push test', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/share.js
+++ b/packages/cli/test/commands/share.js
@@ -11,6 +11,7 @@ import * as initLib from '../../src/scripts/init-lib';
 import * as init from '../../src/scripts/init';
 import * as link from '../../src/scripts/link';
 import * as unlink from '../../src/scripts/unlink';
+import * as publish from '../../src/scripts/publish';
 import * as pull from '../../src/scripts/pull';
 import * as push from '../../src/scripts/push';
 import * as remove from '../../src/scripts/remove';
@@ -56,6 +57,7 @@ exports.stubCommands = function () {
     this.init = sinon.stub(init, 'default')
     this.link = sinon.stub(link, 'default')
     this.unlink = sinon.stub(unlink, 'default')
+    this.publish = sinon.stub(publish, 'default')
     this.pull = sinon.stub(pull, 'default')
     this.push = sinon.stub(push, 'default')
     this.remove = sinon.stub(remove, 'default')
@@ -85,6 +87,7 @@ exports.stubCommands = function () {
     this.init.restore()
     this.link.restore()
     this.unlink.restore()
+    this.publish.restore()
     this.pull.restore()
     this.push.restore()
     this.remove.restore()

--- a/packages/cli/test/commands/unlink.test.js
+++ b/packages/cli/test/commands/unlink.test.js
@@ -12,7 +12,7 @@ contract('unlink command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos unlink mock-stdlib@1.1.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ full: undefined, deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployLibs: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/mocks/packages/package-empty.zos.json
+++ b/packages/cli/test/mocks/packages/package-empty.zos.json
@@ -3,5 +3,5 @@
   "zosversion": "2",
   "version": "1.1.0",
   "contracts": {},
-  "full": true
+  "publish": true
 }

--- a/packages/cli/test/mocks/packages/package-unsupported-zosversion.zos.json
+++ b/packages/cli/test/mocks/packages/package-unsupported-zosversion.zos.json
@@ -3,5 +3,5 @@
   "version": "1.1.0",
   "contracts": {},
   "zosversion": "3",
-  "full": true
+  "publish": true
 }

--- a/packages/cli/test/mocks/packages/package-with-contracts-and-multiple-stdlibs.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-contracts-and-multiple-stdlibs.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "contracts": {
     "Impl": "ImplV1"

--- a/packages/cli/test/mocks/packages/package-with-contracts-and-stdlib-v2.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-contracts-and-stdlib-v2.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.0",
   "contracts": {
     "Impl": "ImplV1"

--- a/packages/cli/test/mocks/packages/package-with-contracts-and-stdlib.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-contracts-and-stdlib.zos.json
@@ -1,12 +1,11 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
-  "version": "1.0",
+  "version": "1.1.0",
   "contracts": {
     "Impl": "ImplV1"
   },
   "dependencies": {
-    "mock-stdlib": "1.1.0"
+    "mock-stdlib-undeployed": "1.1.0"
   }
 }

--- a/packages/cli/test/mocks/packages/package-with-contracts-v2.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-contracts-v2.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.2.0",
   "contracts": {
     "Impl": "ImplV1",

--- a/packages/cli/test/mocks/packages/package-with-contracts.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-contracts.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "solidityLibs": {
     

--- a/packages/cli/test/mocks/packages/package-with-invalid-contracts.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-invalid-contracts.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "contracts": {
     "Impl": "ImplV1",

--- a/packages/cli/test/mocks/packages/package-with-invalid-stdlib.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-invalid-stdlib.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "dependencies": {
     "mock-stdlib-invalid": "1.0.0"

--- a/packages/cli/test/mocks/packages/package-with-multiple-stdlibs.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-multiple-stdlibs.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "contracts": {},
   "dependencies": {

--- a/packages/cli/test/mocks/packages/package-with-stdlib-range.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-stdlib-range.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "contracts": {},
   "dependencies": {

--- a/packages/cli/test/mocks/packages/package-with-stdlib.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-stdlib.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "contracts": {},
   "dependencies": {

--- a/packages/cli/test/mocks/packages/package-with-undeployed-stdlib.zos.json
+++ b/packages/cli/test/mocks/packages/package-with-undeployed-stdlib.zos.json
@@ -1,7 +1,7 @@
 {
   "name": "Herbs",
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "version": "1.1.0",
   "dependencies": {
     "mock-stdlib-undeployed": "1.1.0"

--- a/packages/cli/test/models/TestHelper.test.js
+++ b/packages/cli/test/models/TestHelper.test.js
@@ -67,7 +67,7 @@ contract('TestHelper', function ([_, owner]) {
   describe('for lightweight app project', function() {
     beforeEach(async function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
-      this.packageFile.full = false
+      this.packageFile.publish = false
       this.networkFile = this.packageFile.networkFile('test')
       this.app = await TestHelper(txParams, this.networkFile)
     })

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -233,7 +233,7 @@ contract('create script', function([_, owner]) {
   describe('on lightweight app', function () {
     beforeEach('setup', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
-      this.packageFile.full = false
+      this.packageFile.publish = false
     });
 
     shouldHandleCreateScript();

--- a/packages/cli/test/scripts/init.test.js
+++ b/packages/cli/test/scripts/init.test.js
@@ -21,55 +21,55 @@ contract('init script', function() {
 
   it('should default to lightweight apps', async function () {
     await init({ name, version, packageFile: this.packageFile });
-    this.packageFile.isFull.should.eq(false)
+    this.packageFile.isLightweight.should.eq(true)
   });
 
-  function testInit(full) {
-    it('should have correct full mark', async function () {
-      await init({ full, name, version, packageFile: this.packageFile });
-      this.packageFile.isFull.should.eq(full)
+  function testInit(publish) {
+    it('should have correct publish mark', async function () {
+      await init({ publish, name, version, packageFile: this.packageFile });
+      this.packageFile.isLightweight.should.eq(!publish)
     });
 
     it('should not be marked as lib', async function () {
-      await init({ full, name, version, packageFile: this.packageFile });
+      await init({ publish, name, version, packageFile: this.packageFile });
       this.packageFile.isLib.should.be.false
     });
 
     it('should have the appropriate app name', async function() {
-      await init({ full, name, version, packageFile: this.packageFile });
+      await init({ publish, name, version, packageFile: this.packageFile });
       this.packageFile.hasName(name).should.be.true
     });
 
     it('should have a default version if not specified', async function() {
-      await init({ full, name, packageFile: this.packageFile });
+      await init({ publish, name, packageFile: this.packageFile });
       this.packageFile.isCurrentVersion('0.1.0').should.be.true
     });
 
     it('should have the appropriate version', async function() {
-      await init({ full, name, version, packageFile: this.packageFile });
+      await init({ publish, name, version, packageFile: this.packageFile });
       this.packageFile.isCurrentVersion(version).should.be.true
     });
 
     it('should have an empty contracts object', async function() {
-      await init({ full, name, version, packageFile: this.packageFile });
+      await init({ publish, name, version, packageFile: this.packageFile });
       this.packageFile.contracts.should.be.eql({})
     });
 
     it('should set dependency', async function () {
-      await init({ full, name, version, libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });     
+      await init({ publish, name, version, libs: ['mock-stdlib@1.1.0'], packageFile: this.packageFile });     
       this.packageFile.getDependencyVersion('mock-stdlib').should.eq('1.1.0')
     });
 
     it('should not overwrite existing file by default', async function () {
       fs.writeJson(this.packageFile.fileName, { name: 'previousApp' })
-      await init({ full, name, version, packageFile: this.packageFile }).should.be.rejectedWith(`Cannot overwrite existing file ${this.packageFile.fileName}`)
+      await init({ publish, name, version, packageFile: this.packageFile }).should.be.rejectedWith(`Cannot overwrite existing file ${this.packageFile.fileName}`)
 
       cleanup(this.packageFile.fileName)
     });
 
     it('should overwrite existing file if requested', async function () {
       fs.writeJson(this.packageFile.fileName, { name: 'previousApp', version: '0' })
-      await init({ full, name, version, force: true, packageFile: this.packageFile })
+      await init({ publish, name, version, force: true, packageFile: this.packageFile })
 
       this.packageFile.hasName(name).should.be.true
       this.packageFile.isCurrentVersion(version).should.be.true

--- a/packages/cli/test/scripts/publish.test.js
+++ b/packages/cli/test/scripts/publish.test.js
@@ -1,0 +1,88 @@
+'use strict'
+require('../setup')
+
+import { App, Package, ImplementationDirectory } from 'zos-lib'
+
+import publish from '../../src/scripts/publish.js';
+import push from '../../src/scripts/push.js';
+import ZosPackageFile from '../../src/models/files/ZosPackageFile';
+
+const should = require('chai').should();
+
+contract('publish script', function([_, owner]) {
+  const network = 'test';
+  const txParams = { from: owner };
+  const defaultVersion = '1.1.0';
+  const projectName = 'Herbs';
+  const contractAlias = 'Impl';
+  const dependencyName = 'mock-stdlib-undeployed';
+
+  beforeEach('pushing package', async function () {
+    const packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts-and-stdlib.zos.json');
+    packageFile.publish = false;
+    this.networkFile = packageFile.networkFile(network);
+
+    await push({ network, txParams, networkFile: this.networkFile, deployLibs: true });
+    this.previousContractAddress = this.networkFile.contract(contractAlias).address;
+    this.previousDependencyAddress = this.networkFile.getDependency(dependencyName).package;
+  })
+
+  describe('before publishing', function () {
+    it('should have no package contracts', async function () {
+      should.not.exist(this.networkFile.packageAddress);
+      should.not.exist(this.networkFile.providerAddress);
+      should.not.exist(this.networkFile.appAddress);
+    })
+  })
+
+  describe('publishing an app', function () {
+    beforeEach('publishing', async function () {
+      await publish({ network, txParams, networkFile: this.networkFile });
+    })
+
+    it('should log contracts addresses in network file', async function () {
+      this.networkFile.appAddress.should.be.nonzeroAddress;
+      this.networkFile.packageAddress.should.be.nonzeroAddress;
+      this.networkFile.providerAddress.should.be.nonzeroAddress;
+    });
+
+    it('should deploy contracts at logged addresses', async function () {
+      const app = await App.fetch(this.networkFile.appAddress);
+      (await app.getPackage(projectName)).package.address.should.eq(this.networkFile.packageAddress);
+
+      const thepackage = await Package.fetch(this.networkFile.packageAddress);
+      (await thepackage.getDirectory(defaultVersion)).address.should.eq(this.networkFile.providerAddress);
+
+      const provider = await ImplementationDirectory.fetch(this.networkFile.providerAddress);
+      (await provider.getImplementation(contractAlias)).should.be.nonzeroAddress;
+    });
+
+    it('should reuse deployed implementations', async function () {
+      const provider = await ImplementationDirectory.fetch(this.networkFile.providerAddress);
+      (await provider.getImplementation(contractAlias)).should.eq(this.previousContractAddress);
+      this.networkFile.contract(contractAlias).address.should.eq(this.previousContractAddress);
+    });
+
+    it('should link dependencies', async function () {
+      const app = await App.fetch(this.networkFile.appAddress);
+      (await app.getPackage(dependencyName)).package.address.should.eq(this.previousDependencyAddress);
+    });
+  })
+
+  describe('publishing with modified contracts', async function () {
+    beforeEach('publishing', async function () {
+      const contractData = this.networkFile.contract(contractAlias);
+      this.networkFile.setContract(contractAlias, { ... contractData, bytecodeHash: '0xabcdef' })
+      await publish({ network, txParams, networkFile: this.networkFile });
+    })
+
+    it('should not redeploy modified contract on app', async function () {
+      const app = await App.fetch(this.networkFile.appAddress);
+      const newImplFromApp = await app.getImplementation(projectName, contractAlias);
+      const newImplFromFile = this.networkFile.contract(contractAlias).address;
+      
+      newImplFromApp.should.eq(newImplFromFile);
+      newImplFromApp.should.eq(this.previousContractAddress);
+    });
+  })
+});

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -282,13 +282,6 @@ contract('push script', function([_, owner]) {
     });
   };
 
-  const shouldNotPushWhileFrozen = function () {
-    it('should refuse to push when frozen', async function() {
-      await freeze({ network, txParams, networkFile: this.networkFile })
-      await push({ network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/frozen/i)
-    });
-  };
-
   describe('an empty app', function() {
     beforeEach('pushing package-empty', async function () {
       const packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -275,50 +275,12 @@ contract('push script', function([_, owner]) {
     });
   };
 
-  const shouldMigrateToFullApp = function () {
-    beforeEach('loading previous address', function () {
-      this.previousAddress = this.networkFile.contract('Impl').address
-    })
-
-    describe('migration to full app', function () {
-      beforeEach('migrating', async function () {
-        await push({ full: true, network, txParams, networkFile: this.networkFile })
-      })
-  
-      shouldDeployApp();
-
-      it('should reuse contract implementations', async function () {
-        const newImpl = await getImplementationFromApp.call(this, 'Impl');
-        newImpl.should.eq(this.previousAddress);
-      });
-
-      it('should redeploy modified contract on app', async function () {
-        modifyBytecode.call(this, 'Impl');
-        await push({ networkFile: this.networkFile, network, txParams });
-
-        const newImplFromApp = await getImplementationFromApp.call(this, 'Impl');
-        const newImplFromFile = this.networkFile.contract('Impl').address;
-        
-        newImplFromApp.should.eq(newImplFromFile);
-        newImplFromApp.should.not.eq(this.previousAddress);
-      });
-    })
-
-    describe('migration with modified contracts', async function () {
-      beforeEach('migrating', async function () {
-        modifyBytecode.call(this, 'Impl');
-        await push({ full: true, network, txParams, networkFile: this.networkFile });
-      })
-
-      it('should redeploy modified contract on app', async function () {
-        const newImplFromApp = await getImplementationFromApp.call(this, 'Impl');
-        const newImplFromFile = this.networkFile.contract('Impl').address;
-        
-        newImplFromApp.should.eq(newImplFromFile);
-        newImplFromApp.should.not.eq(this.previousAddress);
-      });
-    })
-  }
+  const shouldNotPushWhileFrozen = function () {
+    it('should refuse to push when frozen', async function() {
+      await freeze({ network, txParams, networkFile: this.networkFile })
+      await push({ network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/frozen/i)
+    });
+  };
 
   const shouldNotPushWhileFrozen = function () {
     it('should refuse to push when frozen', async function() {
@@ -481,27 +443,12 @@ contract('push script', function([_, owner]) {
     it('should run push', async function () {
       await push({ network, txParams, networkFile: this.networkFile })
     });
-
-    describe('migration to full app', function () {
-      beforeEach('migrating', async function () {
-        await push({ network, txParams, networkFile: this.networkFile })
-        await push({ full: true, network, txParams, networkFile: this.networkFile })
-      });
-      shouldDeployApp();
-    });
-
-    describe('migration from scratch', function () {
-      beforeEach('migrating', async function () {
-        await push({ full: true, network, txParams, networkFile: this.networkFile })
-      });
-      shouldDeployApp();
-    });
   });
 
   describe('a lightweight app with contracts', function() {
     beforeEach('pushing package-with-contracts', async function () {
       const packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
-      packageFile.full = false
+      packageFile.publish = false
       this.networkFile = packageFile.networkFile(network)
 
       await push({ network, txParams, networkFile: this.networkFile })
@@ -511,7 +458,6 @@ contract('push script', function([_, owner]) {
     shouldValidateContracts();
     shouldRedeployContracts();
     shouldDeleteContracts({ unregisterFromDirectory: false });
-    shouldMigrateToFullApp();
 
     it('should not reupload contracts after version bump', async function () {
       const previousAddress = this.networkFile.contract('Impl').address

--- a/packages/cli/test/scripts/status.test.js
+++ b/packages/cli/test/scripts/status.test.js
@@ -253,7 +253,7 @@ contract('status script', function([_, owner]) {
   describe('on lightweight app project', function () {
     beforeEach('creating package and network files', function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
-      this.packageFile.full = false
+      this.packageFile.publish = false
       this.networkFile = this.packageFile.networkFile(network)
     })
 

--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -278,7 +278,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
   describe('on application contract in lightweight mode', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
-      this.packageFile.full = false
+      this.packageFile.publish = false
     });
 
     shouldHandleUpdateScript();
@@ -295,7 +295,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
   describe('on dependency contract in lightweight mode', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
-      this.packageFile.full = false
+      this.packageFile.publish = false
     });
 
     shouldHandleUpdateOnDependency();

--- a/packages/lib/src/helpers/advanceBlock.js
+++ b/packages/lib/src/helpers/advanceBlock.js
@@ -1,0 +1,11 @@
+export default function advanceBlock () {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_mine',
+      id: Date.now(),
+    }, (err, res) => {
+      return err ? reject(err) : resolve(res);
+    });
+  });
+}

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -4,6 +4,7 @@ const version = 'v' + require('../package.json').version
 // helpers
 import decodeLogs from './helpers/decodeLogs'
 import encodeCall from './helpers/encodeCall'
+import sleep from './helpers/sleep'
 
 // utils
 import ABI from './utils/ABIs'
@@ -11,8 +12,8 @@ import Semver from './utils/Semver'
 import Logger from './utils/Logger'
 import FileSystem from './utils/FileSystem'
 import Contracts from './utils/Contracts'
-import { sendTransaction, deploy } from './utils/Transactions'
 import { bodyCode, constructorCode, bytecodeDigest, replaceSolidityLibAddress, isSolidityLib, getSolidityLibNames } from './utils/Bytecode'
+import { sendTransaction, deploy, isGanacheNode, awaitConfirmations, hasBytecode } from './utils/Transactions'
 import { flattenSourceCode } from './utils/Solidity'
 import { semanticVersionEqual, toSemanticVersion, semanticVersionToString } from './utils/Semver';
 
@@ -65,6 +66,10 @@ export {
   replaceSolidityLibAddress, 
   getSolidityLibNames,
   isSolidityLib,
+  sleep,
+  isGanacheNode,
+  awaitConfirmations,
+  hasBytecode,
   Proxy,
   Logger,
   ABI,

--- a/packages/lib/src/utils/Semver.js
+++ b/packages/lib/src/utils/Semver.js
@@ -1,5 +1,6 @@
 import semver from 'semver';
 import _ from 'lodash';
+import util from 'util';
 
 export function toSemanticVersion(version) {
   if (_.isString(version)) {
@@ -19,7 +20,7 @@ export function semanticVersionToString(version) {
   } else if (_.isArray(version)) {
     return version.join('.');
   } else {
-    throw Error(`Cannot handle version identifier ${version}`)
+    throw Error(`Cannot handle version identifier ${util.inspect(version)}`)
   }
 }
 

--- a/packages/lib/src/utils/Transactions.js
+++ b/packages/lib/src/utils/Transactions.js
@@ -9,8 +9,8 @@ import sleep from '../helpers/sleep';
 import Contracts from './Contracts'
 import BN from 'bignumber.js'
 
-// Store last block for gasLimit information
-const state = { };
+// Cache, exported for testing
+export const state = { };
 
 // Gas estimates are multiplied by this value to allow for an extra buffer (for reference, truffle-next uses 1.25)
 const GAS_MULTIPLIER = 1.25;

--- a/packages/lib/src/utils/Transactions.js
+++ b/packages/lib/src/utils/Transactions.js
@@ -160,7 +160,7 @@ function checkGasPrice(txParams) {
   }
 }
 
-async function isGanacheNode () {
+export async function isGanacheNode () {
   const nodeVersion = await getNodeVersion();
   return nodeVersion.match(/TestRPC/);
 }
@@ -183,4 +183,26 @@ async function calculateActualGas(estimatedGas) {
   // this once the issue is resolved.
   if (await isGanacheNode()) gasToUse += 15000;
   return gasToUse >= blockLimit ? (blockLimit-1) : gasToUse;
+}
+
+export async function awaitConfirmations(transactionHash, confirmations = 12, interval = 1000, timeout = (10 * 60 * 1000)) {
+  if (await isGanacheNode()) return;
+  const getTxBlock = () => (promisify(web3.eth.getTransactionReceipt.bind(web3.eth))(transactionHash).then(r => r.blockNumber));
+  const getCurrentBlock = () => (promisify(web3.eth.getBlock.bind(web3.eth))('latest').then(b => b.number));
+  const now = +(new Date());
+
+  while (true) {
+    if ((new Date() - now) > timeout) {
+      throw new Error(`Exceeded timeout of ${timeout / 1000} seconds awaiting confirmations for transaction ${transactionHash}`)
+    }
+    const currentBlock = await getCurrentBlock();
+    const txBlock = await getTxBlock();
+    if (currentBlock - txBlock >= confirmations) return true;
+    await sleep(interval);
+  }
+}
+
+export async function hasBytecode(address) {
+  const bytecode = await promisify(web3.eth.getCode.bind(web3.eth))(address);
+  return bytecode.length > 2;
 }

--- a/packages/vouching/src/scripts/deploy.js
+++ b/packages/vouching/src/scripts/deploy.js
@@ -6,7 +6,7 @@ import configureTPL from '../kernel/configureTPL'
 import exportKernelData from '../kernel/exportKernelData'
 import createKernelContracts from '../kernel/createKernelContracts'
 
-const { push, session } = scripts
+const { push, session, publish } = scripts
 
 export default async function deploy(options) {
   const oneDay = 60 * 60 * 24
@@ -14,7 +14,8 @@ export default async function deploy(options) {
   log.base(`Pushing ZeppelinOS app with options ${JSON.stringify(options, null, 2)}...`)
   const isLocalOrTest = options.network === 'local' || options.network === 'test'
   if (isLocalOrTest) removeZosFiles(options)
-  await push({ deployLibs: isLocalOrTest, full: true, ...options })
+  await push({ deployLibs: isLocalOrTest, ...options })
+  await publish({ ...options })
   stdout.silent(true)
   const { app, jurisdiction, validator, zepToken, vouching } = await createKernelContracts(options)
   await configureTPL(jurisdiction, validator, options)

--- a/packages/vouching/zos.json
+++ b/packages/vouching/zos.json
@@ -1,6 +1,6 @@
 {
   "zosversion": "2",
-  "full": true,
+  "publish": true,
   "name": "zos-vouching",
   "version": "0.0.1",
   "contracts": {

--- a/tests/cli-app/test/integration.test.js
+++ b/tests/cli-app/test/integration.test.js
@@ -21,7 +21,7 @@ function runIntegrationTest({ lightweight }) {
   registerProjectHooks(network);
 
   it('initialize zos', function () {
-    const flags = lightweight ? '' : '--full';
+    const flags = lightweight ? '' : '--publish';
     run(`npx zos init cli-app 0.5.0 ${flags}`)
   })
 


### PR DESCRIPTION
Adds a new `publish` command that migrates the current app/lib from lightweight into a full app, by deploying a directory, package and app contracts.

Also deprecates the `--full` flag for `push`, and renames that flag in `init` to `--publish`.

Fixes #255