### PR TITLE
Preserve stack trace when using ScriptError

### DIFF
--- a/packages/cli/src/models/errors/ScriptError.js
+++ b/packages/cli/src/models/errors/ScriptError.js
@@ -1,8 +1,9 @@
 'use strict'
 
 export default class ScriptError extends Error {
-  constructor(message, cb) {
+  constructor({ message, stack }, cb) {
     super(message)
+    this.stack = stack
     this.cb = cb
   }
 }

--- a/packages/cli/src/scripts/create.js
+++ b/packages/cli/src/scripts/create.js
@@ -17,6 +17,6 @@ export default async function createProxy({ packageName, contractAlias, initMeth
     return proxy;
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded()
-    throw new ScriptError(error.message, cb)
+    throw new ScriptError(error, cb)
   }
 }

--- a/packages/cli/src/scripts/freeze.js
+++ b/packages/cli/src/scripts/freeze.js
@@ -8,6 +8,6 @@ export default async function freeze({ network, txParams = {}, networkFile = und
     controller.writeNetworkPackageIfNeeded()
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded()
-    throw new ScriptError(error.message, cb)
+    throw new ScriptError(error, cb)
   }
 }

--- a/packages/cli/src/scripts/publish.js
+++ b/packages/cli/src/scripts/publish.js
@@ -9,6 +9,6 @@ export default async function publish({ network, txParams = {}, networkFile = un
     controller.writeNetworkPackageIfNeeded();
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();
-    throw new ScriptError(error.message, cb);
+    throw new ScriptError(error, cb);
   }
 }

--- a/packages/cli/src/scripts/pull.js
+++ b/packages/cli/src/scripts/pull.js
@@ -8,6 +8,6 @@ export default async function pull({ network, txParams = {}, networkFile = undef
     controller.writeNetworkPackageIfNeeded()
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded()
-    throw new ScriptError(error.message, cb)
+    throw new ScriptError(error, cb)
   }
 }

--- a/packages/cli/src/scripts/push.js
+++ b/packages/cli/src/scripts/push.js
@@ -11,8 +11,8 @@ export default async function push({ network, deployLibs, reupload = false, forc
     const address = controller.isLib ? controller.packageAddress : controller.appAddress;
     if (address) stdout(address);
     controller.writeNetworkPackageIfNeeded()
-  } catch(error) {
+  } catch (error) {
     const cb = () => controller.writeNetworkPackageIfNeeded()
-    throw new ScriptError(error.message, cb)
+    throw new ScriptError(error, cb)
   }
 }


### PR DESCRIPTION
We were loosing the original error stack trace due to the `ScriptError` implementation. This PR overwrites the `ScriptError` stack trace with the original one.