### PR TITLE
Addes typed dependencies to the lib package

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -170,7 +170,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -233,7 +233,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -455,12 +455,12 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-flow": {
@@ -937,7 +937,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
         "babel-core": "^6.0.14",
@@ -1040,7 +1040,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -1302,7 +1302,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1314,7 +1314,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1359,7 +1359,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -1453,7 +1453,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -1620,7 +1620,7 @@
     },
     "eth-json-rpc-middleware": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
       "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
       "requires": {
         "async": "^2.5.0",
@@ -1755,7 +1755,7 @@
         },
         "ethereumjs-vm": {
           "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+          "resolved": "http://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
           "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
           "requires": {
             "async": "^2.1.2",
@@ -1809,7 +1809,7 @@
         },
         "web3-provider-engine": {
           "version": "13.8.0",
-          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+          "resolved": "http://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
           "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
           "requires": {
             "async": "^2.5.0",
@@ -1909,7 +1909,7 @@
     },
     "ethereumjs-block": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
         "async": "^2.0.1",
@@ -2098,7 +2098,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
@@ -2227,7 +2227,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2289,12 +2289,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2309,17 +2311,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2436,7 +2441,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2448,6 +2454,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2462,6 +2469,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2573,7 +2581,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2585,6 +2594,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2706,6 +2716,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3033,7 +3044,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -3297,12 +3308,12 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -3381,7 +3392,7 @@
     },
     "level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
         "inherits": "^2.0.1",
@@ -3397,7 +3408,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3408,7 +3419,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -3434,7 +3445,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3445,7 +3456,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "xtend": {
@@ -3481,7 +3492,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -3697,12 +3708,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3890,7 +3901,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -3906,7 +3917,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "output-file-sync": {
@@ -3995,7 +4006,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -4032,7 +4043,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -4267,7 +4278,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
         "regenerate": "^1.2.1",
@@ -4277,12 +4288,12 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -4462,7 +4473,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -4644,7 +4655,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -4731,13 +4742,13 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -5146,7 +5157,7 @@
     },
     "utf8": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
       "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
     "util-deprecate": {
@@ -5189,7 +5200,7 @@
     },
     "web3": {
       "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+      "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
@@ -5263,7 +5274,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
@@ -5288,7 +5299,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1051,6 +1051,23 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "browserify-sha3": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
+      "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+      "dev": true,
+      "requires": {
+        "js-sha3": "^0.3.1"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+          "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+          "dev": true
+        }
+      }
+    },
     "browserslist": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
@@ -1669,6 +1686,16 @@
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -1890,11 +1917,28 @@
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "dev": true,
       "requires": {
         "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
       }
     },
     "ethereumjs-account": {
@@ -2289,14 +2333,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2311,20 +2353,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2441,8 +2480,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2454,7 +2492,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2469,7 +2506,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2581,8 +2617,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2594,7 +2629,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2716,7 +2750,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3350,6 +3383,16 @@
         "inherits": "^2.0.3",
         "nan": "^2.2.1",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "keccakjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
+      "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+      "dev": true,
+      "requires": {
+        "browserify-sha3": "^0.0.1",
+        "sha3": "^1.1.0"
       }
     },
     "kind-of": {
@@ -4478,6 +4521,15 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+      "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+      "dev": true,
+      "requires": {
+        "nan": "2.10.0"
       }
     },
     "shebang-command": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
+    "ethereumjs-abi": "^0.6.5",
     "mock-stdlib": "file:./test/mocks/mock-stdlib",
     "mock-stdlib-2": "file:./test/mocks/mock-stdlib-2",
     "mock-stdlib-invalid": "file:./test/mocks/mock-stdlib-invalid",

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -7820,6 +7820,23 @@
         }
       }
     },
+    "web3-typescript-typings": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/web3-typescript-typings/-/web3-typescript-typings-0.10.2.tgz",
+      "integrity": "sha1-qZA4FdKooNvXP9XbN0Bw3gvTBJc=",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "~4.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
+          "dev": true
+        }
+      }
+    },
     "webpack-addons": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -63,6 +63,7 @@
     "tmp": "^0.0.33",
     "truffle": "^4.1.13",
     "ts-node": "^7.0.1",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "web3-typescript-typings": "^0.10.2"
   }
 }

--- a/packages/lib/scripts/test.sh
+++ b/packages/lib/scripts/test.sh
@@ -9,5 +9,5 @@ if [ "$SOLIDITY_COVERAGE" = true ]; then
   fi
 else
   node_modules/.bin/truffle compile
-  node_modules/.bin/truffle test "$@"
+  TS_NODE_PROJECT="tsconfig.test.json" node_modules/.bin/truffle test "$@"
 fi

--- a/packages/lib/src/@types/ethereumjs-abi.d.ts
+++ b/packages/lib/src/@types/ethereumjs-abi.d.ts
@@ -1,0 +1,19 @@
+declare module 'ethereumjs-abi' {
+  import BN from 'bignumber.js';
+  export type PrimitiveEncodable = string | number | boolean | BN;
+  export type Encodable = PrimitiveEncodable | PrimitiveEncodable[];
+  export type PrimitiveDecodable = string | boolean | BN;
+  export type Decodable = PrimitiveDecodable | PrimitiveDecodable[];
+  export function rawEncode(types: string[], args: Encodable[]): Buffer;
+  export function rawDecode(types: string[], data: Buffer): Decodable[];
+  export function simpleEncode(signature: string, ...args: Encodable[]): Buffer;
+  export function simpleDecode(signature: string, data: Buffer): Decodable[];
+  export function soliditySHA3(types: string[], args: Encodable[]): Buffer;
+  export function soliditySHA256(types: string[], args: Encodable[]): Buffer;
+  export function solidityRIPEMD160(types: string[], args: Encodable[]): Buffer;
+  export function eventID(name: string, types: string[]): Buffer;
+  export function methodID(name: string, types: string[]): Buffer;
+  export function stringify(types: string[], args: Encodable[]): string[];
+  export function fromSerpent(type: string): string[];
+  export function toSerpent(types: string[]): string;
+}

--- a/packages/lib/src/application/ImplementationDirectory.ts
+++ b/packages/lib/src/application/ImplementationDirectory.ts
@@ -54,7 +54,7 @@ export default class ImplementationDirectory {
     return this.directoryContract.owner(this.txParams);
   }
 
