### PR TITLE
Add tests to verify command and fix initializer call.

### DIFF
--- a/packages/cli/src/commands/verify.js
+++ b/packages/cli/src/commands/verify.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import _ from 'lodash'
 import verify from '../scripts/verify'
 import Initializer from '../models/initializer/Initializer'
 
@@ -19,12 +20,13 @@ const register = program => program
 
 
 async function action(contractAlias, options) {
-  const { optimizer, optimizerRuns } = options
+  const { optimizer, optimizerRuns, remote, apiKey } = options
   if (optimizer && !optimizerRuns) {
     throw new Error('Cannot verify contract without defining optimizer runs')
   }
-  const { network, txParams } = await Initializer.init(options)
-  await verify(contractAlias, { ...options, network, txParams })
+  const { network, txParams } = await Initializer.call(options)
+  const opts = _.pickBy({ optimizer, optimizerRuns, remote, apiKey, network, txParams })
+  await verify(contractAlias, { optimizer, optimizerRuns, remote, apiKey, network, txParams })
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0)
 }
 

--- a/packages/cli/test/commands/verify.test.js
+++ b/packages/cli/test/commands/verify.test.js
@@ -1,12 +1,14 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share'
 
 contract('verify command', function() {
-
   stubCommands()
-  
-  // TODO: Add tests for verify command
+
+  itShouldParse('calls verify with options', 'verify', 'zos verify Impl --network rinkeby --remote etherscan --optimizer --optimizer-runs 150 --api-key AP1-K3Y', function(verify) {
+    const args = { optimizer: true, optimizerRuns: '150', apiKey: 'AP1-K3Y', remote: 'etherscan', network: 'rinkeby', txParams: {} }
+    verify.should.have.been.calledWithExactly('Impl', args)
+  })
 
 })


### PR DESCRIPTION
- Add a simple test case for the `verify` command
- Take only necessary attributes from `commander.js` options
- Change `Initializer.init()` in favour of `Initializer.call()`