### PR TITLE
Corrected links to sub-sections of advanced.md that were removed.

### DIFF
--- a/packages/docs/docs/docs/erc20_onboarding.md
+++ b/packages/docs/docs/docs/erc20_onboarding.md
@@ -129,7 +129,7 @@ token metadata.
 
 _Initializers are the way to define constructor functionality for upgradeable contracts in ZeppelinOS. The `isInitializer`
 modifier will make sure your `initialize` method can only be called once in the whole lifetime of your contract. To
-read more about this, please go to the [following section](advanced.html#initializers-vs-constructors)_
+read more about this, please go to the [following section](proxies.md#the-constructor-caveat)_
 
 Notice that all the contracts from `openzeppelin-zos` have been adapted for ZeppelinOS compatibility, and should be the
 ones used when dealing with upgradeable contracts.

--- a/packages/docs/docs/docs/new_2.md
+++ b/packages/docs/docs/docs/new_2.md
@@ -42,7 +42,7 @@ Unfortunately, 2.x introduces breaking changes, so a project that was created us
 
 ## Changes to your contracts
 
-When it comes to Solidity code, there is nothing special you need to consider when using ZeppelinOS 2.x other than using initializers instead of constructors. For more info on this, see the ["Initializers vs constructors"](https://docs.zeppelinos.org/docs/advanced.html#initializers-vs-constructors) section of the documentation.
+When it comes to Solidity code, there is nothing special you need to consider when using ZeppelinOS 2.x other than using initializers instead of constructors. For more info on this, see the ["the constructor caveat"](proxies.md#the-constructor-caveat) section of the documentation.
 
 As with 1.x, ZeppelinOS 2.x will manage all upgradeability and package linking features without you having to use special Solidity syntax.
 

--- a/packages/docs/docs/docs/writing_contracts.md
+++ b/packages/docs/docs/docs/writing_contracts.md
@@ -8,7 +8,7 @@ When working with upgradeable contracts in ZeppelinOS, there are a few minor cav
 
 ## Initializers
 
-You can use your Solidity contracts in ZeppelinOS without any modifications, except for their _constructors_. Due to a requirement of the proxy-based upgradeability system, no constructors can be used in upgradeable contracts. You can read in-depth about the reasons behind this restriction [in the advanced topics section](advanced.md#initializers-vs-constructors).
+You can use your Solidity contracts in ZeppelinOS without any modifications, except for their _constructors_. Due to a requirement of the proxy-based upgradeability system, no constructors can be used in upgradeable contracts. You can read in-depth about the reasons behind this restriction [in the advanced topics section](proxies.md#the-constructor-caveat).
 
 This means that, when using a contract within ZeppelinOS, you need to change its constructor into a regular function, typically named `initialize`, where you run all the setup logic:
 
@@ -188,7 +188,7 @@ contract MyContract is Initializable {
 
 ## Modifying your contracts
 
-When writing new versions of your contracts, either due to new features or bugfixing, there is an additional restriction to observe: you cannot change the order in which the contract state variables are declared, nor their type. You can read more about the reasons behind this restriction [in the advanced topics section](advanced.md#preserving-the-storage-structure).
+When writing new versions of your contracts, either due to new features or bugfixing, there is an additional restriction to observe: you cannot change the order in which the contract state variables are declared, nor their type. You can read more about the reasons behind this restriction [in the proxies section](proxies.md).
 
 This means that if you have an initial contract that looks like this:
 

--- a/packages/docs/docs/website/versioned_docs/version-1.0.0/building.md
+++ b/packages/docs/docs/website/versioned_docs/version-1.0.0/building.md
@@ -28,7 +28,7 @@ contract MyContract is Migratable {
 }
 ```
 
-Notice that your sample contract has an `initialize` function instead of the standard constructor. This is a requirement of [the ZeppelinOS upgradeability system](advanced.md#initializers-vs-constructors).
+Notice that your sample contract has an `initialize` function instead of the standard constructor. This is a requirement of [ZeppelinOS initializer functions](proxies.md#the-constructor-caveat).
 
 Before deploying your upgradeable app to the network, you need to add your contract:
 

--- a/packages/docs/docs/website/versioned_docs/version-1.0.0/low_level_contract.md
+++ b/packages/docs/docs/website/versioned_docs/version-1.0.0/low_level_contract.md
@@ -9,7 +9,7 @@ original_id: low_level_contract
 
 > **Note**: for a fully working project with this example, see the [`examples/simple`](https://github.com/zeppelinos/zos-lib/tree/master/examples/simple) folder of the `zos-lib` repository.
 
-To develop an upgradeable smart contract, we need to create a simple [upgradeability proxy](https://blog.zeppelinos.org/proxy-patterns/). This is a [special contract](advanced.md#the-proxy-system) that will hold the storage of our upgradeable contract and redirect function calls to a `logic` contract, which we can update.
+To develop an upgradeable smart contract, we need to create a simple [upgradeability proxy](https://blog.zeppelinos.org/proxy-patterns/). This is a [special contract](proxies.md) that will hold the storage of our upgradeable contract and redirect function calls to a `logic` contract, which we can update.
 
 Let's walk through the following example to see how it works:
 
@@ -29,7 +29,7 @@ contract MyContract is Initializable {
 }
 ```
 
-Notice the `initialize` function. Most contracts require some sort of initialization function, but upgradeable contracts can't use constructors because the proxy won't be able to call them. This is why we need to use the [initializable pattern](advanced.md#initializers-vs-constructors) provided by `zos-lib`.
+Notice the `initialize` function. Most contracts require some sort of initialization function, but upgradeable contracts can't use constructors because the proxy won't be able to call them. This is why we need to use the [initializable pattern](proxies.md#the-constructor-caveat) provided by `zos-lib`.
 
 ### Deploy it
 
@@ -80,7 +80,7 @@ contract MyContract is Initializable {
 }
 ```
 
-> **Note**: when we update our logic contract's code, we can't change the proxy's [storage layout](advanced.md#preserving-the-storage-structure). This means we can't remove any previously existing state variables. We can, however, remove functions we don't want to use anymore.
+> **Note**: when we update our logic contract's code, we can't change the proxy's [storage layout](proxies.md#unstructured-storage-proxies). This means we can't remove any previously existing state variables. We can, however, remove functions we don't want to use anymore.
 
 ### Upgrade it
 


### PR DESCRIPTION
Fix #320 

Note that the issue just mentioned `#initializers-vs-constructors`, but this PR also fixes links to other sections of `advanced.md` that were moved to `proxies.md`:

- [x] `#initializers-vs-constructors`
- [x] `#the-proxy-system`
- [x] `#preserving-the-storage-structure`