### PR TITLE
Add Etherscan as remote verification application for 'verify' command

### DIFF
--- a/packages/cli/src/commands/verify.js
+++ b/packages/cli/src/commands/verify.js
@@ -14,6 +14,7 @@ const register = program => program
   .option('-o, --optimizer', 'enables optimizer option')
   .option('--optimizer-runs <runs>', 'specify number of runs if optimizer enabled.')
   .option('--remote <remote>', 'specify remote endpoint to use for verification')
+  .option('--api-key <key>', 'specify etherscan API key')
   .action(action);
 
 

--- a/packages/cli/src/commands/verify.js
+++ b/packages/cli/src/commands/verify.js
@@ -14,7 +14,7 @@ const register = program => program
   .option('-o, --optimizer', 'enables optimizer option')
   .option('--optimizer-runs <runs>', 'specify number of runs if optimizer enabled.')
   .option('--remote <remote>', 'specify remote endpoint to use for verification')
-  .option('--api-key <key>', 'specify etherscan API key')
+  .option('--api-key <key>', 'specify etherscan API key. To get one, go to: https://etherscancom.freshdesk.com/support/solutions/articles/35000022163-i-need-an-api-key')
   .action(action);
 
 

--- a/packages/cli/src/models/Verifier.js
+++ b/packages/cli/src/models/Verifier.js
@@ -9,13 +9,18 @@ const Verifier = {
   async verifyAndPublish(remote, params) {
     if (remote === 'etherchain') {
       await publishToEtherchain(params)
+    } else if (remote === 'etherscan') {
+      await publishToEtherscan(params)
     } else {
-      throw new Error('Invalid remote. Currently, ZeppelinOS contract verifier only supports etherchain as remote verification application.')
+      throw new Error('Invalid remote. Currently, ZeppelinOS contract verifier supports etherchain(mainnet only) and etherscan as remote verification applications.')
     }
   }
 }
 
 async function publishToEtherchain(params) {
+  if(params.network !== 'mainnet')
+    throw new Error('Invalid network. Currently, etherchain supports only mainnet')
+  
   const etherchainVerificationUrl = 'https://www.etherchain.org/tools/verifyContract'
   const etherchainContractUrl = 'https://www.etherchain.org/account'
   const { compilerVersion, optimizer, contractAddress } = params
@@ -44,6 +49,105 @@ async function publishToEtherchain(params) {
     }
   } catch(error) {
     throw Error(error.message || 'Error while trying to publish contract')
+  }
+}
+
+async function publishToEtherscan(params) {
+  if (params.apiKey === undefined) {
+    throw new Error('API key not specified.')
+  }
+
+  const { network, compilerVersion, optimizer, contractAddress } = params
+  const compiler = `v${compilerVersion.replace('.Emscripten.clang', '')}`
+  const optimizerStatus = optimizer ? 1 : 0
+
+  let apiSubdomain = ''
+
+  if (network === 'mainnet') {
+    apiSubdomain = 'api'
+  } else if (network === 'rinkeby') {
+    apiSubdomain = 'api-rinkeby'
+  } else if (network === 'ropsten') {
+    apiSubdomain = 'api-ropsten'
+  } else if (network === 'kovan') {
+    apiSubdomain = 'api-kovan'
+  } else {
+    throw new Error('Invalid network. Currently, etherscan supports mainnet, rinkeby, ropsten and kovan')
+  }
+
+  const etherscanApiUrl = `https://${apiSubdomain}.etherscan.io/api`
+  const etherscanContractUrl = `https://${network}.etherscan.io/address`
+
+  const checkVerificationStatus = async (guid) => {
+    const queryParams = querystring.stringify({
+      guid,
+      action: 'checkverifystatus',
+      module: 'contract',
+    })
+
+    try {
+      const response = await axios.request({
+        method: 'GET',
+        url: `${etherscanApiUrl}?${queryParams}`,
+      })
+
+      if (response.status === 200) {
+        if (response.data.status === '1') {
+          return true
+        } else {
+          return false
+        }
+      } else {
+        throw new Error(`Error while trying to verify contract; ${response.data.status}; ${response.data.message}; ${response.data.result}`)
+      }
+    } catch(error) {
+      throw new Error(error.message || 'Error while trying to check verification status')
+    } 
+  }
+
+  try {
+    const response = await axios.request({
+      method: 'POST',
+      url: etherscanApiUrl,
+      data: querystring.stringify({
+        apikey: params.apiKey,
+        module: 'contract',
+        action: 'verifysourcecode',
+        contractaddress: contractAddress,
+        sourceCode: params.contractSource,
+        contractname: params.contractName,
+        compilerversion: compiler,
+        optimizationUsed: optimizerStatus,
+        runs: params.optimizerRuns,
+      }),
+      headers: {
+        'Content-type': 'application/x-www-form-urlencoded'
+      }
+    })
+    if (response.status === 200 && response.data.status === '1') {
+      log.info(`Contract verification in process(this is usually under 30 seconds)...\nGUID: ${response.data.result}`)
+
+      await new Promise((resolve, reject) => {
+        const checkIntervalId = setInterval(async () => {
+          const verificationStatus = await checkVerificationStatus(response.data.result)
+
+          if (verificationStatus === false) {
+            return
+          }
+
+          log.info(`Contract verified successfully. You can check it here: ${etherscanContractUrl}/${contractAddress}#code`)
+
+          clearInterval(checkIntervalId)
+
+          resolve()
+        }, 3000)
+      })
+    } else {
+      throw new Error(`Error while trying to verify contract; ${response.data.status}; ${response.data.message}; ${response.data.result}`)
+    }
+
+  } catch(error) {
+    throw new Error(error.message || 'Error while trying to verify contract')
   }
 }
 

