### PR TITLE
Fixes a bug on encodeCall

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -795,6 +795,10 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bignumber.js": {
+			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+		},
 		"bindings": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -1436,17 +1440,8 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
+				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
 				"ethereumjs-util": "^5.1.1"
-			},
-			"dependencies": {
-				"ethereumjs-abi": {
-					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"requires": {
-						"bn.js": "^4.10.0",
-						"ethereumjs-util": "^5.0.0"
-					}
-				}
 			}
 		},
 		"eth-tx-summary": {
@@ -1587,6 +1582,14 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+		},
+		"ethereumjs-abi": {
+			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+			"requires": {
+				"bn.js": "^4.10.0",
+				"ethereumjs-util": "^5.0.0"
+			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -4020,16 +4023,11 @@
 			"resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
 			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
+				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
 				"crypto-js": "^3.1.4",
 				"utf8": "^2.1.1",
 				"xhr2": "*",
 				"xmlhttprequest": "*"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				}
 			}
 		},
 		"web3-provider-engine": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -795,10 +795,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bignumber.js": {
-			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-		},
 		"bindings": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -1440,8 +1436,17 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
-				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
 				"ethereumjs-util": "^5.1.1"
+			},
+			"dependencies": {
+				"ethereumjs-abi": {
+					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"requires": {
+						"bn.js": "^4.10.0",
+						"ethereumjs-util": "^5.0.0"
+					}
+				}
 			}
 		},
 		"eth-tx-summary": {
@@ -1582,14 +1587,6 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-		},
-		"ethereumjs-abi": {
-			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-			"requires": {
-				"bn.js": "^4.10.0",
-				"ethereumjs-util": "^5.0.0"
-			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -4023,11 +4020,16 @@
 			"resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
 			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
 				"crypto-js": "^3.1.4",
 				"utf8": "^2.1.1",
 				"xhr2": "*",
 				"xmlhttprequest": "*"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+				}
 			}
 		},
 		"web3-provider-engine": {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -1,15 +1,35 @@
 import abi from 'ethereumjs-abi';
 import BN from 'bignumber.js';
 
-function formatValue(value: any): string {
-  if (typeof(value) === 'number' || BN.isBigNumber(value)) return value.toString();
-  else if (typeof(value) === 'string' && value.match(/\d+(\.\d+)?e(\+)?\d+/)) return (new BN(value)).toString(10);
-  else return value;
+export function formatValue(value: any): string | void {
+
+  // Numbers.
+  if(typeof(value) === 'number') {
+    if(value % 1 === 0) return value.toString(10);
+    else throw new Error('Floating point numbers are not supported on parameter encoding.');
+  }
+
+  // Big numbers.
+  if(BN.isBigNumber(value)) return value.toString();
+
+  // Strings.
+  if(typeof(value) === 'string') {
+    const hasHexRadix = value.indexOf('0x') !== -1 || value.indexOf('0X') !== -1;
+
+    // Numeric strings with exponents, e.g. '1.5e9'.
+    if(!hasHexRadix && value.match(/\d+(\.\d+)?e(\+)?\d+/)) {
+      return (new BN(value)).toString(10);
+    }
+  }
+
+  // Something else.
+  return value;
 }
 
 export default function encodeCall(name: string, args: string[] = [], rawValues: any[] = []): string {
-  const values: string[] = rawValues.map(formatValue);
+  const values: string[] = <string[]>rawValues.map(formatValue);
   const methodId: string = abi.methodID(name, args).toString('hex');
+  // TODO: verify that each type-value pair is valid.
   const params: Buffer = abi.rawEncode(args, values).toString('hex');
   return '0x' + methodId + params;
 }

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+require('../../setup');
+
+import encodeCall, { formatValue } from '../../../src/helpers/encodeCall';
+import BN from 'bignumber.js';
+
+describe('encodeCall helper', function() {
+
+  describe('encodeCall function', function() {
+    it('should return a string with the 0x radix', function() {
+      const enc = encodeCall('myFunction', ['uint256', 'address'], [123, '0x123']);
+      assert(enc.indexOf('0x') !== -1);
+    });
+
+    it('should be a valid hexadecimal', function() {
+      const enc = encodeCall('myFunction', ['uint256', 'address'], [123, '0x123']);
+      expect(enc.match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
+    });
+
+    // TODO: extend encoding tests...
+    
+  });
+
+  describe('formatValue function', function() {
+
+    describe('on integers', function() {
+      it('should return a small integer as a string', function() {
+        expect(formatValue(5)).to.equal('5');
+      });
+
+      it('should return a large integer as a string', function() {
+        expect(formatValue(Number.MAX_SAFE_INTEGER)).to.equal(Number.MAX_SAFE_INTEGER.toString());
+      });
+    });
+
+    describe('on floats', function() {
+      it('should throw', function() {
+        expect(function(){ 
+          formatValue(3.14) 
+        }).to.throw(/Floating point numbers are not supported on parameter encoding./);
+      });
+    });
+
+    describe('on bignumbers', function() {
+      it('should return a small bignumber as a string', function() {
+        expect(formatValue(new BN(5))).to.equal('5');
+      });
+
+      it('should return a large bignumber as a string', function() {
+        expect(formatValue(new BN(Number.MAX_SAFE_INTEGER))).to.equal(Number.MAX_SAFE_INTEGER.toString());
+      });
+    });
+
+    describe('on numeric strings', function() {
+      it('should identify numeric strings with exponents', function() {
+        expect(formatValue('1.5e9')).to.equal(new BN('1.5e9').toString(10));
+      });
+    });
+
+    describe('on strings', function() {
+      it('should just pass them along', function() {
+        expect(formatValue('hello')).to.equal('hello');
+        expect(formatValue('42')).to.equal('42');
+      });
+    });
+    
+    describe('on hexadecimal strings', function() {
+      it('should handle addresses', function() {
+        expect(formatValue('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F')).to.equal('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F');
+      });
+      
+      it('should not mistake addresses with "e" characters as exponentials', function() {
+        expect(formatValue('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e')).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
+      });
+      
+      it('should handle other hexadecimal strings', function() {
+        expect(formatValue('0x39af68cF04Abb0e18e')).to.equal('0x39af68cF04Abb0e18e');
+        expect(formatValue('0x2A')).to.equal('0x2A');
+      });
+    });
+    
+    describe('on hexadecimal numbers', function() {
+      it('should handle addresses', function() {
+        expect(formatValue(0xEB1020C2BfA170489fca37068F9c857CDCd5f19F)).to.equal(parseInt('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F', 16).toString());
+      });
+
+      it('should not mistake addresses with "e" characters as exponentials', function() {
+        expect(formatValue(0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e)).to.equal(parseInt('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e', 16).toString());
+      });
+
+      it('should handle other hexadecimal numbers', function() {
+        expect(formatValue(0x39af68cF04Abb0e18e)).to.equal(parseInt('0x39af68cF04Abb0e18e', 16).toString());
+        expect(formatValue(0x2A)).to.equal(parseInt('0x2A', 16).toString());
+      });
+    });
+  });
+})


### PR DESCRIPTION
Fix #421 

Lib's encodeCall helper was failing for any hexadecimal strings that contained the character 'e'. It was interpreting these as an exponential number (e.g. `1.5e9`) and interpreting the hexadecimal value as a decimal.

As a result, addresses like "0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e" were being parsed as some weird exponential number and ending up as "0x0000000000000000000000000000000000000977" in EVM storage.

Note that this PR also includes some tests for the helper, and some suggestions to (1) further improve it and (2) increase its test coverage. 