### PR TITLE
Add solidity syntax highlighter to docs

### DIFF
--- a/packages/docs/docs/website/package-lock.json
+++ b/packages/docs/docs/website/package-lock.json
@@ -1901,6 +1901,11 @@
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
       "dev": true
     },
+    "highlightjs-solidity": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.6.tgz",
+      "integrity": "sha512-NzdwI5gX+8H3z/YEXk01dKOY0QuffhNkUZw9umHUCXlzKB+1n2SexTTZpSGAmZYetHT/bccCm+3QqBULtTLmdA=="
+    },
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",

--- a/packages/docs/docs/website/package.json
+++ b/packages/docs/docs/website/package.json
@@ -9,6 +9,7 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.0.7"
+    "docusaurus": "^1.0.7",
+    "highlightjs-solidity": "^1.0.6"
   }
 }

--- a/packages/docs/docs/website/siteConfig.js
+++ b/packages/docs/docs/website/siteConfig.js
@@ -43,6 +43,9 @@ const siteConfig = {
   // gaTrackingId: 'UA-85043059-1',
   highlight: {
     theme: 'default',
+    hljs: function(hljs) {
+      require('highlightjs-solidity')(hljs);
+    }
   },
   scripts: ['https://buttons.github.io/buttons.js'],
   stylesheets: [


### PR DESCRIPTION
Added https://github.com/pospi/highlightjs-solidity as suggested in the issue. The end result looks like this:

![screenshot from 2018-10-26 11-33-18](https://user-images.githubusercontent.com/429604/47558469-7ed08180-d913-11e8-8319-eaf8667e061a.png)

We can still make more improvements by playing with themes (see the Styles section in the [demo page](https://highlightjs.org/static/demo/)). I'll loop in @blancoagostina to discuss that.

Fixes #341