### PR TITLE
Fix BigNumber promise call in doc site example

### DIFF
--- a/packages/docs/docs/docs/upgrading.md
+++ b/packages/docs/docs/docs/upgrading.md
@@ -73,7 +73,7 @@ by the `create` command we ran above._
 
 ```console
 truffle(local)> myContract = MyContract.at('<your-contract-address>')
-truffle(local)> myContract.x().then((num)=> num.toString())
+truffle(local)> myContract.x().then(x => x.toString())
 '42'
 
 truffle(local)> myContract.s()

--- a/packages/docs/docs/docs/upgrading.md
+++ b/packages/docs/docs/docs/upgrading.md
@@ -73,8 +73,8 @@ by the `create` command we ran above._
 
 ```console
 truffle(local)> myContract = MyContract.at('<your-contract-address>')
-truffle(local)> myContract.x().toString()
-42
+truffle(local)> myContract.x().then((num)=> num.toString())
+'42'
 
 truffle(local)> myContract.s()
 "hitchhiker"

--- a/packages/docs/docs/website/versioned_docs/version-2.0.0/upgrading.md
+++ b/packages/docs/docs/website/versioned_docs/version-2.0.0/upgrading.md
@@ -74,7 +74,7 @@ by the `create` command we ran above._
 
 ```console
 truffle(local)> myContract = MyContract.at('<your-contract-address>')
-truffle(local)> myContract.x().toString()
+truffle(local)> myContract.x().then(x => x.toString())
 42
 
 truffle(local)> myContract.s()


### PR DESCRIPTION
myContract.x().toString() does not return a number, it returns a promise object. 
myContract.x().toString() returns a pending promise: '[object Promise]'
myContract.x() returns a bigNumber object: BigNumber { s: 1, e: 1, c: [ 42 ] }
To return a string format of the returned promise object we need: 
myContract.x().then((num)=> num.toString()) will return '42'