### PR TITLE
Use version of dependency for identifying proxies in network json file

### DIFF
--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -26,7 +26,7 @@ contract('create script', function([_, owner]) {
   ];
 
   const network = 'test';
-  const version = '1.1.0';
+  const version = '0.4.0';
   const txParams = { from: owner };
 
   const assertProxy = async function(networkFile, alias, { version, say, implementation, packageName, value }) {
@@ -159,6 +159,8 @@ contract('create script', function([_, owner]) {
     });
 
     describe('with dependency', function () {
+      const dependencyVersion = '1.1.0';
+
       beforeEach('setting dependency', async function () {
         await linkLibs({ libs: ['mock-stdlib-undeployed@1.1.0'], packageFile: this.packageFile });
         await push({ network, txParams, deployLibs: true, networkFile: this.networkFile });
@@ -171,17 +173,17 @@ contract('create script', function([_, owner]) {
 
       it('should create a proxy from a dependency', async function () {
         await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-        await assertProxy(this.networkFile, 'Greeter', { version, packageName: 'mock-stdlib-undeployed' });
+        await assertProxy(this.networkFile, 'Greeter', { version: dependencyVersion, packageName: 'mock-stdlib-undeployed' });
       });
 
       it('should initialize a proxy from a dependency', async function () {
         await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile, initMethod: 'initialize', initArgs: ["42"] });
-        await assertProxy(this.networkFile, 'Greeter', { version, packageName: 'mock-stdlib-undeployed', value: 42 });
+        await assertProxy(this.networkFile, 'Greeter', { version: dependencyVersion, packageName: 'mock-stdlib-undeployed', value: 42 });
       });
 
       it('should initialize a proxy from a dependency using explicit function', async function () {
         await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile, initMethod: 'clashingInitialize(uint256)', initArgs: ["42"] });
-        await assertProxy(this.networkFile, 'Greeter', { version, packageName: 'mock-stdlib-undeployed', value: 42 });
+        await assertProxy(this.networkFile, 'Greeter', { version: dependencyVersion, packageName: 'mock-stdlib-undeployed', value: 42 });
       });
     });
 
@@ -233,6 +235,7 @@ contract('create script', function([_, owner]) {
   describe('on lightweight app', function () {
     beforeEach('setup', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+      this.packageFile.version = version
       this.packageFile.publish = false
     });
 
@@ -242,6 +245,7 @@ contract('create script', function([_, owner]) {
   describe('on full app', function () {
     beforeEach('setup', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+      this.packageFile.version = version
     });
 
     shouldHandleCreateScript();

--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -21,8 +21,8 @@ const Greeter_V2 = Contracts.getFromNodeModules('mock-stdlib-2', 'GreeterImpl')
 
 contract('update script', function([_skipped, owner, anotherAccount]) {
   const network = 'test';
-  const version_1 = '1.1.0';
-  const version_2 = '1.2.0';
+  const version_1 = '0.1.0';
+  const version_2 = '0.2.0';
   const txParams = { from: owner };
 
   const assertProxyInfo = async function(networkFile, contractAlias, proxyIndex, { version, implementation, address, value }) {
@@ -230,7 +230,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
       const proxyAddress = this.networkFile.getProxies({ contract: 'Greeter'})[0].address;
       await update({ proxyAddress, network, txParams, networkFile: this.networkFile });
 
-      await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2, address: proxyAddress });
+      await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0', address: proxyAddress });
       const upgradedProxy = await Greeter_V2.at(proxyAddress);
       (await upgradedProxy.version()).should.eq('1.2.0');
 
@@ -242,27 +242,27 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
     it('should upgrade the version of all proxies given their name', async function() {
       await update({ packageName: 'mock-stdlib-undeployed-2', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(proxyAddress).version()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(anotherProxyAddress).version()).should.eq('1.2.0');
     });
 
     it('should upgrade the version of all proxies given their package', async function() {
       await update({ packageName: 'mock-stdlib-undeployed-2', network, txParams, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(proxyAddress).version()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(anotherProxyAddress).version()).should.eq('1.2.0');
     });
 
     it('should upgrade the version of all proxies', async function() {
       await update({ network, txParams, all: true, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(proxyAddress).version()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2 });
+      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
       (await Greeter_V2.at(anotherProxyAddress).version()).should.eq('1.2.0');
     });
   };
@@ -270,6 +270,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
   describe('on application contract', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+      this.packageFile.version = version_1
     });
 
     shouldHandleUpdateScript();
@@ -279,6 +280,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
       this.packageFile.publish = false
+      this.packageFile.version = version_1
     });
 
     shouldHandleUpdateScript();
@@ -287,6 +289,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
   describe('on dependency contract', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
+      this.packageFile.version = version_1;
     });
 
     shouldHandleUpdateOnDependency();
@@ -296,6 +299,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
       this.packageFile.publish = false
+      this.packageFile.version = version_1;
     });
 
     shouldHandleUpdateOnDependency();


### PR DESCRIPTION
Changes both create and update commands to retrieve the package version
of either the project package or the dependency package when annotating
the proxy version in the network json file.

Fixes #267