### PR TITLE
This process does not work with ZOS

### DIFF
--- a/packages/docs/docs/docs/mainnet.md
+++ b/packages/docs/docs/docs/mainnet.md
@@ -23,7 +23,9 @@ module.exports = {
     mainnet: {
       provider: function() {
         return new HDWalletProvider(mnemonic, "https://mainnet.infura.io/<INFURA_Access_Token>")
-      },
+      },      
+      gas: 5000000,
+      gasPrice: 5e9,
       network_id: 1
     }
   }
@@ -44,6 +46,7 @@ And now you can run `zos` commands in mainnet. For example:
 ```console
 zos push --network mainnet
 ```
+
 
 This will use your first account generated from the mnemonic. If you want to
 specify a different account, use the `--from` flag.


### PR DESCRIPTION
Attempting to deploy (and EVM package) using zos following the mainnet recomendations as listed here fails with the error: 

Cowardly refusing to execute transaction with excessively high default gas price of 100 gwei. Consider explicitly setting a different gasPrice value in your truffle.js config file. You can check reasonable values for gas price in https://ethgasstation.info/.

We need to set the gas value and gas price. I added an example above, however this is not always enough either and can fail with either: 

ProviderError: insufficient funds for gas * price + value

or

Error: Contract transaction couldn't be found after 50 blocks

or

Error: ProviderError: gas required exceeds allowance or always failing transaction

They contract may still be deployed however in the case of the final error example.