### PR TITLE
Handle scientific notation in argument initializers

### DIFF
--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -122,6 +122,16 @@ contract('create script', function([_, owner]) {
       await assertProxy(this.networkFile, anotherContractAlias, { version, say: 'WithLibraryV1' });
     });
 
+    it('should initialize a proxy using scientific notation', async function() {
+      const proxy = await createProxy({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: ["20e10"], networkFile: this.networkFile });
+      (await proxy.value()).toString().should.be.eq('200000000000');
+    });
+
+    it('should initialize a proxy using large number on scientific notation', async function() {
+      const proxy = await createProxy({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: ["20e70"], networkFile: this.networkFile });
+      (await proxy.value()).toString().should.be.eq('2e+71');
+    });
+
     describe('warnings', function () {
       beforeEach('capturing log output', function () {
         this.logs = new CaptureLogs();

--- a/packages/lib/src/helpers/encodeCall.js
+++ b/packages/lib/src/helpers/encodeCall.js
@@ -4,6 +4,8 @@ import BN from 'bignumber.js'
 function formatValue(value) {
   if (typeof(value) === 'number' || BN.isBigNumber(value)) {
     return value.toString();
+  } else if (typeof(value) === 'string' && value.match(/\d+(\.\d+)?e(\+)?\d+/)) {
+    return (new BN(value)).toString(10);
   } else {
     return value;
   }


### PR DESCRIPTION
Apparently ethereumjs-abi is using a version of bignumber that fails to
properly parse a number of the form '20e10'. To workaround this, we
pre-parse all arguments, pass them through bignumber, and then send them
to the encode function.

Fixes #327