### PR TITLE
Make `lib/bin/zos-cli.js` executable after transpiling to ts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "compile-ts": "rm -rf lib && tsc",
-    "prepare": "npm run compile-ts",
+    "prepare": "npm run compile-ts && chmod 755 ./lib/bin/zos-cli.js",
     "test": "./scripts/test.sh",
     "gen-docs": "babel-node docs/bin/docs.js",
     "watch": "tsc -w",


### PR DESCRIPTION
Closes https://github.com/zeppelinos/zos/issues/518.
Just running a `chmod 755 ./lib/bin/zos-cli.js` after running `npm run compile-ts`. It seems that tsc doesn't keep file system permissions, as mentioned here: https://github.com/Microsoft/TypeScript/issues/16257#issuecomment-319604800
@facuspagnuolo, I noticed that `src/bin/errors.js` and `src/bin/program.js` have also execute permissions, but I don't see why. Any hints?