### PR TITLE
Check if package is frozen before uploading solidity libs

### DIFF
--- a/packages/cli/src/models/files/ZosNetworkFile.js
+++ b/packages/cli/src/models/files/ZosNetworkFile.js
@@ -86,6 +86,11 @@ export default class ZosNetworkFile {
     delete this.data.solidityLibs[libName]
   }
 
+  setSolidityLib(alias, value) {
+    if (!this.data.solidityLibs) this.data.solidityLibs = {};
+    this.data.solidityLibs[alias] = value
+  }
+
   solidityLib(libName) {
     return this.data.solidityLibs[libName]
   }

--- a/packages/cli/src/models/network/NetworkAppController.js
+++ b/packages/cli/src/models/network/NetworkAppController.js
@@ -50,11 +50,6 @@ export default class NetworkAppController extends NetworkBaseController {
     }
   }
 
-  async push(reupload = false, force = false) {
-    await super.push(reupload, force);
-    await this.handleLibsLink()
-  }
-
   async deployLibs() {
     await allPromisesOrError(
       _.map(this.packageFile.dependencies, (version, dep) => this.deployLibIfNeeded(dep, version))

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -77,14 +77,26 @@ export default class NetworkBaseController {
 
     this._checkVersion()
     await this.fetchOrDeploy(this.packageVersion)
-    await this.uploadSolidityLibs(changedLibraries);
+    await this.handleLibsLink();
     
+    this.checkNotFrozen();
+    await this.uploadSolidityLibs(changedLibraries);
     await Promise.all([
       this.uploadContracts(contracts), 
       this.unsetContracts()
     ])
 
     await this._unsetSolidityLibs()
+  }
+
+  async handleLibsLink() {
+    return;
+  }
+
+  checkNotFrozen() {
+    if (this.networkFile.frozen) {
+      throw Error('Cannot modify contracts in a frozen version. Run zos bump to create a new version first.');
+    }
   }
 
   async newVersion(versionName) {
@@ -145,10 +157,6 @@ export default class NetworkBaseController {
   }
 
   async uploadContracts(contracts) {
-    if (this.networkFile.frozen) {
-      throw Error('Cannot upload contracts for a frozen version. Run zos bump to create a new version first.');
-    }
-
     await allPromisesOrError(
       contracts.map(([contractAlias, contractClass]) => this.uploadContract(contractAlias, contractClass))
     )


### PR DESCRIPTION
Previously the check was done only when uploading contracts, and caused
the solidity lib upload to fail with an EVM revert.

Fixes #266