### PR TITLE
Fix storage layout parsing when there are complex types

### DIFF
--- a/packages/lib/contracts/mocks/StorageMocksForComparison.sol
+++ b/packages/lib/contracts/mocks/StorageMocksForComparison.sol
@@ -50,3 +50,11 @@ contract StorageMockSimpleWithReplacedVar {
   uint256 a;
   string c;
 }
+
+contract StorageMockComplexOriginal {
+  mapping(address => uint256) a;
+}
+
+contract StorageMockComplexWithChangedVar {
+  mapping(address => address) a;
+}

--- a/packages/lib/src/validations/Storage.js
+++ b/packages/lib/src/validations/Storage.js
@@ -87,7 +87,7 @@ class StorageLayout {
     const sourcePath = path.relative(process.cwd(), this.getNode(contractNode.scope, 'SourceUnit').absolutePath)
     const varNodes = contractNode.nodes.filter(node => node.stateVariable && !node.constant)
     varNodes.forEach(node => {
-      const typeInfo = this.getTypeInfo(node.typeName)
+      const typeInfo = this.getAndRegisterTypeInfo(node.typeName)
       this.registerType(typeInfo)
       const storageInfo = { contract: contractNode.name, path: sourcePath, ... this.getStorageInfo(node, typeInfo) }
       this.storage.push(storageInfo)
@@ -128,6 +128,12 @@ class StorageLayout {
     }
   }
 
+  getAndRegisterTypeInfo(node) {
+    const typeInfo = this.getTypeInfo(node);
+    this.registerType(typeInfo);
+    return typeInfo;
+  }
+
   getTypeInfo(node) {
     switch (node.nodeType) {
       case 'ElementaryTypeName': return this.getElementaryTypeInfo(node);
@@ -165,7 +171,7 @@ class StorageLayout {
   }
   
   getArrayTypeInfo({ baseType, length, }) {
-    const { id: baseTypeId, label: baseTypeLabel } = this.getTypeInfo(baseType)
+    const { id: baseTypeId, label: baseTypeLabel } = this.getAndRegisterTypeInfo(baseType)
     const lengthDescriptor = length ? length.value : 'dyn'
     const lengthLabel = length ? length.value : ''
     return { 
@@ -212,8 +218,7 @@ class StorageLayout {
     const members = referencedNode.members
       .filter(member => member.nodeType === 'VariableDeclaration')
       .map(member => {
-        const typeInfo = this.getTypeInfo(member.typeName)
-        this.registerType(typeInfo)
+        const typeInfo = this.getAndRegisterTypeInfo(member.typeName)
         return this.getStorageInfo(member, typeInfo)
       })
 
@@ -235,6 +240,6 @@ class StorageLayout {
   getValueTypeInfo(node) {
     return (node.nodeType === 'Mapping')
       ? this.getValueTypeInfo(node.valueType)
-      : this.getTypeInfo(node)
+      : this.getAndRegisterTypeInfo(node)
   }  
 }

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -95,4 +95,9 @@ contract('Layout', () => {
     ]);
   });
 
+  it('reports no changes on complex contract', function () {
+    const result = compare('StorageMockComplexOriginal', 'StorageMockComplexOriginal');
+    assertChanges(result, []);
+  });
+
 })

--- a/packages/lib/test/src/validations/Storage.test.js
+++ b/packages/lib/test/src/validations/Storage.test.js
@@ -306,7 +306,7 @@ contract('Storage', () => {
   })
 
   describe('#getStructsOrEnums', function () {
-    it('returns all structs and enums', function () {
+    it('returns all structs and enums from complex contract', function () {
       const storageInfo = getStorageLayout(Contracts.getFromLib('StorageMockMixed'))
       const result = getStructsOrEnums(storageInfo)
       const resultVarNames = result.map(variable => variable.label)
@@ -322,5 +322,36 @@ contract('Storage', () => {
         'my_enum_mapping',
       ])
     })
+
+    it('returns none from mappings contract', function () {
+      const storageInfo = getStorageLayout(Contracts.getFromLib('StorageMockWithMappings'))
+      const result = getStructsOrEnums(storageInfo)
+      const resultVarNames = result.map(variable => variable.label)
+
+      resultVarNames.should.be.deep.eq([])
+    })
+
+    it('returns none from arrays contract', function () {
+      const storageInfo = getStorageLayout(Contracts.getFromLib('StorageMockWithArrays'))
+      const result = getStructsOrEnums(storageInfo)
+      const resultVarNames = result.map(variable => variable.label)
+
+      resultVarNames.should.be.deep.eq([])
+    })
+
+    it('returns struct from structs contract', function () {
+      const storageInfo = getStorageLayout(Contracts.getFromLib('StorageMockWithStructs'))
+      const result = getStructsOrEnums(storageInfo)
+      const resultVarNames = result.map(variable => variable.label)
+
+      resultVarNames.should.be.deep.eq([
+        "my_struct",
+        "my_struct_dynarray",
+        "my_struct_staticarray",
+        "my_struct_mapping"
+      ])
+    })
   });
 })
+
+


### PR DESCRIPTION
Given a contract with a mapping or array (not struct), the check for
whether it contained structs or enums failed if there was no variable
with the same type as the value type of the mapping or array. For
instance, a contract with a variable of type `array(string)` and another
`string` would work, but a contract with just `array(string)` would
fail.