### PR TITLE
Remove whitespace from beginning of testing .md

### DIFF
--- a/packages/docs/docs/docs/testing.md
+++ b/packages/docs/docs/docs/testing.md
@@ -1,5 +1,4 @@
-
-  ---
+---
 id: testing
 title: Testing upgradeable projects
 ---


### PR DESCRIPTION
There was a whitespace at the beginning of the `testing.md` section that was causing trouble when trying to build the doc site (notice that the latest deploy does not have this section updated). I'm redeploying after merging this PR.