### PR TITLE
Add default gasPrice to truffle.js blueprint.

### DIFF
--- a/packages/cli/src/models/truffle/blueprint.truffle.js
+++ b/packages/cli/src/models/truffle/blueprint.truffle.js
@@ -4,6 +4,7 @@ module.exports = {
       host: 'localhost',
       port: 9545,
       gas: 5000000,
+      gasPrice: 5e9,
       network_id: '*',
     }
   }


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/311.