### PR TITLE
Check package json version instead of zos version for dependencies

### DIFF
--- a/packages/cli/test/mocks/mock-stdlib/zos.invalid.json
+++ b/packages/cli/test/mocks/mock-stdlib/zos.invalid.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "zosversion": "2",
+  "provider": {
+    "address": "0x0000000000000000000000000000000000000010"
+  },
+  "package": {
+    "address": "0x0000000000000000000000000000000000000080"
+  },
+  "contracts": {
+    "Greeter": {
+      "address": "0x1020",
+      "bytecodeHash": "0x0001"
+    }
+  }
+}

--- a/packages/cli/test/models/Dependency.test.js
+++ b/packages/cli/test/models/Dependency.test.js
@@ -54,7 +54,7 @@ contract('Dependency', function([_, from]) {
   describe('#constructor', function() {
     context('with invalid version', function() {
       it('throws an error',function() {
-        assertErrorMessage(() => new Dependency('mock-stdlib', '1.2.0'), /does not match version/)
+        assertErrorMessage(() => new Dependency('mock-stdlib', '1.2.0'), /requires package version 1\.2\.0/)
       })
     })
 
@@ -115,9 +115,15 @@ contract('Dependency', function([_, from]) {
       })
 
       context('for an existent network', function() {
-        it ('generates network file', function() {
+        it ('returns network file', function() {
           const networkFile = this.dependency.getNetworkFile('test')
           networkFile.fileName.should.eq('node_modules/mock-stdlib/zos.test.json')
+        })
+      })
+
+      context('on a mismatching version', function() {
+        it('throws an error', function() {
+          assertErrorMessage(() => this.dependency.getNetworkFile('invalid'), /defines version 1\.1\.0/)
         })
       })
     })

--- a/packages/cli/test/scripts/link.test.js
+++ b/packages/cli/test/scripts/link.test.js
@@ -56,9 +56,10 @@ contract('link script', function() {
       .should.be.rejectedWith('Package projects cannot use other packages.');
   });
 
-  it('should raise an error if requested version of dependency does not match its package version', async function () {
-    await linkLibs({ libs: ['mock-stdlib-invalid@1.0.0'], packageFile: this.packageFile })
-      .should.be.rejectedWith('Required dependency version 1.0.0 does not match version 2.0.0')
+  it('should allow mismatching npm and zos versions', async function () {
+    // mock-stdlib-invalid has npm version 1.1.0 but zos version 2.0.0
+    await linkLibs({ libs: ['mock-stdlib-invalid@1.1.0'], packageFile: this.packageFile });
+    this.shouldHaveDependency('mock-stdlib', '1.1.0');
   });
 
   it('should install the dependency if a valid version range is requested', async function () {
@@ -73,7 +74,7 @@ contract('link script', function() {
 
   it('should raise an error if requested version range does not match its package version', async function () {
     await linkLibs({ libs: ['mock-stdlib@~1.0.0'], packageFile: this.packageFile })
-      .should.be.rejectedWith('Required dependency version ~1.0.0 does not match version 1.1.0')
+      .should.be.rejectedWith('mock-stdlib requires package version ~1.0.0, but 1.1.0 was found.')
   });
 
   it('should raise an error if requested version of dependency lacks zosversion identifier', async function () {

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -296,6 +296,7 @@ contract('push script', function([_, owner]) {
         const mockStdlibPackage = new ZosPackageFile('test/mocks/mock-stdlib/zos.json');
         mockStdlibPackage.version = newVersion;
         sinon.stub(Dependency.prototype, 'getPackageFile').callsFake(() => mockStdlibPackage);
+        sinon.stub(Dependency.prototype, 'getNpmFile').callsFake(() => ({ version: '1.2.0' }));
 
         await this.dependencyPackage.newVersion(newVersion)
         this.dependencyGetNetworkFileStub.callsFake(() => ({ packageAddress: this.dependencyPackage.address, version: newVersion }));
@@ -436,7 +437,7 @@ contract('push script', function([_, owner]) {
 
       it('should fail to push', async function () {
         await push({ network, txParams, networkFile: this.networkFile })
-          .should.be.rejectedWith(/Required dependency version 1.0.0 does not match version 2.0.0/)
+          .should.be.rejectedWith(/requires package version 1.0.0, but 1.1.0 was found/)
       });
     })
 


### PR DESCRIPTION
Changes all dependency version validations to check against the package.json version instead of the zos.json version. This allows publishing an update of the npm package without modifying the zos.json versions. The downside is that we are coupling the zos.json declared dependency with npm versioning (the dependencies node of the zos.json file will now list dependencies with their npm version, and not their zos version), but we can review this in the future when we allow other package managers to be used. We can discuss whether this is the best approach though, as it allows to completely unsync the npm version and the zos version for a dependency, and whether to merge it now in case it introduces potential new issues.

We do use the zos.json version to check the zos.network.json files. If a dependency updates its zos.json version, but fails to update a zos.network.json, the consumer will reject using the dependency on that network.

Fixes #308