### PR TITLE
Fetch last proxy created event to handle recursive proxy creation

### DIFF
--- a/packages/lib/contracts/mocks/ProxyCreator.sol
+++ b/packages/lib/contracts/mocks/ProxyCreator.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.24;
+
+import "../application/App.sol";
+import "../Initializable.sol";
+
+contract ProxyCreator is Initializable {
+
+  address public created;
+
+  function initialize(App app, string packageName, string contractName, bytes data) public initializer {
+    created = app.create(packageName, contractName, data);
+  }
+
+  function name() public pure returns (string) {
+    return "ProxyCreator";
+  }
+
+}

--- a/packages/lib/src/app/App.js
+++ b/packages/lib/src/app/App.js
@@ -1,5 +1,7 @@
 'use strict'
 
+import _ from 'lodash'
+
 import Logger from '../utils/Logger'
 import decodeLogs from '../helpers/decodeLogs'
 import copyContract from '../helpers/copyContract'
@@ -100,7 +102,7 @@ export default class App {
 
     log.info(`TX receipt received: ${receipt.transactionHash}`)
     const logs = decodeLogs(receipt.logs, this.constructor.getContractClass())
-    const address = logs.find(l => l.event === 'ProxyCreated').args.proxy
+    const address = _.findLast(logs, l => l.event === 'ProxyCreated').args.proxy
     log.info(`${packageName} ${contractName} proxy: ${address}`)
     return new contractClass(address)
   }


### PR DESCRIPTION
Note that this still leaves the issue that any proxies created from
within a contract will **not** be tracked by the CLI, and will need to
be manually updated.

Fixes #366