### PR TITLE
Preserve stack trace when using DeployError

### DIFF
--- a/packages/lib/src/project/AppProject.js
+++ b/packages/lib/src/project/AppProject.js
@@ -35,7 +35,7 @@ export default class AppProject extends BasePackageProject {
       project.package = thepackage
       return project
     } catch(deployError) {
-      throw new DeployError(deployError.message, { thepackage, directory, app })
+      throw new DeployError(deployError, { thepackage, directory, app })
     }
   }
 

--- a/packages/lib/src/project/LibProject.js
+++ b/packages/lib/src/project/LibProject.js
@@ -27,7 +27,7 @@ export default class LibProject extends BasePackageProject {
 
       return project
     } catch(deployError) {
-      throw new DeployError(deployError.message, { thepackage, directory })
+      throw new DeployError(deployError, { thepackage, directory })
     }
   }
 

--- a/packages/lib/src/utils/errors/DeployError.js
+++ b/packages/lib/src/utils/errors/DeployError.js
@@ -1,8 +1,9 @@
 'use strict'
 
 export class DeployError extends Error {
-  constructor(message, props) {
+  constructor({ message, stack }, props) {
     super(message)
+    this.stack = stack
     Object.keys(props).forEach(prop => this[prop] = props[prop])
   }
 }


### PR DESCRIPTION
We were losing `zos-lib` stack trace when using `DeployError`. This PR overwrites the `DeployError` stack trace with the original one.