### PR TITLE
Use contract method `estimateGas` function instead of `web3.eth.estimateGas` for contract method calls

### DIFF
--- a/packages/lib/src/utils/Transactions.js
+++ b/packages/lib/src/utils/Transactions.js
@@ -93,8 +93,8 @@ async function _sendTransaction(contractFn, args = [], txParams = {}) {
   }
 
   // Estimate gas for the call
-  const estimateGasTxParams = { ... txParams, ... contractFn.request(...args).params[0] };
-  const gas = await estimateActualGas(estimateGasTxParams);
+  const gas = await estimateActualGasFnCall(contractFn, args, txParams)
+
   return contractFn(...args, { gas, ... txParams });
 }
 
@@ -137,6 +137,20 @@ export async function estimateGas(txParams, retries = RETRY_COUNT) {
     if (retries <= 0) throw Error(error);
     await sleep(RETRY_SLEEP_TIME);
     return await estimateGas(txParams, retries - 1);
+  }
+}
+
+export async function estimateActualGasFnCall(contractFn, args, txParams, retries = RETRY_COUNT) {
+  // Retry if estimate fails. This could happen because we are depending
+  // on a previous transaction being mined that still hasn't reach the node
+  // we are working with, if the txs are routed to different nodes.
+  // See https://github.com/zeppelinos/zos/issues/192 for more info.
+  try {
+    return await calculateActualGas(await contractFn.estimateGas(...args, txParams))
+  } catch(error) {
+    if (retries <= 0) throw Error(error);
+    await sleep(RETRY_SLEEP_TIME);
+    return estimateActualGasFnCall(contractFn, args, txParams, retries - 1);
   }
 }
 

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -90,18 +90,18 @@ contract('Transactions', function([_account1, account2]) {
     });
 
     it('retries estimating gas', async function () {
-      sinon.stub(web3.eth, 'estimateGas')
-        .onFirstCall().yields(new Error('gas required exceeds allowance or always failing transaction'), null)
-        .yields(null, 800000)
+      const stub = sinon.stub(this.instance.initialize, 'estimateGas')
+      _.times(3, i => stub.onCall(i).throws('Error', 'gas required exceeds allowance or always failing transaction'))
+      stub.returns(800000)
 
       const { tx } = await sendTransaction(this.instance.initialize, [42, 'foo', [1,2,3]]);
       assertGas(tx, 800000 * 1.25 + 15000);
     });
 
     it('retries estimating gas up to 3 times', async function () {
-      const stub = sinon.stub(web3.eth, 'estimateGas')
-      _.times(4, i => stub.onCall(i).yields(new Error('gas required exceeds allowance or always failing transaction'), null))
-      stub.yields(null, 800000)
+      const stub = sinon.stub(this.instance.initialize, 'estimateGas')
+      _.times(4, i => stub.onCall(i).throws('Error', 'gas required exceeds allowance or always failing transaction'))
+      stub.returns(800000)
 
       await sendTransaction(this.instance.initialize, [42, 'foo', [1,2,3]]).should.be.rejectedWith(/always failing transaction/);
     });


### PR DESCRIPTION
Fixes #297 and #441 

The problem was not related with dependencies as mentioned in #297, but with contract method calls when using `truffle-hdwallet-provider`. For some reason, `web3.eth.estimateGas` fails to execute in this specific case, but the `estimateGas` function from the method (i.e., `mycontract.myFunction.estimateGas`) doesn't.
