### PR TITLE
Delete mock contracts when publishing package

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "scripts/test.sh",
     "prepare": "rm -rf build/contracts && truffle compile && rm -rf lib && babel src --out-dir lib",
+    "prepublishOnly": "echo 'Removing mock contracts...' && grep -hoP '^\\s*contract \\K(\\w+)' contracts/mocks/*.sol | sort | uniq | xargs -t -I% rm build/contracts/%.json",
     "watch": "babel src -w -d lib"
   },
   "files": [


### PR DESCRIPTION
Fixes zeppelinos/zos-lib#208