### PR TITLE
Review security warnings messages and capture them in docs

### DIFF
--- a/packages/cli/test/interface/ValidationLogger.test.js
+++ b/packages/cli/test/interface/ValidationLogger.test.js
@@ -24,12 +24,12 @@ contract('ValidationLogger', function() {
   describe('warnings', function () {
     it('logs delegate call', async function () {
       validationLogger().log({ hasDelegateCall: true });
-      this.logs.warns[0].should.match(/has a delegatecall/);
+      this.logs.warns[0].should.match(/delegatecall/);
     });
 
     it('logs selfdestruct', async function () {
       validationLogger().log({ hasSelfDestruct: true });
-      this.logs.warns[0].should.match(/has a selfdestruct/);
+      this.logs.warns[0].should.match(/selfdestruct/);
     });
 
     it('logs uninitialized contracts', async function () {
@@ -39,12 +39,12 @@ contract('ValidationLogger', function() {
     
     it('logs vars unchecked for storage layout', async function () {
       validationLogger().log({ storageUncheckedVars: [{ label: 'foo', contract: 'MyContract' }] });
-      this.logs.warns[0].should.match(/foo \(MyContract\) contain a struct or enum/);
+      this.logs.warns[0].should.match(/foo \(MyContract\) contains a struct or enum/);
     });
 
     it('logs when detecting initial values in fields declarations', async function () {
       validationLogger().log({ hasInitialValuesInDeclarations: true });
-      this.logs.warns[0].should.match(/has an initial value/);
+      this.logs.warns[0].should.match(/sets an initial value/);
     });
   });
 
@@ -56,12 +56,12 @@ contract('ValidationLogger', function() {
   
     it('reports inserted var', function () {
       compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithInsertedVar');
-      this.logs.errors[0].should.match(/New variable 'uint256 c' was added in contract StorageMockSimpleWithInsertedVar/);
+      this.logs.errors[0].should.match(/New variable 'uint256 c' was inserted in contract StorageMockSimpleWithInsertedVar/);
     });
   
     it('reports unshifted var', function () {
       compare('StorageMockSimpleOriginal', 'StorageMockSimpleWithUnshiftedVar');
-      this.logs.errors[0].should.match(/New variable 'uint256 c' was added in contract StorageMockSimpleWithUnshiftedVar/);
+      this.logs.errors[0].should.match(/New variable 'uint256 c' was inserted in contract StorageMockSimpleWithUnshiftedVar/);
     });
   
     it('reports appended var', function () {

--- a/packages/docs/docs/docs/writing_contracts.md
+++ b/packages/docs/docs/docs/writing_contracts.md
@@ -186,6 +186,16 @@ contract MyContract is Initializable {
 }
 ```
 
+## Potentially unsafe operations
+
+When working with upgradeable smart contracts, you will always interact with the contract instance, and never with the underlying logic contract. However, nothing prevents a malicious actor from sending transactions to the logic contract directly. This does not pose a threat, since any changes to the state of the logic contracts do not affect your contract instances, as the storage of the logic contracts is never used in your project.
+
+There is, however, an exception. If the direct call to the logic contract triggers a `selfdestruct` operation, then the logic contract will be destroyed, and all your contract instances will end up delegating all calls to an address without any code. This would effectively break all contract instances in your project.
+
+A similar effect can be achieved is the logic contract contains a `delegatecall` operation. If the contract can be made to `delegatecall` into a malicious contract that contains a `selfdestruct`, then the calling contract will be destroyed.
+
+As such, it is strongly recommended to avoid any usage of either `selfdestruct` or `delegatecall` in your contracts. If you need to include them, make absolutely sure they cannot be called by an attacker on an uninitialized logic contract.
+
 ## Modifying your contracts
 
 When writing new versions of your contracts, either due to new features or bugfixing, there is an additional restriction to observe: you cannot change the order in which the contract state variables are declared, nor their type. You can read more about the reasons behind this restriction [in the proxies section](proxies.md).
@@ -245,6 +255,29 @@ contract MyContract {
 }
 ```
 
+Keep in mind that if you rename a variable, then it will keep the same value as before after upgrading. This may be the desired behaviour if the new variable is semantically the same as the old one:
+
+```solidity
+contract MyContract {
+  uint256 private x;
+  string private z; // starts with the value from `y`
+}
+```
+
+And if you remove a variable from the end of the contract, note that the storage will not be cleared. A subsequent update that adds a new variable will cause that variable to read the leftover value from the deleted one.
+
+```solidity
+contract MyContract {
+  uint256 private x;
+}
+
+// Then upgraded to...
+
+contract MyContract {
+  uint256 private x;
+  string private z; // starts with the value from `y`
+}
+```
 
 Note that you may also be inadvertently changing the storage variables of your contract by changing its parent contracts. For instance, if you have the following contracts:
 
@@ -286,5 +319,6 @@ contract Base {
 ```
 
 Then the variable `base2` whould be assigned the slot that `child` had in the previous version. A workaround for this is to declare unused variables on base contracts that you may want to extend in the future, as a means of "reserving" those slots. Note that this trick does not involve increased gas usage.
+
 
 > Violating any of these storage layout restrictions will cause the upgraded version of the contract to have its storage values mixed up, and can lead to critical errors in your application.

--- a/packages/docs/docs/docs/writing_contracts.md
+++ b/packages/docs/docs/docs/writing_contracts.md
@@ -192,7 +192,7 @@ When working with upgradeable smart contracts, you will always interact with the
 
 There is, however, an exception. If the direct call to the logic contract triggers a `selfdestruct` operation, then the logic contract will be destroyed, and all your contract instances will end up delegating all calls to an address without any code. This would effectively break all contract instances in your project.
 
-A similar effect can be achieved is the logic contract contains a `delegatecall` operation. If the contract can be made to `delegatecall` into a malicious contract that contains a `selfdestruct`, then the calling contract will be destroyed.
+A similar effect can be achieved if the logic contract contains a `delegatecall` operation. If the contract can be made to `delegatecall` into a malicious contract that contains a `selfdestruct`, then the calling contract will be destroyed.
 
 As such, it is strongly recommended to avoid any usage of either `selfdestruct` or `delegatecall` in your contracts. If you need to include them, make absolutely sure they cannot be called by an attacker on an uninitialized logic contract.
 


### PR DESCRIPTION
Updates all validation messages from ValidationLogger to simplify them
and add links to documentation. Add to writing contracts doc info on any
validations missing.

Fixes #248