-  public async getImplementation(contractName: string): Promise<string> | never {
+  public async getImplementation(contractName: string): Promise<string | never> {
     if (!contractName) throw Error('Contract name is required to retrieve an implementation');
     return await this.directoryContract.getImplementation(contractName, this.txParams);
   }

--- a/packages/lib/src/application/ImplementationDirectory.ts
+++ b/packages/lib/src/application/ImplementationDirectory.ts
@@ -55,7 +55,7 @@ export default class ImplementationDirectory {
   }
 
   public async getImplementation(contractName: string): Promise<string> | never {
-    if (!contractName) { throw Error('Contract name is required to retrieve an implementation'); }
+    if (!contractName) throw Error('Contract name is required to retrieve an implementation');
     return await this.directoryContract.getImplementation(contractName, this.txParams);
   }
 

--- a/packages/lib/src/application/Package.ts
+++ b/packages/lib/src/application/Package.ts
@@ -53,18 +53,18 @@ export default class Package {
     return this.packageContract.hasVersion(toSemanticVersion(version));
   }
 
-  public async isFrozen(version: string): Promise<boolean> | never {
+  public async isFrozen(version: string): Promise<boolean | never> {
     const directory = await this.getDirectory(version);
     return directory.isFrozen();
   }
 
-  public async freeze(version: string): Promise<any> | never {
+  public async freeze(version: string): Promise<any | never> {
     const directory = await this.getDirectory(version);
     if (!directory.freeze) throw Error('Implementation directory does not support freezing');
     return directory.freeze();
   }
 
-  public async getImplementation(version: string, contractName: string): Promise<string> | never {
+  public async getImplementation(version: string, contractName: string): Promise<string | never> {
     const directory = await this.getDirectory(version);
     return directory.getImplementation(contractName);
   }
@@ -78,7 +78,7 @@ export default class Package {
     return directory;
   }
 
-  public async getDirectory(version: string): Promise<ImplementationDirectory> | never {
+  public async getDirectory(version: string): Promise<ImplementationDirectory | never> {
     if (!version) throw Error('Cannot get a directory from a package without specifying a version');
     const directoryAddress = await this.packageContract.getContract(toSemanticVersion(version));
     return ImplementationDirectory.fetch(directoryAddress, this.txParams);

--- a/packages/lib/src/artifacts/BuildArtifacts.ts
+++ b/packages/lib/src/artifacts/BuildArtifacts.ts
@@ -47,11 +47,7 @@ export class BuildArtifacts {
   }
 
   public registerArtifactForSourcePath(sourcePath: string, artifact: Artifact): void {
-
-    if (!this.sourcesToArtifacts[sourcePath]) {
-      this.sourcesToArtifacts[sourcePath] = [];
-    }
-
+    if (!this.sourcesToArtifacts[sourcePath]) this.sourcesToArtifacts[sourcePath] = [];
     this.sourcesToArtifacts[sourcePath].push(artifact);
   }
 }

--- a/packages/lib/src/artifacts/ContractFactory.ts
+++ b/packages/lib/src/artifacts/ContractFactory.ts
@@ -58,15 +58,13 @@ export default class ContractFactory {
     this._validateNonUnlinkedLibraries();
 
     const [args, txParams] = this._parseArguments(passedArguments);
-    if (!txParams.data) {
-      txParams.data = this.binary;
-    }
+    if (!txParams.data) txParams.data = this.binary;
     const self = this;
 
     return new Promise(function(resolve, reject) {
       const contractClass: any = ZWeb3.contract(self.abi);
       contractClass.new(...args, txParams, function(error, instance) {
-        if (error) { reject(error); }
+        if (error) reject(error);
         else if (instance && instance.address) {
           const wrapper: ContractWrapper = self._wrapContract(instance);
           resolve(wrapper);
@@ -77,9 +75,7 @@ export default class ContractFactory {
 
   public at(address: string): ContractWrapper | never {
 
-    if (!ZWeb3.isAddress(address)) {
-      throw new Error('Given address is not valid: ' + address);
-    }
+    if (!ZWeb3.isAddress(address)) throw new Error('Given address is not valid: ' + address);
 
     const contractClass: any = ZWeb3.contract(this.abi);
     const contract: any = contractClass.at(address);
@@ -172,9 +168,7 @@ export default class ContractFactory {
     let givenTxParams = {};
     if (params.length > 0) {
       const lastArg = params[params.length - 1];
-      if (typeof(lastArg) === 'object' && !Array.isArray(lastArg) && !BN.isBigNumber(lastArg)) {
-        givenTxParams = params.pop();
-      }
+      if (typeof(lastArg) === 'object' && !Array.isArray(lastArg) && !BN.isBigNumber(lastArg)) givenTxParams = params.pop();
     }
     const txParams = { ...this.txParams, ...givenTxParams };
     return [params, txParams];
@@ -199,9 +193,7 @@ export default class ContractFactory {
   }
 
   private _validateNonEmptyBinary(): void | never {
-    if (this.bytecode === '') {
-      throw new Error(`A bytecode must be provided for contract ${this.contractName}.`);
-    }
+    if (this.bytecode === '') throw new Error(`A bytecode must be provided for contract ${this.contractName}.`);
   }
 
   private _validateNonUnlinkedLibraries(): void | never {

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -153,7 +153,7 @@ export default class ZWeb3 {
     return ZWeb3._getTransactionReceiptWithTimeout(tx, timeout, new Date().getTime());
   }
 
-  private static async _getTransactionReceiptWithTimeout(tx: string, timeout: number, startTime: number): Promise<any> | never {
+  private static async _getTransactionReceiptWithTimeout(tx: string, timeout: number, startTime: number): Promise<any | never> {
     const receipt: any = await ZWeb3._tryGettingTransactionReceipt(tx);
     if (receipt) {
       if (parseInt(receipt.status, 16) !== 0) return receipt;
@@ -166,7 +166,7 @@ export default class ZWeb3 {
     throw new Error(`Transaction ${tx} wasn't processed in ${timeout / 1000} seconds!`);
   }
 
-  private static async _tryGettingTransactionReceipt(tx: string): Promise<any> | never {
+  private static async _tryGettingTransactionReceipt(tx: string): Promise<any | never> {
     try {
       return await ZWeb3.getTransactionReceipt(tx);
     } catch (error) {

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -23,7 +23,7 @@ export default class ZWeb3 {
 
   // TODO: this.web3 could be cached and initialized lazily?
   public static web3(): any {
-    if (!ZWeb3.provider) { throw new Error('ZWeb3 must be initialized with a web3 provider'); }
+    if (!ZWeb3.provider) throw new Error('ZWeb3 must be initialized with a web3 provider');
     const Web3 = require('web3');
 
     // TODO: improve provider validation for HttpProvider scenarios
@@ -156,13 +156,13 @@ export default class ZWeb3 {
   private static async _getTransactionReceiptWithTimeout(tx: string, timeout: number, startTime: number): Promise<any> | never {
     const receipt: any = await ZWeb3._tryGettingTransactionReceipt(tx);
     if (receipt) {
-      if (parseInt(receipt.status, 16) !== 0) { return receipt; }
+      if (parseInt(receipt.status, 16) !== 0) return receipt;
       throw new Error(`Transaction: ${tx} exited with an error (status 0).`);
     }
 
     await sleep(1000);
     const timeoutReached = timeout > 0 && new Date().getTime() - startTime > timeout;
-    if (!timeoutReached) { return await ZWeb3._getTransactionReceiptWithTimeout(tx, timeout, startTime); }
+    if (!timeoutReached) return await ZWeb3._getTransactionReceiptWithTimeout(tx, timeout, startTime);
     throw new Error(`Transaction ${tx} wasn't processed in ${timeout / 1000} seconds!`);
   }
 
@@ -170,8 +170,8 @@ export default class ZWeb3 {
     try {
       return await ZWeb3.getTransactionReceipt(tx);
     } catch (error) {
-      if (error.message.includes('unknown transaction')) { return null; }
-      else { throw error; }
+      if (error.message.includes('unknown transaction')) return null;
+      else throw error;
     }
   }
 }

--- a/packages/lib/src/helpers/advanceBlock.ts
+++ b/packages/lib/src/helpers/advanceBlock.ts
@@ -1,6 +1,6 @@
 import ZWeb3 from '../artifacts/ZWeb3';
 
-export default function advanceBlock():Promise<any> {
+export default function advanceBlock(): Promise<any> {
   return new Promise((resolve, reject) => {
     ZWeb3.provider.sendAsync({
       jsonrpc: '2.0',

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -2,13 +2,9 @@ import abi from 'ethereumjs-abi';
 import BN from 'bignumber.js';
 
 function formatValue(value: any): string {
-  if (typeof(value) === 'number' || BN.isBigNumber(value)) {
-    return value.toString();
-  } else if (typeof(value) === 'string' && value.match(/\d+(\.\d+)?e(\+)?\d+/)) {
-    return (new BN(value)).toString(10);
-  } else {
-    return value;
-  }
+  if (typeof(value) === 'number' || BN.isBigNumber(value)) return value.toString();
+  else if (typeof(value) === 'string' && value.match(/\d+(\.\d+)?e(\+)?\d+/)) return (new BN(value)).toString(10);
+  else return value;
 }
 
 export default function encodeCall(name: string, args: string[] = [], rawValues: any[] = []): string {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -8,8 +8,8 @@ function formatValue(value: any): string {
 }
 
 export default function encodeCall(name: string, args: string[] = [], rawValues: any[] = []): string {
-  const values: string[] = rawValues.map(formatValue);
-  const methodId: string = abi.methodID(name, args).toString('hex');
-  const params: Buffer = abi.rawEncode(args, values).toString('hex');
+  const values = rawValues.map(formatValue);
+  const methodId = abi.methodID(name, args).toString('hex');
+  const params = abi.rawEncode(args, values).toString('hex');
   return '0x' + methodId + params;
 }

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -5,7 +5,7 @@ import Package from '../application/Package';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import BasePackageProject from './BasePackageProject';
 import SimpleProject from './SimpleProject';
-import ContractFactory, { ContractWrapper }  from '../artifacts/ContractFactory';
+import ContractFactory, { ContractWrapper } from '../artifacts/ContractFactory';
 import { DeployError } from '../utils/errors/DeployError';
 import { semanticVersionToString } from '../utils/Semver';
 
@@ -39,13 +39,9 @@ export default class AppProject extends BasePackageProject {
       app = appAddress
         ? await App.fetch(appAddress, txParams)
         : await App.deploy(txParams);
-      if (packageAddress) {
-        thepackage = await Package.fetch(packageAddress, txParams);
-      } else if (await app.hasPackage(name, version)) {
-        thepackage = (await app.getPackage(name)).package;
-      } else {
-        thepackage = await Package.deploy(txParams);
-      }
+      if (packageAddress) thepackage = await Package.fetch(packageAddress, txParams);
+      else if (await app.hasPackage(name, version)) thepackage = (await app.getPackage(name)).package;
+      else thepackage = await Package.deploy(txParams);
       directory = await thepackage.hasVersion(version)
         ? await thepackage.getDirectory(version)
         : await thepackage.newVersion(version);
@@ -103,9 +99,7 @@ export default class AppProject extends BasePackageProject {
   }
 
   public async getCurrentDirectory(): Promise<ImplementationDirectory> {
-    if (!this.directory) {
-      this.directory = await this.app.getProvider(this.name);
-    }
+    if (!this.directory) this.directory = await this.app.getProvider(this.name);
     return this.directory;
   }
 

--- a/packages/lib/src/project/SimpleProject.ts
+++ b/packages/lib/src/project/SimpleProject.ts
@@ -115,7 +115,7 @@ export default class SimpleProject  {
     delete this.dependencies[name];
   }
 
-  public async _getOrDeployImplementation(contractClass: ContractFactory, packageName: string, contractName?: string, redeployIfChanged?: boolean): Promise<string> | never {
+  public async _getOrDeployImplementation(contractClass: ContractFactory, packageName: string, contractName?: string, redeployIfChanged?: boolean): Promise<string | never> {
     if (!contractName) contractName = contractClass.contractName;
 
     const implementation = await (!packageName || packageName === this.name

--- a/packages/lib/src/project/SimpleProject.ts
+++ b/packages/lib/src/project/SimpleProject.ts
@@ -7,10 +7,10 @@ import { deploy } from '../utils/Transactions';
 import { toAddress } from '../utils/Addresses';
 import { bytecodeDigest } from '..';
 import { buildCallData, callDescription, CalldataInfo } from '../utils/ABIs';
-import ContractFactory  from '../artifacts/ContractFactory';
+import ContractFactory from '../artifacts/ContractFactory';
 
 interface Implementations {
-  [contractName: string]: Implementation
+  [contractName: string]: Implementation;
 }
 
 interface Implementation {
@@ -23,7 +23,7 @@ interface Dependencies {
 }
 
 interface Dependency {
-  package: string,
+  package: string;
   version: string;
 }
 

--- a/packages/lib/src/proxy/Proxy.ts
+++ b/packages/lib/src/proxy/Proxy.ts
@@ -63,8 +63,6 @@ export default class Proxy {
     const currentAdmin: string = await this.admin();
     const { from }: { from?: string } = this.txParams;
     // TODO: If no `from` is set, load which is the default account and use it to compare against the current admin
-    if (from && currentAdmin !== from) {
-      throw new Error(`Cannot modify proxy from non-admin account: current admin is ${currentAdmin} and sender is ${from}`);
-    }
+    if (from && currentAdmin !== from) throw new Error(`Cannot modify proxy from non-admin account: current admin is ${currentAdmin} and sender is ${from}`);
   }
 }

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -26,13 +26,13 @@ export function buildCallData(contractClass: ContractFactory, methodName: string
 
 export function getABIFunction(contractClass: ContractFactory, methodName: string, args: any[]): FunctionInfo {
   const targetMethod: FunctionInfo = tryGetTargetFunction(contractClass, methodName, args);
-  if (targetMethod) { methodName = targetMethod.name; }
+  if (targetMethod) methodName = targetMethod.name;
 
   const matchArgsTypes = (fn) => targetMethod && fn.inputs.every((input, index) => targetMethod.inputs[index] && targetMethod.inputs[index].type === input.type);
   const matchNameAndArgsLength = (fn) => fn.name === methodName && fn.inputs.length === args.length;
 
   let abiMethods: FunctionInfo[] = contractClass.abi.filter((fn) => matchNameAndArgsLength(fn) && matchArgsTypes(fn));
-  if (abiMethods.length === 0) { abiMethods = contractClass.abi.filter((fn) => matchNameAndArgsLength(fn)); }
+  if (abiMethods.length === 0) abiMethods = contractClass.abi.filter((fn) => matchNameAndArgsLength(fn));
 
   switch (abiMethods.length) {
     case 0: throw Error(`Could not find method ${methodName} with ${args.length} arguments in contract ${contractClass.contractName}`);
@@ -64,7 +64,7 @@ function tryGetTargetFunction(contractClass: ContractFactory, methodName: string
 
 function tryGetFunctionNodeFromMostDerivedContract(contractClass: ContractFactory, methodName: string, args: any[]): Node | null {
   const linearizedBaseContracts: Node[] | null = tryGetLinearizedBaseContracts(contractClass);
-  if (!linearizedBaseContracts) { return null; }
+  if (!linearizedBaseContracts) return null;
 
   const nodeMatches = (node: Node) => (
     node.nodeType === 'FunctionDefinition' &&

--- a/packages/lib/src/utils/Addresses.ts
+++ b/packages/lib/src/utils/Addresses.ts
@@ -4,13 +4,9 @@ export const ZERO_ADDRESS: string = '0x0000000000000000000000000000000000000000'
 
 // TS-TODO: Web3 typings? => contract.
 export function toAddress(contractOrAddress: string | any): string {
-  if (_.isEmpty(contractOrAddress)) {
-    throw Error(`Contract or address expected`);
-  } else if (_.isString(contractOrAddress)) {
-    return contractOrAddress;
-  } else {
-    return contractOrAddress.address;
-  }
+  if (_.isEmpty(contractOrAddress)) throw Error(`Contract or address expected`);
+  else if (_.isString(contractOrAddress)) return contractOrAddress;
+  else return contractOrAddress.address;
 }
 
 export function isZeroAddress(address: string): boolean {

--- a/packages/lib/src/utils/ContractAST.ts
+++ b/packages/lib/src/utils/ContractAST.ts
@@ -80,9 +80,7 @@ export default class ContractAST {
 
   public getNode(id: string, type: string): Node | never {
 
-    if (!this.nodes[id]) {
-      throw Error(`No AST nodes with id ${id} found`);
-    }
+    if (!this.nodes[id]) throw Error(`No AST nodes with id ${id} found`);
 
     const candidates = this.nodes[id].filter((node: Node) => node.nodeType === type);
     switch (candidates.length) {
@@ -100,7 +98,7 @@ export default class ContractAST {
       .filter((node) => node.nodeType === 'ImportDirective')
       .map((node) => node.absolutePath)
       .forEach((importPath) => {
-        if (this.imports.has(importPath)) { return; }
+        if (this.imports.has(importPath)) return;
         this.imports.add(importPath);
         this.artifacts.getArtifactsFromSourcePath(importPath).forEach((importedArtifact) => {
           this._collectNodes(importedArtifact.ast);
@@ -112,21 +110,17 @@ export default class ContractAST {
   private _collectNodes(node: Node): void {
 
     // Return if we have already seen this node
-    if (_.some(this.nodes[node.id] || [], (n) => _.isEqual(n, node))) { return; }
+    if (_.some(this.nodes[node.id] || [], (n) => _.isEqual(n, node))) return;
 
     // Only process nodes of the filtered types (or SourceUnits)
-    if (node.nodeType !== 'SourceUnit' && this.nodesFilter && !_.includes(this.nodesFilter, node.nodeType)) { return; }
+    if (node.nodeType !== 'SourceUnit' && this.nodesFilter && !_.includes(this.nodesFilter, node.nodeType))  return;
 
     // Add node to collection with this id otherwise
-    if (!this.nodes[node.id]) {
-      this.nodes[node.id] = [];
-    }
+    if (!this.nodes[node.id]) this.nodes[node.id] = [];
     this.nodes[node.id].push(node);
 
     // Call recursively to children
-    if (node.nodes) {
-      node.nodes.forEach(this._collectNodes.bind(this));
-    }
+    if (node.nodes) node.nodes.forEach(this._collectNodes.bind(this));
 
   }
 }

--- a/packages/lib/src/utils/FileSystem.ts
+++ b/packages/lib/src/utils/FileSystem.ts
@@ -20,12 +20,12 @@ export function createDir(dir: string): void {
 }
 
 export function createDirPath(dirPath: string): void {
-  const folders = dirPath.split('/')
+  const folders = dirPath.split('/');
   folders.reduce((subDir, folder) => {
-    const subFolderPath = `${subDir}/${folder}`
-    if (folder && !exists(subFolderPath)) createDir(subFolderPath)
-    return subFolderPath
-  }, '')
+    const subFolderPath = `${subDir}/${folder}`;
+    if (folder && !exists(subFolderPath)) createDir(subFolderPath);
+    return subFolderPath;
+  }, '');
 }
 
 export function isDir(targetPath: string): boolean {
@@ -33,15 +33,11 @@ export function isDir(targetPath: string): boolean {
 }
 
 export function ifExistsThrow(filename: string, message: string): void {
-  if (exists(filename)) {
-    throw Error(message);
-  }
+  if (exists(filename)) throw Error(message);
 }
 
 export function ifNotExistsThrow(filename: string, message: string): void {
-  if (!exists(filename)) {
-    throw Error(message);
-  }
+  if (!exists(filename)) throw Error(message);
 }
 
 // TS-TODO: Returned object could be of a more specific type
@@ -50,12 +46,8 @@ export function parseJson(filename: string): {} {
 }
 
 export function parseJsonIfExists(filename: string): {} | null {
-  if (exists(filename)) {
-    return JSON.parse(read(filename));
-  }
-  else {
-    return null;
-  }
+  if (exists(filename)) return JSON.parse(read(filename));
+  else return null;
 }
 
 export function editJson(file: string, edit: ({}) => void): void {

--- a/packages/lib/src/utils/Logger.ts
+++ b/packages/lib/src/utils/Logger.ts
@@ -41,12 +41,8 @@ export default class Logger {
   }
 
   public log(msg: string, color: string = ''): void {
-    if (this.opts.silent) {
-      return;
-    }
-    if (this.opts.verbose) {
-      msg = `[${this._prefix}] ${msg}`;
-    }
+    if (this.opts.silent) return;
+    if (this.opts.verbose) msg = `[${this._prefix}] ${msg}`;
     console.error(chalk.keyword(color)(msg));
   }
 

--- a/packages/lib/src/utils/Semver.ts
+++ b/packages/lib/src/utils/Semver.ts
@@ -11,9 +11,7 @@ type RawSemanticVersion = [any, any, any];
 export function toSemanticVersion(version: string | RawSemanticVersion): SemanticVersion | never {
   if (_.isString(version)) {
     const semanticVersion: any = semver.parse(version);
-    if (!semanticVersion) {
-      throw Error(`Cannot parse version identifier ${version}`);
-    }
+    if (!semanticVersion) throw Error(`Cannot parse version identifier ${version}`);
     return [semanticVersion.major, semanticVersion.minor, semanticVersion.patch];
   } else if (_.isArray(version) && version.length === 3) {
     const semverGenericArray: RawSemanticVersion = <RawSemanticVersion> version;
@@ -21,21 +19,16 @@ export function toSemanticVersion(version: string | RawSemanticVersion): Semanti
       return x.toNumber ? x.toNumber() : x;
     });
     return <SemanticVersion> semverTyped;
-  } else {
-    throw Error(`Cannot parse version identifier ${version}`);
-  }
+  } else throw Error(`Cannot parse version identifier ${version}`);
 
 }
 
 export function semanticVersionToString(version: string | RawSemanticVersion): string | never {
-  if (_.isString(version)) {
-    return <string> version;
-  } else if (_.isArray(version)) {
+  if (_.isString(version)) return <string> version;
+    else if (_.isArray(version)) {
     const semverGenericArray: RawSemanticVersion = <RawSemanticVersion> version;
     return <string> (semverGenericArray.join('.'));
-  } else {
-    throw Error(`Cannot handle version identifier ${util.inspect(version)}`);
-  }
+  } else throw Error(`Cannot handle version identifier ${util.inspect(version)}`);
 }
 
 export function semanticVersionEqual(v1: string | RawSemanticVersion, v2: string | RawSemanticVersion): boolean {

--- a/packages/lib/src/utils/Transactions.ts
+++ b/packages/lib/src/utils/Transactions.ts
@@ -155,7 +155,7 @@ export async function estimateActualGas(txParams: any): Promise<any> {
   return calculateActualGas(estimatedGas);
 }
 
-async function getETHGasStationPrice(): Promise<any> | never {
+async function getETHGasStationPrice(): Promise<any | never> {
   if (state.gasPrice) return state.gasPrice;
 
   try {
@@ -199,7 +199,7 @@ async function calculateActualGas(estimatedGas): Promise<any> {
   return gasToUse >= blockLimit ? (blockLimit - 1) : gasToUse;
 }
 
-export async function awaitConfirmations(transactionHash: string, confirmations: number = 12, interval: number = 1000, timeout: number = (10 * 60 * 1000)): Promise<any> | never {
+export async function awaitConfirmations(transactionHash: string, confirmations: number = 12, interval: number = 1000, timeout: number = (10 * 60 * 1000)): Promise<any | never> {
   if (await ZWeb3.isGanacheNode()) return;
   const getTxBlock = () => (ZWeb3.getTransactionReceipt(transactionHash).then((r) => r.blockNumber));
   const now = +(new Date());

--- a/packages/lib/src/utils/Transactions.ts
+++ b/packages/lib/src/utils/Transactions.ts
@@ -48,7 +48,7 @@ export async function sendTransaction(contractFn: GenericFunction, args: any[] =
   try {
     return await _sendTransaction(contractFn, args, txParams);
   } catch (error) {
-    if (!error.message.match(/nonce too low/) || retries <= 0) { throw error; }
+    if (!error.message.match(/nonce too low/) || retries <= 0) throw error;
     return sendTransaction(contractFn, args, txParams, retries - 1);
   }
 }
@@ -66,7 +66,7 @@ export async function deploy(contract: ContractFactory, args: any[] = [], txPara
   try {
     return await _deploy(contract, args, txParams);
   } catch (error) {
-    if (!error.message.match(/nonce too low/) || retries <= 0) { throw error; }
+    if (!error.message.match(/nonce too low/) || retries <= 0) throw error;
     return deploy(contract, args, txParams, retries - 1);
   }
 }
@@ -82,9 +82,7 @@ export async function sendDataTransaction(contract: ContractWrapper, txParams: a
   await fixGasPrice(txParams);
 
   // If gas is set explicitly, use it
-  if (txParams.gas) {
-    return contract.sendTransaction(txParams);
-  }
+  if (txParams.gas) return contract.sendTransaction(txParams);
   // Estimate gas for the call and run the tx
   const gas = await estimateActualGas({ to: contract.address, ...txParams });
   return contract.sendTransaction({ gas, ...txParams });
@@ -99,9 +97,7 @@ export async function sendDataTransaction(contract: ContractWrapper, txParams: a
  */
 async function _sendTransaction(contractFn: GenericFunction, args: any[] = [], txParams: any = {}) {
   // If gas is set explicitly, use it
-  if (txParams.gas) {
-    return contractFn(...args, txParams);
-  }
+  if (txParams.gas) return contractFn(...args, txParams);
 
   // Estimate gas for the call
   const gas = await estimateActualGasFnCall(contractFn, args, txParams);
@@ -118,9 +114,7 @@ async function _sendTransaction(contractFn: GenericFunction, args: any[] = [], t
  */
 async function _deploy(contract: ContractFactory, args: any[] = [], txParams: any = {}): Promise<ContractWrapper> {
   // If gas is set explicitly, use it
-  if (txParams.gas) {
-    return contract.new(...args, txParams);
-  }
+  if (txParams.gas) return contract.new(...args, txParams);
 
   const data: string = contract.getData(args, txParams);
   const gas: number = await estimateActualGas({ data, ...txParams });
@@ -136,7 +130,7 @@ export async function estimateGas(txParams: any, retries: number = RETRY_COUNT):
     // Use json-rpc method estimateGas to retrieve estimated value
     return await ZWeb3.estimateGas(txParams);
   } catch (error) {
-    if (retries <= 0) { throw Error(error); }
+    if (retries <= 0) throw Error(error);
     await sleep(RETRY_SLEEP_TIME);
     return await estimateGas(txParams, retries - 1);
   }
@@ -150,7 +144,7 @@ export async function estimateActualGasFnCall(contractFn: GenericFunction, args:
   try {
     return await calculateActualGas(await contractFn.estimateGas(...args, txParams));
   } catch(error) {
-    if (retries <= 0) { throw Error(error); }
+    if (retries <= 0) throw Error(error);
     await sleep(RETRY_SLEEP_TIME);
     return estimateActualGasFnCall(contractFn, args, txParams, retries - 1);
   }
@@ -181,14 +175,12 @@ async function fixGasPrice(txParams: any): Promise<any> {
 
   if ((TRUFFLE_DEFAULT_GAS_PRICE.eq(gasPrice) || !gasPrice) && await ZWeb3.isMainnet()) {
     txParams.gasPrice = await getETHGasStationPrice();
-    if (TRUFFLE_DEFAULT_GAS_PRICE.lte(txParams.gasPrice)) {
-      throw new Error('The current gas price estimate from ethgasstation.info is over 100 gwei. If you do want to send a transaction with a gas price this high, please set it manually in your truffle.js configuration file.');
-    }
+    if (TRUFFLE_DEFAULT_GAS_PRICE.lte(txParams.gasPrice)) throw new Error('The current gas price estimate from ethgasstation.info is over 100 gwei. If you do want to send a transaction with a gas price this high, please set it manually in your truffle.js configuration file.');
   }
 }
 
 async function getBlockGasLimit(): Promise<any> {
-  if (state.block) { return state.block.gasLimit; }
+  if (state.block) return state.block.gasLimit;
   state.block = await ZWeb3.getLatestBlock();
   return state.block.gasLimit;
 }
@@ -203,22 +195,20 @@ async function calculateActualGas(estimatedGas): Promise<any> {
   // This is a viable workaround as long as we don't have other methods that have higher refunds,
   // such as cleaning more storage positions or selfdestructing a contract. We should be able to fix
   // this once the issue is resolved.
-  if (await ZWeb3.isGanacheNode()) { gasToUse += 15000; }
+  if (await ZWeb3.isGanacheNode()) gasToUse += 15000;
   return gasToUse >= blockLimit ? (blockLimit - 1) : gasToUse;
 }
 
 export async function awaitConfirmations(transactionHash: string, confirmations: number = 12, interval: number = 1000, timeout: number = (10 * 60 * 1000)): Promise<any> | never {
-  if (await ZWeb3.isGanacheNode()) { return; }
+  if (await ZWeb3.isGanacheNode()) return;
   const getTxBlock = () => (ZWeb3.getTransactionReceipt(transactionHash).then((r) => r.blockNumber));
   const now = +(new Date());
 
   while (true) {
-    if ((+(new Date()) - now) > timeout) {
-      throw new Error(`Exceeded timeout of ${timeout / 1000} seconds awaiting confirmations for transaction ${transactionHash}`);
-    }
+    if ((+(new Date()) - now) > timeout) throw new Error(`Exceeded timeout of ${timeout / 1000} seconds awaiting confirmations for transaction ${transactionHash}`);
     const currentBlock: number = await ZWeb3.getLatestBlockNumber();
     const txBlock: number = await getTxBlock();
-    if (currentBlock - txBlock >= confirmations) { return true; }
+    if (currentBlock - txBlock >= confirmations) return true;
     await sleep(interval);
   }
 }

--- a/packages/lib/src/validations/InitialValues.ts
+++ b/packages/lib/src/validations/InitialValues.ts
@@ -10,9 +10,7 @@ export function hasInitialValuesInDeclarations(contractClass: ContractFactory): 
 function detectInitialValues(contractClass: ContractFactory): boolean {
   const nodes = contractClass.ast.nodes.filter((n) => n.name === contractClass.contractName);
   for (const node of nodes) {
-    if (hasInitialValues(node)) {
-      return true;
-    }
+    if (hasInitialValues(node)) return true;
     for (const baseContract of node.baseContracts || []) {
       const parentContract: ContractFactory = Contracts.getFromLocal(baseContract.baseName.name);
       return detectInitialValues(parentContract);

--- a/packages/lib/src/validations/Initializers.ts
+++ b/packages/lib/src/validations/Initializers.ts
@@ -19,7 +19,7 @@ export function getUninitializedBaseContracts(contractClass: ContractFactory): s
 function getUninitializedDirectBaseContracts(contractClass: ContractFactory, uninitializedBaseContracts: any): void {
   // Check whether the contract has base contracts
   const baseContracts: any = contractClass.ast.nodes.find((n) => n.name === contractClass.contractName).baseContracts;
-  if (baseContracts.length === 0) { return; }
+  if (baseContracts.length === 0) return;
 
   // Run check for the base contracts
   for (const baseContract of baseContracts) {
@@ -48,32 +48,27 @@ function getUninitializedDirectBaseContracts(contractClass: ContractFactory, uni
   if (initializer === undefined) {
     // A contract may lack initializer as long as the base contracts don't have more than 1 initializers in total
     // If there are 2 or more base contracts with initializers, child contract should initialize all of them
-    if (baseContractsWithInitialize.length > 1) {
-      for (const baseContract of baseContractsWithInitialize) {
+    if (baseContractsWithInitialize.length > 1)
+      for (const baseContract of baseContractsWithInitialize)
         uninitializedBaseContracts[baseContract] = contractClass.contractName;
-      }
-    }
+
     return;
   }
 
   // Update map with each call of "initialize" function of the base contract
   const initializedContracts: any = {};
-  for (const statement of initializer.body.statements) {
+  for (const statement of initializer.body.statements)
     if (statement.nodeType === 'ExpressionStatement' && statement.expression.nodeType === 'FunctionCall') {
       const baseContractName: string = statement.expression.expression.expression.name;
       const functionName: string = statement.expression.expression.memberName;
-      if (baseContractInitializers[baseContractName] === functionName) {
+      if (baseContractInitializers[baseContractName] === functionName)
         initializedContracts[baseContractName] = true;
-      }
     }
-  }
 
   // For each base contract with "initialize" function, check that it's called in the function
-  for (const contractName of baseContractsWithInitialize) {
-    if (!initializedContracts[contractName]) {
+  for (const contractName of baseContractsWithInitialize)
+    if (!initializedContracts[contractName])
       uninitializedBaseContracts[contractName] = contractClass.contractName;
-    }
-  }
   return;
 }
 
@@ -84,9 +79,8 @@ function getContractInitializer(contractClass: ContractFactory): Node | undefine
   for (const contractFunction of contractFunctions) {
     const functionModifiers: any = contractFunction.modifiers;
     const initializerModifier: any = functionModifiers.find((m) => m.modifierName.name === 'initializer');
-    if (contractFunction.name === 'initialize' || initializerModifier !== undefined) {
+    if (contractFunction.name === 'initialize' || initializerModifier !== undefined)
       return contractFunction;
-    }
   }
   return undefined;
 }

--- a/packages/lib/src/validations/Instructions.ts
+++ b/packages/lib/src/validations/Instructions.ts
@@ -11,19 +11,17 @@ export function hasDelegateCall(contractClass: ContractFactory): boolean {
 
 function hasTypeIdentifier(contractClass: ContractFactory, typeIdentifier: string): boolean {
   for (const node of contractClass.ast.nodes.filter((n) => n.name === contractClass.contractName)) {
-    if (hasKeyValue(node, 'typeIdentifier', typeIdentifier)) { return true; }
-    for (const baseContract of node.baseContracts || []) {
-      if (hasTypeIdentifier(Contracts.getFromLocal(baseContract.baseName.name), typeIdentifier)) { return true; }
-    }
+    if (hasKeyValue(node, 'typeIdentifier', typeIdentifier)) return true;
+    for (const baseContract of node.baseContracts || [])
+      if (hasTypeIdentifier(Contracts.getFromLocal(baseContract.baseName.name), typeIdentifier)) return true;
   }
   return false;
 }
 
 function hasKeyValue(data: any, key: string, value: string): boolean {
-  if (!data) { return false; }
-  if (data[key] === value) { return true; }
-  for (const childKey in data) {
-    if (typeof(data[childKey]) === 'object' && hasKeyValue(data[childKey], key, value)) { return true; }
-  }
+  if (!data) return false;
+  if (data[key] === value) return true;
+  for (const childKey in data)
+    if (typeof(data[childKey]) === 'object' && hasKeyValue(data[childKey], key, value)) return true;
   return false;
 }

--- a/packages/lib/src/validations/Layout.ts
+++ b/packages/lib/src/validations/Layout.ts
@@ -37,15 +37,10 @@ function storageEntryMatches(originalVar: StorageInfo, updatedVar: StorageInfo, 
   const typeMatches = (originalType.id === updatedType.id);
   const nameMatches = (originalVar.label === updatedVar.label);
 
-  if (typeMatches && nameMatches) {
-    return 'equal';
-  } else if (typeMatches) {
-    return 'rename';
-  } else if (nameMatches) {
-    return 'typechange';
-  } else {
-    return 'replace';
-  }
+  if (typeMatches && nameMatches) return 'equal';
+  else if (typeMatches) return 'rename';
+  else if (nameMatches) return 'typechange';
+  else return 'replace';
 }
 
 // Adapted from https://gist.github.com/andrei-m/982927 by Andrei Mackenzie
@@ -54,8 +49,8 @@ function levenshtein(originalStorage: StorageInfo[], updatedStorage: StorageInfo
   const a = originalStorage;
   const b = updatedStorage;
 
-  if (a.length === 0) { return [[b.length * INSERTION_COST]]; }
-  if (b.length === 0) { return [[a.length * DELETION_COST]]; }
+  if (a.length === 0) return [[b.length * INSERTION_COST]];
+  if (b.length === 0) return [[a.length * DELETION_COST]];
 
   const matrix: any[] = Array(a.length + 1);
 
@@ -66,23 +61,19 @@ function levenshtein(originalStorage: StorageInfo[], updatedStorage: StorageInfo
   }
 
   // increment each column in the first row
-  for (let j = 0; j <= b.length; j++) {
-    matrix[0][j] = j * INSERTION_COST;
-  }
+  for (let j = 0; j <= b.length; j++) matrix[0][j] = j * INSERTION_COST;
 
   // fill in the rest of the matrix
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      if (areEqualFn(a[i - 1], b[j - 1])) {
+  for (let i = 1; i <= a.length; i++)
+    for (let j = 1; j <= b.length; j++)
+      if (areEqualFn(a[i - 1], b[j - 1]))
         matrix[i][j] = matrix[i - 1][j - 1];
-      } else {
+      else {
         const insertionCost = j > a.length ? 0 : INSERTION_COST; // appending is free
         matrix[i][j] = Math.min(matrix[i - 1][j - 1] + SUBSTITUTION_COST,
                                 matrix[i][j - 1] + insertionCost,
                                 matrix[i - 1][j] + DELETION_COST);
       }
-    }
-  }
 
   return matrix;
 }
@@ -121,9 +112,8 @@ function walk(matrix: number[][], originalStorage: StorageInfo[], updatedStorage
       operations.unshift({ action: matchResult, updated, original });
       i--;
       j--;
-    } else {
-      throw Error(`Could not walk matrix at position ${i},${j}:\n${(<any> matrix).map(util.inspect).join('\n')}\n`);
     }
+    else throw Error(`Could not walk matrix at position ${i},${j}:\n${(<any> matrix).map(util.inspect).join('\n')}\n`);
   }
 
   return operations;

--- a/packages/lib/src/validations/Storage.ts
+++ b/packages/lib/src/validations/Storage.ts
@@ -15,9 +15,7 @@ import {
 // TS-TODO: define return type after typing class members below.
 export function getStorageLayout(contract: ContractFactory, artifacts: BuildArtifacts): StorageLayoutInfo {
 
-  if (!artifacts) {
-    artifacts = getBuildArtifacts();
-  }
+  if (!artifacts) artifacts = getBuildArtifacts();
 
   const layout = new StorageLayout(contract, artifacts);
   const { types, storage } = layout.run();
@@ -35,13 +33,9 @@ export function getStructsOrEnums(info: StorageLayoutInfo): StorageInfo[] {
 // TS-TODO: Define parameter types type after typing class members below.
 function containsStructOrEnum(typeName: string, types): boolean {
   const type = types[typeName];
-  if (type.kind === 'struct' || type.kind === 'enum') {
-    return true;
-  } else if (type.valueType) {
-    return containsStructOrEnum(type.valueType, types);
-  } else {
-    return false;
-  }
+  if (type.kind === 'struct' || type.kind === 'enum') return true;
+  else if (type.valueType) return containsStructOrEnum(type.valueType, types);
+  else return false;
 }
 
 const CONTRACT_TYPE_INFO: TypeInfo = {
@@ -112,7 +106,7 @@ class StorageLayout {
       .filter((node) => node.nodeType === 'ImportDirective')
       .map((node) => node.absolutePath)
       .forEach((importPath) => {
-        if (this.imports.has(importPath)) { return; }
+        if (this.imports.has(importPath)) return;
         this.imports.add(importPath);
         this.artifacts.getArtifactsFromSourcePath(importPath).forEach((importedArtifact) => {
           this.collectNodes(importedArtifact.ast);
@@ -124,14 +118,14 @@ class StorageLayout {
   private collectNodes(node: Node): void {
 
     // Return if we have already seen this node.
-    if (_.some(this.nodes[node.id] || [], (n) => _.isEqual(n, node))) { return; }
+    if (_.some(this.nodes[node.id] || [], (n) => _.isEqual(n, node))) return;
 
     // Add node to collection with this id otherwise.
-    if (!this.nodes[node.id]) { this.nodes[node.id] = []; }
+    if (!this.nodes[node.id]) this.nodes[node.id] = [];
     this.nodes[node.id].push(node);
 
     // Call recursively to children.
-    if (node.nodes) { node.nodes.forEach(this.collectNodes.bind(this)); }
+    if (node.nodes) node.nodes.forEach(this.collectNodes.bind(this));
   }
 
   private visitVariables(contractNode: Node): void {
@@ -160,9 +154,7 @@ class StorageLayout {
 
   private getNode(id: number, nodeType: string): Node | never {
 
-    if (!this.nodes[id]) {
-      throw Error(`No AST nodes with id ${id} found`);
-    }
+    if (!this.nodes[id]) throw Error(`No AST nodes with id ${id} found`);
 
     const candidates = this.nodes[id].filter((node) => node.nodeType === nodeType);
     switch (candidates.length) {
@@ -286,9 +278,7 @@ class StorageLayout {
     // Identify structs by contract and name
     const referencedNode = this.getNode(referencedDeclaration, 'StructDefinition');
     const id = `t_struct<${referencedNode.canonicalName}>`;
-    if (this.types[id]) {
-      return this.types[id];
-    }
+    if (this.types[id]) return this.types[id];
 
     // We shortcircuit type registration in this scenario to handle recursive structs
     const typeInfo = { id, kind: 'struct', label: referencedNode.canonicalName, members: [] };

--- a/packages/lib/src/validations/index.ts
+++ b/packages/lib/src/validations/index.ts
@@ -48,7 +48,7 @@ export function validationPasses(validations: any): boolean {
 
 function validateStorage(contractClass: ContractFactory, existingContractInfo: any = {}, buildArtifacts: any = null): any {
   const originalStorageInfo = _.pick(existingContractInfo, 'storage', 'types');
-  if (_.isEmpty(originalStorageInfo.storage)) { return { }; }
+  if (_.isEmpty(originalStorageInfo.storage)) return {};
 
   const updatedStorageInfo = getStorageLayout(contractClass, buildArtifacts);
   const storageUncheckedVars = getStructsOrEnums(updatedStorageInfo);

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./lib",
     "allowJs": false,
-    "noEmitOnError": true
+    "noEmitOnError": true,
+    "declaration": true
   },
   "include": [
     "./src"

--- a/packages/lib/tsconfig.test.json
+++ b/packages/lib/tsconfig.test.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "allowJs": false,
-    "noEmitOnError": true
+    "allowJs": true
   },
   "include": [
     "./src"

--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,7 @@
       "no-empty": [true, "allow-empty-functions"],
       "no-consecutive-blank-lines": [true, 1],
       "no-var-requires": [false],
-      "curly": [true, "ignore-same-line"]
+      "curly": [true, "ignore-same-line", "as-needed"]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Solves #478 

This PR introduces typed dependencies for the lib package, which can be divided into 3 groups:
1) Dependencies like axios or bignumber.js, that already included `.d.ts` files, for which nothing needed to be done. Note that Web3 v1.x is typed in this way, but Web3 v0.x (the one we're using) is not. 
2) Dependencies like ethereumjs-abi, for which custom `.d.ts` files were written in src/@types.
3) Dependencies like Web3 v0.x which don't have official declaration files in the DefinitelyTyped repository, but unofficial declaration files were found.

In short, the most interesting part of this PR is that we are using typings for Web3 v0.x from `web3-typescript-typings`. The typings were used only in packages/lib/src/artifacts/ZWeb3.ts but could ripple up to a lot of code above, such as Transactions.ts and much, much more. This would be very interesting, since it would define a large part of the interfaces we use, that are currently being used as `any`.