### PR TITLE
Updated OpenZeppelin to v2.0.

### DIFF
--- a/packages/lib/contracts/application/ImplementationDirectory.sol
+++ b/packages/lib/contracts/application/ImplementationDirectory.sol
@@ -2,13 +2,15 @@ pragma solidity ^0.4.24;
 
 import "./ImplementationProvider.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import 'openzeppelin-solidity/contracts/AddressUtils.sol';
+import 'openzeppelin-solidity/contracts/utils/Address.sol';
 
 /**
  * @title ImplementationDirectory
  * @dev Implementation provider that stores contract implementations in a mapping.
  */
 contract ImplementationDirectory is ImplementationProvider, Ownable {
+  using Address for address;
+
   /**
    * @dev Emitted when the implementation of a contract is changed.
    * @param contractName Name of the contract.
@@ -59,7 +61,7 @@ contract ImplementationDirectory is ImplementationProvider, Ownable {
    * @param implementation Address of the implementation.
    */
   function setImplementation(string contractName, address implementation) public onlyOwner whenNotFrozen {
-    require(AddressUtils.isContract(implementation), "Cannot set implementation in directory with a non-contract address");
+    require(implementation.isContract(), "Cannot set implementation in directory with a non-contract address");
     implementations[contractName] = implementation;
     emit ImplementationChanged(contractName, implementation);
   }

--- a/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
 import './Proxy.sol';
-import 'openzeppelin-solidity/contracts/AddressUtils.sol';
+import 'openzeppelin-solidity/contracts/utils/Address.sol';
 
 /**
  * @title UpgradeabilityProxy
@@ -10,6 +10,8 @@ import 'openzeppelin-solidity/contracts/AddressUtils.sol';
  * Such a change is called an implementation upgrade.
  */
 contract UpgradeabilityProxy is Proxy {
+  using Address for address;
+
   /**
    * @dev Emitted when the implementation is upgraded.
    * @param implementation Address of the new implementation.
@@ -64,7 +66,7 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation Address of the new implementation.
    */
   function _setImplementation(address newImplementation) private {
-    require(AddressUtils.isContract(newImplementation), "Cannot set a proxy implementation to a non-contract address");
+    require(newImplementation.isContract(), "Cannot set a proxy implementation to a non-contract address");
 
     bytes32 slot = IMPLEMENTATION_SLOT;
 

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -6300,9 +6300,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.0.0.tgz",
+      "integrity": "sha512-SolpxQFArtiYnlSNg3dZ9sz0WVlKtPqSOcJkXRllaZp4+Lpfqz3vxF0yoh7g75TszKPyadqoJmU7+GM/vwh9SA=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -41,7 +41,7 @@
     "chalk": "^2.4.1",
     "ethereumjs-abi": "^0.6.5",
     "glob": "^7.1.3",
-    "openzeppelin-solidity": "~1.10.0",
+    "openzeppelin-solidity": "^2.0.0",
     "semver": "^5.5.1",
     "truffle-flattener": "^1.2.8",
     "web3": "^0.18.4"


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/565

OpenZeppelin 2.0 has been audited and has a stable API, so migrating early to the 2.x branch will prevent future upgrade issues.