--- a/packages/cli/src/models/network/NetworkBaseController.js
+++ b/packages/cli/src/models/network/NetworkBaseController.js
@@ -324,14 +324,14 @@ export default class NetworkBaseController {
     return !this.isLocalContract(contractAlias) || this.networkFile.hasContract(contractAlias);
   }
 
-  async verifyAndPublishContract(contractAlias, optimizer, optimizerRuns, remote) {
+  async verifyAndPublishContract(contractAlias, optimizer, optimizerRuns, remote, apiKey) {
     const contractName = this.packageFile.contract(contractAlias)
     const { compilerVersion, sourcePath } = this.localController.getContractSourcePath(contractAlias)
     const contractSource = await flattenSourceCode([sourcePath])
     const contractAddress = this.networkFile.contracts[contractAlias].address
     log.info(`Verifying and publishing ${contractAlias} on ${remote}`)
 
-    await Verifier.verifyAndPublish(remote, { contractName, compilerVersion, optimizer, optimizerRuns, contractSource, contractAddress })
+    await Verifier.verifyAndPublish(remote, { contractName, compilerVersion, optimizer, optimizerRuns, contractSource, contractAddress, apiKey, network: this.network })
   }
 
   writeNetworkPackageIfNeeded() {

--- a/packages/cli/src/scripts/verify.js
+++ b/packages/cli/src/scripts/verify.js
@@ -1,6 +1,9 @@
 import ControllerFor from '../models/network/ControllerFor'
 
 export default async function verify(contractAlias, { network = 'mainnet', txParams = {}, networkFile = undefined, optimizer = false, optimizerRuns = 200, remote = 'etherchain', apiKey = undefined }) {
+  if (remote === 'etherscan' && !apiKey) {
+    throw new Error('Etherscan API key not specified. To get one, follow this link: https://etherscancom.freshdesk.com/support/solutions/articles/35000022163-i-need-an-api-key')
+  }
   const controller = ControllerFor(network, txParams, networkFile)
   controller.checkLocalContractDeployed(contractAlias, true)
   await controller.verifyAndPublishContract(contractAlias, optimizer, optimizerRuns, remote, apiKey)

--- a/packages/cli/src/scripts/verify.js
+++ b/packages/cli/src/scripts/verify.js
@@ -1,7 +1,7 @@
 import ControllerFor from '../models/network/ControllerFor'
 
-export default async function verify(contractAlias, { network = 'mainnet', txParams = {}, networkFile = undefined, optimizer = false, optimizerRuns = 200, remote = 'etherchain' }) {
+export default async function verify(contractAlias, { network = 'mainnet', txParams = {}, networkFile = undefined, optimizer = false, optimizerRuns = 200, remote = 'etherchain', apiKey = undefined }) {
   const controller = ControllerFor(network, txParams, networkFile)
   controller.checkLocalContractDeployed(contractAlias, true)
-  await controller.verifyAndPublishContract(contractAlias, optimizer, optimizerRuns, remote)
+  await controller.verifyAndPublishContract(contractAlias, optimizer, optimizerRuns, remote, apiKey)
 }

--- a/packages/cli/src/utils/sleep.js
+++ b/packages/cli/src/utils/sleep.js
@@ -1,0 +1,6 @@
+'use strict'
+
+export default function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+

--- a/packages/cli/test/scripts/verify.test.js
+++ b/packages/cli/test/scripts/verify.test.js
@@ -60,6 +60,8 @@ contract('verify script', function () {
   })
 
   describe('contract verification', function () {
+    const network = 'mainnet'
+
     beforeEach(async function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
       this.networkFile = this.packageFile.networkFile(network)
@@ -77,21 +79,44 @@ contract('verify script', function () {
       await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'invalid-remote' }, /Invalid remote/)
     })
 
-    it('throws error if specifying anything but mainnet as a network for etherchain', async function() {
-      await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' }, /Invalid network/)
-    })
-    
-    /*it('throws error if contract could not be verified on etherchain', async function () {
-      this.axiosStub.returns({ status: 200, data: '<div id="infoModal"><div class="modal-body"> Error: </div></div>' })
-      await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' }, /Error/)
+    describe('against etherscan', function() {
+      it('throws error if not specifying api key option', async function() {
+        await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherscan' }, /Etherscan API key not specified/)
+      })
+
+      it('throws error if contract could not be verified', async function() {
+        this.axiosStub.returns({ status: 200, data: { status: '0', result: 'Something went wrong' } })
+        await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherscan', apiKey: 'AP1_k3Y' }, /Error/)
+      })
+
+      it('logs a success info message when contract is verified', async function() {
+        this.axiosStub.onCall(0).returns({ status: 200, data: { status: '1', result: 'GU1D_NUMB3R' } })
+        this.axiosStub.onCall(1).returns({ status: 200, data: { status: '1' } })
+        await verify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' })
+        this.logs.infos.should.have.lengthOf(3)
+        this.logs.infos[0].should.match(/Verifying and publishing/)
+        this.logs.infos[1].should.match(/Contract verification in process/)
+        this.logs.infos[2].should.match(/Contract verified successfully/)
+      })
     })
 
-    it('logs a success info message when contract is verified', async function () {
-      this.axiosStub.returns({ status: 200, data: '<div id="infoModal"><div class="modal-body"> successful </div></div>' })
-      await verify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' })
-      this.logs.infos.should.have.lengthOf(2)
-      this.logs.infos[0].should.match(/Verifying and publishing/)
-      this.logs.infos[1].should.match(/Contract verified and published successfully. You can check it here/)
-    })*/
+    describe('against etherchain', function() {
+      it('throws error if specifying anything but mainnet as a network', async function() {
+        await assertVerify(contractAlias, { network: 'test', networkFile: this.networkFile, remote: 'etherchain' }, /Invalid network/)
+      })
+
+      it('throws error if contract could not be verified', async function () {
+        this.axiosStub.returns({ status: 200, data: '<div id="infoModal"><div class="modal-body"> Error: </div></div>' })
+        await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' }, /Error/)
+      })
+
+      it('logs a success info message when contract is verified', async function () {
+        this.axiosStub.returns({ status: 200, data: '<div id="infoModal"><div class="modal-body"> successful </div></div>' })
+        await verify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' })
+        this.logs.infos.should.have.lengthOf(2)
+        this.logs.infos[0].should.match(/Verifying and publishing/)
+        this.logs.infos[1].should.match(/Contract verified and published successfully. You can check it here/)
+      })
+    })
   })
 })

--- a/packages/cli/test/scripts/verify.test.js
+++ b/packages/cli/test/scripts/verify.test.js
@@ -92,7 +92,7 @@ contract('verify script', function () {
       it('logs a success info message when contract is verified', async function() {
         this.axiosStub.onCall(0).returns({ status: 200, data: { status: '1', result: 'GU1D_NUMB3R' } })
         this.axiosStub.onCall(1).returns({ status: 200, data: { status: '1' } })
-        await verify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' })
+        await verify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherscan', apiKey: 'AP1_k3Y' })
         this.logs.infos.should.have.lengthOf(3)
         this.logs.infos[0].should.match(/Verifying and publishing/)
         this.logs.infos[1].should.match(/Contract verification in process/)

--- a/packages/cli/test/scripts/verify.test.js
+++ b/packages/cli/test/scripts/verify.test.js
@@ -77,7 +77,11 @@ contract('verify script', function () {
       await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'invalid-remote' }, /Invalid remote/)
     })
 
-    it('throws error if contract could not be verified', async function () {
+    it('throws error if specifying anything but mainnet as a network for etherchain', async function() {
+      await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' }, /Invalid network/)
+    })
+    
+    /*it('throws error if contract could not be verified on etherchain', async function () {
       this.axiosStub.returns({ status: 200, data: '<div id="infoModal"><div class="modal-body"> Error: </div></div>' })
       await assertVerify(contractAlias, { network, networkFile: this.networkFile, remote: 'etherchain' }, /Error/)
     })
@@ -88,6 +92,6 @@ contract('verify script', function () {
       this.logs.infos.should.have.lengthOf(2)
       this.logs.infos[0].should.match(/Verifying and publishing/)
       this.logs.infos[1].should.match(/Contract verified and published successfully. You can check it here/)
-    })
+    })*/
   })
 })


### PR DESCRIPTION
Related to https://github.com/zeppelinos/zos/issues/251

Etherscan works with apikey, so this update also add --api-key option to verify command. Example:
`zos verify --remote etherscan --api-key <api key> -n rinkeby <contract name>`