### PR TITLE
Fix ethgasstation HTTP response handling

### DIFF
--- a/packages/lib/src/utils/Transactions.js
+++ b/packages/lib/src/utils/Transactions.js
@@ -166,8 +166,8 @@ async function getETHGasStationPrice() {
   if (state.gasPrice) return state.gasPrice;
 
   try {
-    const apiResponse = await axios.get(GAS_API_URL);
-    const gasPriceGwei = apiResponse.average / 10;
+    const { data: responseData } = await axios.get(GAS_API_URL);
+    const gasPriceGwei = responseData.average / 10;
     const gasPrice = gasPriceGwei * 1e9;
 
     state.gasPrice = gasPrice;

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -74,13 +74,13 @@ contract('Transactions', function([_account1, account2]) {
       await assertGasLt(tx, 1000000);
     });
 
-    describe('Uses an API to determine gas price', async function() {
-      beforeEach('Stub API reply and simulate mainnet', async function() {
+    describe('uses an API to determine gas price', async function() {
+      beforeEach('stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
         sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
       });
 
-      afterEach('Return to testnet and undo stub', async function() {
+      afterEach('return to testnet and undo stub', async function() {
         delete state.gasPrice;
         sinon.restore();
       });
@@ -98,18 +98,18 @@ contract('Transactions', function([_account1, account2]) {
       });
     });
 
-    describe('Does not blindly trust API', async function() {
+    describe('does not blindly trust API', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
         sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
       });
 
-      afterEach('Return to testnet and undo stub', async function() {
+      afterEach('return to testnet and undo stub', async function() {
         delete state.gasPrice;
         sinon.restore();
       });
 
-      it('Produces an error when gas price API gives giant value', async function () {
+      it('produces an error when gas price API gives giant value', async function () {
         await sendTransaction(this.instance.initialize, [42, 'foo', [1,2,3]]).should.be.rejectedWith(/is over 100 gwei/);
       });
     });
@@ -164,13 +164,13 @@ contract('Transactions', function([_account1, account2]) {
       await assertGasLt(tx, 1000000);
     });
 
-    describe('Uses an API to determine gas price', async function() {
+    describe('uses an API to determine gas price', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
         sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
       });
 
-      afterEach('Return to testnet and undo stub', async function() {
+      afterEach('return to testnet and undo stub', async function() {
         delete state.gasPrice;
         sinon.restore();
       });
@@ -188,8 +188,8 @@ contract('Transactions', function([_account1, account2]) {
       });
     });
 
-    describe('Does not blindly trust API', async function() {
-      beforeEach('Stub API reply and simulate mainnet', async function() {
+    describe('does not blindly trust API', async function() {
+      beforeEach('stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
         sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
       });
@@ -199,7 +199,7 @@ contract('Transactions', function([_account1, account2]) {
         sinon.restore();
       });
 
-      it('Produces an error when gas price API gives giant value', async function () {
+      it('produces an error when gas price API gives giant value', async function () {
         await sendDataTransaction(this.instance, { data: this.encodedCall }).should.be.rejectedWith(/is over 100 gwei/);
       });
     });
@@ -232,8 +232,8 @@ contract('Transactions', function([_account1, account2]) {
         await assertGasLt(instance.transactionHash, 1000000);
       });
 
-      describe('Uses an API to determine gas price', async function() {
-        beforeEach('Stub API reply and simulate mainnet', async function() {
+      describe('uses an API to determine gas price', async function() {
+        beforeEach('stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
           sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
@@ -256,8 +256,8 @@ contract('Transactions', function([_account1, account2]) {
         });
       });
 
-      describe('Does not blindly trust API', async function() {
-        beforeEach('Stub API reply and simulate mainnet', async function() {
+      describe('does not blindly trust API', async function() {
+        beforeEach('stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
           sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });
@@ -300,8 +300,8 @@ contract('Transactions', function([_account1, account2]) {
         await assertGasLt(instance.transactionHash, 1000000);
       });
 
-      describe('Uses an API to determine gas price', async function() {
-        beforeEach('Stub API reply and simulate mainnet', async function() {
+      describe('uses an API to determine gas price', async function() {
+        beforeEach('stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
           sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
@@ -324,8 +324,8 @@ contract('Transactions', function([_account1, account2]) {
         });
       });
 
-      describe('Does not blindly trust API', async function() {
-        beforeEach('Stub API reply and simulate mainnet', async function() {
+      describe('does not blindly trust API', async function() {
+        beforeEach('stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
           sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -77,7 +77,7 @@ contract('Transactions', function([_account1, account2]) {
     describe('Uses an API to determine gas price', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-        sinon.stub(axios, 'get').resolves({ average: 49 })
+        sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
       });
 
       afterEach('Return to testnet and undo stub', async function() {
@@ -101,7 +101,7 @@ contract('Transactions', function([_account1, account2]) {
     describe('Does not blindly trust API', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-        sinon.stub(axios, 'get').resolves({ average: 1234123412341234 })
+        sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
       });
 
       afterEach('Return to testnet and undo stub', async function() {
@@ -167,7 +167,7 @@ contract('Transactions', function([_account1, account2]) {
     describe('Uses an API to determine gas price', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-        sinon.stub(axios, 'get').resolves({ average: 49 })
+        sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
       });
 
       afterEach('Return to testnet and undo stub', async function() {
@@ -191,7 +191,7 @@ contract('Transactions', function([_account1, account2]) {
     describe('Does not blindly trust API', async function() {
       beforeEach('Stub API reply and simulate mainnet', async function() {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-        sinon.stub(axios, 'get').resolves({ average: 1234123412341234 })
+        sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
       });
 
       afterEach('Return to testnet and undo stub', async function() {
@@ -235,7 +235,7 @@ contract('Transactions', function([_account1, account2]) {
       describe('Uses an API to determine gas price', async function() {
         beforeEach('Stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-          sinon.stub(axios, 'get').resolves({ average: 49 })
+          sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
 
         afterEach('Return to testnet and undo stub', async function() {
@@ -259,7 +259,7 @@ contract('Transactions', function([_account1, account2]) {
       describe('Does not blindly trust API', async function() {
         beforeEach('Stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-          sinon.stub(axios, 'get').resolves({ average: 1234123412341234 })
+          sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });
 
         afterEach('Return to testnet and undo stub', async function() {
@@ -303,7 +303,7 @@ contract('Transactions', function([_account1, account2]) {
       describe('Uses an API to determine gas price', async function() {
         beforeEach('Stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-          sinon.stub(axios, 'get').resolves({ average: 49 })
+          sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
 
         afterEach('Return to testnet and undo stub', async function() {
@@ -327,7 +327,7 @@ contract('Transactions', function([_account1, account2]) {
       describe('Does not blindly trust API', async function() {
         beforeEach('Stub API reply and simulate mainnet', async function() {
           sinon.stub(ZWeb3, 'isMainnet').resolves(true)
-          sinon.stub(axios, 'get').resolves({ average: 1234123412341234 })
+          sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });
 
         afterEach('Return to testnet and undo stub', async function() {


### PR DESCRIPTION
We are requesting Ethgasstation's API to get a recommended `gas price` value for mainnet transactions, but the HTTP response is not being properly handled. This PR fixes that and updates the test suite.