### PR TITLE
Refactor encodeCall

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -795,6 +795,10 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bignumber.js": {
+			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+		},
 		"bindings": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -1436,17 +1440,8 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
+				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
 				"ethereumjs-util": "^5.1.1"
-			},
-			"dependencies": {
-				"ethereumjs-abi": {
-					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"requires": {
-						"bn.js": "^4.10.0",
-						"ethereumjs-util": "^5.0.0"
-					}
-				}
 			}
 		},
 		"eth-tx-summary": {
@@ -1587,6 +1582,14 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+		},
+		"ethereumjs-abi": {
+			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+			"requires": {
+				"bn.js": "^4.10.0",
+				"ethereumjs-util": "^5.0.0"
+			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -4020,16 +4023,11 @@
 			"resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
 			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
+				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
 				"crypto-js": "^3.1.4",
 				"utf8": "^2.1.1",
 				"xhr2": "*",
 				"xmlhttprequest": "*"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				}
 			}
 		},
 		"web3-provider-engine": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -795,10 +795,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bignumber.js": {
-			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-		},
 		"bindings": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -1440,8 +1436,17 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
-				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
 				"ethereumjs-util": "^5.1.1"
+			},
+			"dependencies": {
+				"ethereumjs-abi": {
+					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"requires": {
+						"bn.js": "^4.10.0",
+						"ethereumjs-util": "^5.0.0"
+					}
+				}
 			}
 		},
 		"eth-tx-summary": {
@@ -1582,14 +1587,6 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-		},
-		"ethereumjs-abi": {
-			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-			"requires": {
-				"bn.js": "^4.10.0",
-				"ethereumjs-util": "^5.0.0"
-			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -4023,11 +4020,16 @@
 			"resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
 			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
 				"crypto-js": "^3.1.4",
 				"utf8": "^2.1.1",
 				"xhr2": "*",
 				"xmlhttprequest": "*"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+				}
 			}
 		},
 		"web3-provider-engine": {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -11,12 +11,15 @@ import _ from 'lodash';
 const ERROR_MESSAGE_PREFIX = 'Encoding error';
 const ERROR_MESSAGE = (type: string, value: any) => `${ERROR_MESSAGE_PREFIX} for type ${type} and value ${value.toString()}`;
 
-export default function encodeCall(name: string, types: string[] = [], rawValues: any[] = []): string {
-  if(types.length !== rawValues.length) throw new Error(ERROR_MESSAGE_PREFIX + '. Supplied number of types and values do not match.');
-  const values = _.zipWith(types, rawValues, parseTypeValuePair);
+export default function encodeCall(name: string, types: string[] = [], values: any[] = []): string {
   const methodId = abi.methodID(name, types).toString('hex');
   const params = abi.rawEncode(types, values).toString('hex');
   return '0x' + methodId + params;
+}
+
+export function parseCallValues(types: string[] = [], rawValues: any[] = []): any[] | never {
+  if(types.length !== rawValues.length) throw new Error(ERROR_MESSAGE_PREFIX + '. Supplied number of types and values do not match.');
+  return _.zipWith(types, rawValues, parseTypeValuePair);
 }
 
 export function parseTypeValuePair(type: string, rawValue: any): any | never {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -30,18 +30,18 @@ export function parseTypeValuePair(type: string, rawValue: any): string | never 
   else if(type === 'string') {
     return rawValue; // Validated by ethereumjs-abi.
   }
-  else if(type.startsWith('bytes')) {
+  else if(type.startsWith('bytes') && !type.includes('[]')) {
     return parseBytes(rawValue);
   }
-  else if(type.startsWith('uint')) {
+  else if(type.startsWith('uint') && !type.includes('[]')) {
     return parseNumber(rawValue, true);
   }
-  else if(type.startsWith('int')) {
+  else if(type.startsWith('int') && !type.includes('[]')) {
     return parseNumber(rawValue, false);
   }
   else {
     // TODO: parse remianing types: fixed, arrays, etc.
-    return rawValue.toString();
+    return rawValue;
   }
 }
 

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -3,62 +3,68 @@ import * as util from 'ethereumjs-util';
 import BN from 'bignumber.js';
 import _ from 'lodash';
 
-const ERROR_MESSAGE_PREFIX = 'Invalid parameter';
-const ERROR_MESSAGE_POSITIVE_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}" must be positive.`;
-const ERROR_MESSAGE_INTEGER_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}" must be an integer.`;
-const ERROR_MESSAGE_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}".`;
-const ERROR_MESSAGE_ADDRESS = (value) => `${ERROR_MESSAGE_PREFIX} address "${value}".`;
-const ERROR_MESSAGE_CHECKSUM_ADDRESS = (value) => `${ERROR_MESSAGE_PREFIX} address "${value}" checksum fails.`;
-const ERROR_MESSAGE_BYTES = (value) => `${ERROR_MESSAGE_PREFIX} bytes "${value}".`;
-const ERROR_MESSAGE_STRING = (value) => `${ERROR_MESSAGE_PREFIX} string "${value}".`;
+const ERROR_MESSAGE_PREFIX = 'Encoding error';
+const ERROR_MESSAGE = (type: string, value: any) => `${ERROR_MESSAGE_PREFIX} for type ${type} and value ${value.toString()}`;
 
 export default function encodeCall(name: string, types: string[] = [], rawValues: any[] = []): string {
-  if(types.length !== rawValues.length) throw new Error('Supplied number of types and values do not match.');
+  if(types.length !== rawValues.length) throw new Error(ERROR_MESSAGE_PREFIX + '. Supplied number of types and values do not match.');
   const values =_.zipWith(types, rawValues, (type: string, value: any) => parseTypeValuePair(type, value));
   const methodId = abi.methodID(name, types).toString('hex');
   const params = abi.rawEncode(types, values).toString('hex');
   return '0x' + methodId + params;
 }
 
-export function parseTypeValuePair(type: string, rawValue: any): string | never {
-  if(type === 'address') return parseAddress(rawValue);
+export function parseTypeValuePair(type: string, rawValue: any): string | string[] | never {
+  // Deal with arrays recursively.
+  if(/^[^\[]+\[.*\]$/.test(type)) {
+    if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
+    if(rawValue.length === 0) return [];
+    const baseType = type.slice(0, type.lastIndexOf('[')); // Remove array part.
+    // TODO: validate length on fixed size arrays.
+    return _.map(rawValue, (rawValueElement) => parseTypeValuePair(baseType, rawValueElement));
+  }
+  // Singles.
+  if(type === 'address') return parseAddress(type, rawValue);
   else if(type === 'string') return rawValue; // Validated by ethereumjs-abi.
-  else if(type.startsWith('bytes') && !type.includes('[]')) return parseBytes(rawValue);
-  else if(type.startsWith('uint') && !type.includes('[]')) return parseNumber(rawValue, true);
-  else if(type.startsWith('int') && !type.includes('[]')) return parseNumber(rawValue, false);
-  else return rawValue; // TODO: parse remianing types: fixed, arrays, etc.
+  else if(type.startsWith('bytes')) return parseBytes(type, rawValue);
+  else if(type.startsWith('uint')) return parseNumber(type, rawValue, true, true);
+  else if(type.startsWith('int')) return parseNumber(type, rawValue, false, true);
+  else if(type.startsWith('ufixed')) return parseNumber(type, rawValue, true, false);
+  else if(type.startsWith('fixed')) return parseNumber(type, rawValue, false, false);
+  else if(type.startsWith('bool')) return rawValue; // TODO
+  else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
 }
 
-function parseBytes(rawValue: string | Buffer): string | never {
+function parseBytes(type: string, rawValue: string | Buffer): string | never {
   if(Buffer.isBuffer(rawValue)) return rawValue.toString();
   else if(typeof(rawValue) === 'string') {
     if(rawValue.toString().length === 0) return rawValue;
     // Require buffers expressed as strings to be valid hexadecimals.
-    if(!/^(0x)[0-9a-f]+$/i.test(rawValue)) throw new Error(ERROR_MESSAGE_BYTES(rawValue));
+    if(!/^(0x)[0-9a-f]+$/i.test(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
     // Test the validity of the buffer.
-    if(Buffer.from(rawValue.substring(2), 'hex').length === 0) throw new Error(ERROR_MESSAGE_BYTES(rawValue));
+    if(Buffer.from(rawValue.substring(2), 'hex').length === 0) throw new Error(ERROR_MESSAGE(type, rawValue));
     return rawValue;
   }
 }
 
-function parseAddress(rawValue: string | Buffer): string | never {
+function parseAddress(type: string, rawValue: string | Buffer): string | never {
   const strAddress = rawValue.toString();
-  if(!util.isValidAddress(strAddress)) throw new Error(ERROR_MESSAGE_ADDRESS(rawValue));
+  if(!util.isValidAddress(strAddress)) throw new Error(ERROR_MESSAGE(type, rawValue));
   // If the address' characters are not all uppercase or lowercase, assume that there is checksum to validate.
   if(/[a-f]/.test(strAddress.substring(2)) && /[A-F]/.test(strAddress.substring(2))) {
-    if(!util.isValidChecksumAddress(strAddress)) throw new Error(ERROR_MESSAGE_CHECKSUM_ADDRESS(rawValue));
+    if(!util.isValidChecksumAddress(strAddress)) throw new Error(ERROR_MESSAGE(type, rawValue) + '. Checksum error.');
   }
   return strAddress;
 }
 
-function parseNumber(rawValue: number | string | BN, mustBePositive: boolean): string | never {
-  if(isNaN(<any>rawValue)) throw new Error(ERROR_MESSAGE_NUMBER(rawValue));
-  if(typeof(rawValue === 'number') && !isFinite(<any>rawValue)) throw new Error(ERROR_MESSAGE_NUMBER(rawValue));
+function parseNumber(type: string, rawValue: number | string | BN, mustBePositive: boolean, mustBeInteger: boolean): string | never {
+  if(isNaN(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
+  if(typeof(rawValue === 'number') && !isFinite(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
   if(typeof(rawValue) === 'string') rawValue = (<string>rawValue).toLowerCase();
   // Funnel everything through bignumber.js.
   const bn = BN.isBigNumber(rawValue) ? <BN>rawValue : new BN(rawValue);
-  if(bn.isNaN()) throw new Error(ERROR_MESSAGE_NUMBER(rawValue));
-  if(mustBePositive && bn.isNegative()) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(rawValue));
-  if(!bn.isInteger()) throw new Error(ERROR_MESSAGE_INTEGER_NUMBER(rawValue));
+  if(bn.isNaN()) throw new Error(ERROR_MESSAGE(type, rawValue));
+  if(mustBePositive && bn.isNegative()) throw new Error(ERROR_MESSAGE(type, rawValue));
+  if(mustBeInteger && !bn.isInteger()) throw new Error(ERROR_MESSAGE(type, rawValue));
   return bn.toString(10);
 }

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -32,7 +32,7 @@ export function parseTypeValuePair(type: string, rawValue: any): any | never {
   // Single type.
   if(type === 'address') return parseAddress(type, rawValue);
   else if(type === 'bool') return parseBool(type, rawValue);
-  else if(type === 'string') return rawValue; // Validated by ethereumjs-abi.
+  else if(type === 'string') return parseString(type, rawValue);
   else if(type.startsWith('bytes')) return parseBytes(type, rawValue);
   else if(type.startsWith('uint')) return parseNumber(type, rawValue, true, true);
   else if(type.startsWith('int')) return parseNumber(type, rawValue, false, true);
@@ -41,7 +41,13 @@ export function parseTypeValuePair(type: string, rawValue: any): any | never {
   else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
 }
 
+function parseString(type: string, rawValue: string): string | never {
+  if(typeof(rawValue) !== 'string') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  return rawValue;
+}
+
 function parseBool(type: string, rawValue: string | boolean): boolean | never {
+  if(typeof(rawValue) !== 'string' && typeof(rawValue) !== 'boolean') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   if(typeof(rawValue) === 'boolean') return rawValue;
   else if(typeof(rawValue) === 'string') {
     if(rawValue === 'true') return true;
@@ -53,6 +59,7 @@ function parseBool(type: string, rawValue: string | boolean): boolean | never {
 
 // TODO: Validate data for fixed size byte arrays (bytes1, bytes2, etc).
 function parseBytes(type: string, rawValue: string | Buffer): Buffer | never {
+  if(typeof(rawValue) !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   if(Buffer.isBuffer(rawValue)) return rawValue;
   else if(typeof(rawValue) === 'string') {
     if(rawValue.length === 0) return Buffer.from(''); // Allow buffers from empty strings.
@@ -66,6 +73,7 @@ function parseBytes(type: string, rawValue: string | Buffer): Buffer | never {
 }
 
 function parseAddress(type: string, rawValue: string | Buffer): string | never {
+  if(typeof(rawValue) !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   const strAddress = rawValue.toString();
   if(!util.isValidAddress(strAddress)) throw new Error(ERROR_MESSAGE(type, rawValue));
   // If the address' characters are not all uppercase or lowercase, assume that there is checksum to validate.
@@ -76,6 +84,7 @@ function parseAddress(type: string, rawValue: string | Buffer): string | never {
 }
 
 function parseNumber(type: string, rawValue: number | string | BN, mustBePositive: boolean, mustBeInteger: boolean): string | never {
+  if(typeof(rawValue) !== 'number' && typeof(rawValue) !== 'string' && !BN.isBigNumber(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   if(isNaN(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
   if(typeof(rawValue === 'number') && !isFinite(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
   if(typeof(rawValue) === 'string') rawValue = (<string>rawValue).toLowerCase();

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -1,35 +1,98 @@
 import abi from 'ethereumjs-abi';
+import * as util from 'ethereumjs-util';
 import BN from 'bignumber.js';
+import _ from 'lodash';
 
-export function formatValue(value: any): string | void {
+const ERROR_MESSAGE_PREFIX = 'Invalid parameter';
+const ERROR_MESSAGE_POSITIVE_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}" must be positive.`;
+const ERROR_MESSAGE_INTEGER_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}" must be an integer.`;
+const ERROR_MESSAGE_NUMBER = (value) => `${ERROR_MESSAGE_PREFIX} number "${value}".`;
+const ERROR_MESSAGE_ADDRESS = (value) => `${ERROR_MESSAGE_PREFIX} address "${value}".`;
+const ERROR_MESSAGE_CHECKSUM_ADDRESS = (value) => `${ERROR_MESSAGE_PREFIX} address "${value}" checksum fails.`;
+const ERROR_MESSAGE_BYTES = (value) => `${ERROR_MESSAGE_PREFIX} bytes "${value}".`;
+const ERROR_MESSAGE_STRING = (value) => `${ERROR_MESSAGE_PREFIX} string "${value}".`;
 
-  // Numbers.
-  if(typeof(value) === 'number') {
-    if(value % 1 === 0) return value.toString(10);
-    else throw new Error('Floating point numbers are not supported on parameter encoding.');
+export default function encodeCall(name: string, types: string[] = [], rawValues: any[] = []): string {
+  if(types.length !== rawValues.length) throw new Error('Supplied number of types and values do not match.');
+  const values = [];
+  _.zipWith(types, rawValues, function(type: string, value: any) {
+    values.push(parseTypeValuePair(type, value));
+  });
+  const methodId = abi.methodID(name, types).toString('hex');
+  const params = abi.rawEncode(types, values).toString('hex');
+  return '0x' + methodId + params;
+}
+
+export function parseTypeValuePair(type: string, rawValue: any): string | never {
+  if(type === 'address') {
+    return parseAddress(rawValue);
   }
-
-  // Big numbers.
-  if(BN.isBigNumber(value)) return value.toString();
-
-  // Strings.
-  if(typeof(value) === 'string') {
-    const hasHexRadix = value.indexOf('0x') !== -1 || value.indexOf('0X') !== -1;
-
-    // Numeric strings with exponents, e.g. '1.5e9'.
-    if(!hasHexRadix && value.match(/\d+(\.\d+)?e(\+)?\d+/)) {
-      return (new BN(value)).toString(10);
-    }
+  else if(type === 'string') {
+    return rawValue; // Validated by ethereumjs-abi.
   }
+  else if(type.startsWith('bytes')) {
+    return parseBytes(rawValue);
+  }
+  else if(type.startsWith('uint')) {
+    return parseNumber(rawValue, true);
+  }
+  else if(type.startsWith('int')) {
+    return parseNumber(rawValue, false);
+  }
+  else {
+    // TODO: parse remianing types: fixed, arrays, etc.
+    return rawValue.toString();
+  }
+}
 
-  // Something else.
+function parseBytes(value: any): string | never {
+  if(typeof(value) !== 'string') throw new Error(ERROR_MESSAGE_BYTES(value));
+  if(!/^(0x)?[0-9a-f]$/i.test(value)) throw new Error(ERROR_MESSAGE_BYTES(value));
   return value;
 }
 
-export default function encodeCall(name: string, args: string[] = [], rawValues: any[] = []): string {
-  const values: string[] = <string[]>rawValues.map(formatValue);
-  const methodId: string = abi.methodID(name, args).toString('hex');
-  // TODO: verify that each type-value pair is valid.
-  const params: Buffer = abi.rawEncode(args, values).toString('hex');
-  return '0x' + methodId + params;
+function parseAddress(value: any): string | never {
+  if(typeof(value) !== 'string') throw new Error(ERROR_MESSAGE_ADDRESS(value));
+  if(!/^(0x)?[0-9a-f]{40}$/i.test(value)) throw new Error(ERROR_MESSAGE_ADDRESS(value));
+  // TODO: It'd be nice to perform a checksum validation here.
+  return value;
+}
+
+function parseNumber(value: any, mustBePositive: boolean): string | never {
+  if(typeof(value) === 'number') return parseNumberFromLiteral(value, mustBePositive);
+  else if(typeof(value) === 'string') return parseNumberFromString(value, mustBePositive);
+  else if(BN.isBigNumber(value)) return parseNumberFromBigNumber(new BN(value), mustBePositive);
+  throw new Error(ERROR_MESSAGE_NUMBER(value));
+}
+
+function parseNumberFromBigNumber(value: BN, mustBePositive: boolean): string | never {
+  if(mustBePositive && value.isNegative()) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(value));
+  if(!value.isInteger()) throw new Error(ERROR_MESSAGE_INTEGER_NUMBER(value));
+  return value.toString();
+}
+
+function parseNumberFromString(value: string, mustBePositive: boolean): string | never {
+  if(isNaN(<any>value)) throw new Error(ERROR_MESSAGE_NUMBER(value));
+  if(value.startsWith('0x') || value.startsWith('0X')) { // Hex.
+    if(!isNaN(parseInt(value, 16))) throw new Error(ERROR_MESSAGE_NUMBER(value));
+    if(mustBePositive && parseInt(value, 16) < 0) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(value));
+    return value;
+  }
+  else { // Not hex.
+    if(value.match(/\d+(\.\d+)?e(\+)?\d+/)) { // Numeric strings with exponents, e.g. '1.5e9'.
+      return parseNumberFromBigNumber(new BN(value), mustBePositive);
+    }
+    else { // Not exponential.
+      if(value.indexOf('.') !== -1) throw new Error(ERROR_MESSAGE_INTEGER_NUMBER(value));
+      const valueNum = parseInt(value, 10);
+      if(valueNum < 0) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(value));
+      return value;
+    }
+  }
+}
+
+function parseNumberFromLiteral(value: number, mustBePositive: boolean): string | never {
+  if(value % 1 !== 0) throw new Error(ERROR_MESSAGE_INTEGER_NUMBER(value));
+  if(mustBePositive && value < 0) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(value));
+  return value.toString();
 }

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -15,7 +15,7 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 }
 
 export function parseTypeValuePair(type: string, rawValue: any): string | string[] | never {
-  // Deal with arrays recursively.
+  // Array type (recurse).
   if(/^[^\[]+\[.*\]$/.test(type)) {
     if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
@@ -23,15 +23,15 @@ export function parseTypeValuePair(type: string, rawValue: any): string | string
     // TODO: validate length on fixed size arrays.
     return _.map(rawValue, (rawValueElement) => parseTypeValuePair(baseType, rawValueElement));
   }
-  // Singles.
+  // Single type.
   if(type === 'address') return parseAddress(type, rawValue);
+  else if(type === 'bool') return rawValue; // TODO
   else if(type === 'string') return rawValue; // Validated by ethereumjs-abi.
   else if(type.startsWith('bytes')) return parseBytes(type, rawValue);
   else if(type.startsWith('uint')) return parseNumber(type, rawValue, true, true);
   else if(type.startsWith('int')) return parseNumber(type, rawValue, false, true);
   else if(type.startsWith('ufixed')) return parseNumber(type, rawValue, true, false);
   else if(type.startsWith('fixed')) return parseNumber(type, rawValue, false, false);
-  else if(type.startsWith('bool')) return rawValue; // TODO
   else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
 }
 

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -14,7 +14,7 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
   return '0x' + methodId + params;
 }
 
-export function parseTypeValuePair(type: string, rawValue: any): string | string[] | never {
+export function parseTypeValuePair(type: string, rawValue: any): string | string[] | boolean | never {
   // Array type (recurse).
   if(/^[^\[]+\[.*\]$/.test(type)) {
     if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
@@ -25,7 +25,7 @@ export function parseTypeValuePair(type: string, rawValue: any): string | string
   }
   // Single type.
   if(type === 'address') return parseAddress(type, rawValue);
-  else if(type === 'bool') return rawValue; // TODO
+  else if(type === 'bool') return parseBool(type, rawValue);
   else if(type === 'string') return rawValue; // Validated by ethereumjs-abi.
   else if(type.startsWith('bytes')) return parseBytes(type, rawValue);
   else if(type.startsWith('uint')) return parseNumber(type, rawValue, true, true);
@@ -33,6 +33,16 @@ export function parseTypeValuePair(type: string, rawValue: any): string | string
   else if(type.startsWith('ufixed')) return parseNumber(type, rawValue, true, false);
   else if(type.startsWith('fixed')) return parseNumber(type, rawValue, false, false);
   else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
+}
+
+function parseBool(type: string, rawValue: string | boolean): boolean | never {
+  if(typeof(rawValue) === 'boolean') return <boolean>rawValue;
+  else if(typeof(rawValue) === 'string') {
+    if(rawValue === 'true') return true;
+    else if(rawValue === 'false') return false;
+    else throw new Error(ERROR_MESSAGE(type, rawValue));
+  }
+  throw new Error(ERROR_MESSAGE(type, rawValue));
 }
 
 function parseBytes(type: string, rawValue: string | Buffer): string | never {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -21,25 +21,12 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 }
 
 export function parseTypeValuePair(type: string, rawValue: any): string | never {
-  if(type === 'address') {
-    return parseAddress(rawValue);
-  }
-  else if(type === 'string') {
-    return rawValue; // Validated by ethereumjs-abi.
-  }
-  else if(type.startsWith('bytes') && !type.includes('[]')) {
-    return parseBytes(rawValue);
-  }
-  else if(type.startsWith('uint') && !type.includes('[]')) {
-    return parseNumber(rawValue, true);
-  }
-  else if(type.startsWith('int') && !type.includes('[]')) {
-    return parseNumber(rawValue, false);
-  }
-  else {
-    // TODO: parse remianing types: fixed, arrays, etc.
-    return rawValue;
-  }
+  if(type === 'address') return parseAddress(rawValue);
+  else if(type === 'string') return rawValue; // Validated by ethereumjs-abi.
+  else if(type.startsWith('bytes') && !type.includes('[]')) return parseBytes(rawValue);
+  else if(type.startsWith('uint') && !type.includes('[]')) return parseNumber(rawValue, true);
+  else if(type.startsWith('int') && !type.includes('[]')) return parseNumber(rawValue, false);
+  else return rawValue; // TODO: parse remianing types: fixed, arrays, etc.
 }
 
 function parseBytes(rawValue: string | Buffer): string | never {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -20,7 +20,7 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 }
 
 export function parseTypeValuePair(type: string, rawValue: any): any | never {
-  // Typle type (recurse by calling this function with the individual elements).
+  // Tuple type (recurse by calling this function with the individual elements).
   if(/^\(.*\)$/.test(type)) { // Test for '(type1,type2)' in type.
     if(typeof rawValue === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -21,14 +21,14 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 
 export function parseTypeValuePair(type: string, rawValue: any): any | never {
   // Typle type (recurse by calling this function with the individual elements).
-  if(/^\(.*\)$/.test(type)) {
+  if(/^\(.*\)$/.test(type)) { // Test for '(type1,type2)' in type.
     if(typeof rawValue === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
     const types = type.replace(/[{()}]/g, '').split(','); // Remove the parenthesis and split the tuple into types.
     return _.zipWith(types, rawValue, (typeElement, rawValueElement) => parseTypeValuePair(typeElement, rawValueElement));
   }
   // Array type (also recurse).
-  if(/^[^\[]+\[.*\]$/.test(type)) { // Test for '[]' in type.
+  if(/^[^\[]+\[.*\]$/.test(type)) { // Test for 'type[*]' in type.
     if(typeof rawValue === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
     const size = type.match(/(.*)\[(.*?)\]$/)[2]; // Find number between '[*]'.

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -40,12 +40,12 @@ export function parseTypeValuePair(type: string, rawValue: any): any | never {
   if(type === 'address') return parseAddress(type, rawValue);
   else if(type === 'bool') return parseBool(type, rawValue);
   else if(type === 'string') return parseString(type, rawValue);
+  else if(type === 'function') return parseFunction(type, rawValue);
   else if(type.startsWith('bytes')) return parseBytes(type, rawValue);
   else if(type.startsWith('uint')) return parseNumber(type, rawValue, true, true);
   else if(type.startsWith('int')) return parseNumber(type, rawValue, false, true);
   else if(type.startsWith('ufixed')) return parseNumber(type, rawValue, true, false);
   else if(type.startsWith('fixed')) return parseNumber(type, rawValue, false, false);
-  else if(type.startsWith('function')) return parseFunction(type, rawValue);
   else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
 }
 

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -16,13 +16,12 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 
 export function parseTypeValuePair(type: string, rawValue: any): string | string[] | boolean | never {
   // Array type (recurse).
-  if(/^[^\[]+\[.*\]$/.test(type)) {
+  if(/^[^\[]+\[.*\]$/.test(type)) { // Test for '[*]' in type.
     if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
-    const size = type.match(/(.*)\[(.*?)\]$/)[2];
+    const size = type.match(/(.*)\[(.*?)\]$/)[2]; // Find number between '[]'.
     if(size !== '' && parseInt(size, 10) !== rawValue.length) throw new Error(ERROR_MESSAGE(type, rawValue) + '. Invalid array length.');
     const baseType = type.slice(0, type.lastIndexOf('[')); // Remove array part.
-    // TODO: validate length on fixed size arrays.
     return _.map(rawValue, (rawValueElement) => parseTypeValuePair(baseType, rawValueElement));
   }
   // Single type.
@@ -38,7 +37,7 @@ export function parseTypeValuePair(type: string, rawValue: any): string | string
 }
 
 function parseBool(type: string, rawValue: string | boolean): boolean | never {
-  if(typeof(rawValue) === 'boolean') return <boolean>rawValue;
+  if(typeof(rawValue) === 'boolean') return rawValue;
   else if(typeof(rawValue) === 'string') {
     if(rawValue === 'true') return true;
     else if(rawValue === 'false') return false;

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -1,15 +1,35 @@
 import abi from 'ethereumjs-abi';
 import BN from 'bignumber.js';
 
-function formatValue(value: any): string {
-  if (typeof(value) === 'number' || BN.isBigNumber(value)) return value.toString();
-  else if (typeof(value) === 'string' && value.match(/\d+(\.\d+)?e(\+)?\d+/)) return (new BN(value)).toString(10);
-  else return value;
+export function formatValue(value: any): string | void {
+
+  // Numbers.
+  if(typeof(value) === 'number') {
+    if(value % 1 === 0) return value.toString(10);
+    else throw new Error('Floating point numbers are not supported on parameter encoding.');
+  }
+
+  // Big numbers.
+  if(BN.isBigNumber(value)) return value.toString();
+
+  // Strings.
+  if(typeof(value) === 'string') {
+    const hasHexRadix = value.indexOf('0x') !== -1 || value.indexOf('0X') !== -1;
+
+    // Numeric strings with exponents, e.g. '1.5e9'.
+    if(!hasHexRadix && value.match(/\d+(\.\d+)?e(\+)?\d+/)) {
+      return (new BN(value)).toString(10);
+    }
+  }
+
+  // Something else.
+  return value;
 }
 
 export default function encodeCall(name: string, args: string[] = [], rawValues: any[] = []): string {
-  const values: string[] = rawValues.map(formatValue);
+  const values: string[] = <string[]>rawValues.map(formatValue);
   const methodId: string = abi.methodID(name, args).toString('hex');
+  // TODO: verify that each type-value pair is valid.
   const params: Buffer = abi.rawEncode(args, values).toString('hex');
   return '0x' + methodId + params;
 }

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -47,6 +47,7 @@ export function parseTypeValuePair(type: string, rawValue: any): string | never 
 
 function parseBytes(value: any): string | never {
   if(typeof(value) !== 'string') throw new Error(ERROR_MESSAGE_BYTES(value));
+  if(value.toString().length === 0) return value;
   if(!/^(0x)?[0-9a-f]$/i.test(value)) throw new Error(ERROR_MESSAGE_BYTES(value));
   return value;
 }

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -20,7 +20,14 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 }
 
 export function parseTypeValuePair(type: string, rawValue: any): any | never {
-  // Array type (recurse by calling this function with the individual elements).
+  // Typle type (recurse by calling this function with the individual elements).
+  if(/^\(.*\)$/.test(type)) {
+    if(typeof rawValue === 'string') rawValue = rawValue.split(',');
+    if(rawValue.length === 0) return [];
+    const types = type.replace(/[{()}]/g, '').split(','); // Remove the parenthesis and split the tuple into types.
+    return _.zipWith(types, rawValue, (typeElement, rawValueElement) => parseTypeValuePair(typeElement, rawValueElement));
+  }
+  // Array type (also recurse).
   if(/^[^\[]+\[.*\]$/.test(type)) { // Test for '[]' in type.
     if(typeof rawValue === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
@@ -39,7 +46,6 @@ export function parseTypeValuePair(type: string, rawValue: any): any | never {
   else if(type.startsWith('ufixed')) return parseNumber(type, rawValue, true, false);
   else if(type.startsWith('fixed')) return parseNumber(type, rawValue, false, false);
   else if(type.startsWith('function')) return parseFunction(type, rawValue);
-  // TODO: Handle tuple types
   else throw new Error(ERROR_MESSAGE(type, rawValue) + '. Unsupported or invalid type.');
 }
 

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -69,7 +69,7 @@ function parseNumber(value: any, mustBePositive: boolean): string | never {
 function parseNumberFromBigNumber(value: BN, mustBePositive: boolean): string | never {
   if(mustBePositive && value.isNegative()) throw new Error(ERROR_MESSAGE_POSITIVE_NUMBER(value));
   if(!value.isInteger()) throw new Error(ERROR_MESSAGE_INTEGER_NUMBER(value));
-  return value.toString();
+  return value.toString(10);
 }
 
 function parseNumberFromString(value: string, mustBePositive: boolean): string | never {

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -19,6 +19,8 @@ export function parseTypeValuePair(type: string, rawValue: any): string | string
   if(/^[^\[]+\[.*\]$/.test(type)) {
     if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
+    const size = type.match(/(.*)\[(.*?)\]$/)[2];
+    if(size !== '' && parseInt(size, 10) !== rawValue.length) throw new Error(ERROR_MESSAGE(type, rawValue) + '. Invalid array length.');
     const baseType = type.slice(0, type.lastIndexOf('[')); // Remove array part.
     // TODO: validate length on fixed size arrays.
     return _.map(rawValue, (rawValueElement) => parseTypeValuePair(baseType, rawValueElement));

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -22,7 +22,7 @@ export default function encodeCall(name: string, types: string[] = [], rawValues
 export function parseTypeValuePair(type: string, rawValue: any): any | never {
   // Array type (recurse).
   if(/^[^\[]+\[.*\]$/.test(type)) { // Test for '[*]' in type.
-    if(typeof(rawValue) === 'string') rawValue = rawValue.split(',');
+    if(typeof rawValue === 'string') rawValue = rawValue.split(',');
     if(rawValue.length === 0) return [];
     const size = type.match(/(.*)\[(.*?)\]$/)[2]; // Find number between '[]'.
     if(size !== '' && parseInt(size, 10) !== rawValue.length) throw new Error(ERROR_MESSAGE(type, rawValue) + '. Invalid array length.');
@@ -42,14 +42,14 @@ export function parseTypeValuePair(type: string, rawValue: any): any | never {
 }
 
 function parseString(type: string, rawValue: string): string | never {
-  if(typeof(rawValue) !== 'string') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  if(typeof rawValue !== 'string') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   return rawValue;
 }
 
 function parseBool(type: string, rawValue: string | boolean): boolean | never {
-  if(typeof(rawValue) !== 'string' && typeof(rawValue) !== 'boolean') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
-  if(typeof(rawValue) === 'boolean') return rawValue;
-  else if(typeof(rawValue) === 'string') {
+  if(typeof rawValue !== 'string' && typeof rawValue !== 'boolean') throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  if(typeof rawValue === 'boolean') return rawValue;
+  else if(typeof rawValue === 'string') {
     if(rawValue === 'true') return true;
     else if(rawValue === 'false') return false;
     else throw new Error(ERROR_MESSAGE(type, rawValue));
@@ -59,9 +59,9 @@ function parseBool(type: string, rawValue: string | boolean): boolean | never {
 
 // TODO: Validate data for fixed size byte arrays (bytes1, bytes2, etc).
 function parseBytes(type: string, rawValue: string | Buffer): Buffer | never {
-  if(typeof(rawValue) !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  if(typeof rawValue !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   if(Buffer.isBuffer(rawValue)) return rawValue;
-  else if(typeof(rawValue) === 'string') {
+  else if(typeof rawValue === 'string') {
     if(rawValue.length === 0) return Buffer.from(''); // Allow buffers from empty strings.
     // Require buffers expressed as strings to be valid hexadecimals.
     if(!/^(0x)[0-9a-f]+$/i.test(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
@@ -73,7 +73,7 @@ function parseBytes(type: string, rawValue: string | Buffer): Buffer | never {
 }
 
 function parseAddress(type: string, rawValue: string | Buffer): string | never {
-  if(typeof(rawValue) !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  if(typeof rawValue !== 'string' && !Buffer.isBuffer(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   const strAddress = rawValue.toString();
   if(!util.isValidAddress(strAddress)) throw new Error(ERROR_MESSAGE(type, rawValue));
   // If the address' characters are not all uppercase or lowercase, assume that there is checksum to validate.
@@ -84,10 +84,10 @@ function parseAddress(type: string, rawValue: string | Buffer): string | never {
 }
 
 function parseNumber(type: string, rawValue: number | string | BN, mustBePositive: boolean, mustBeInteger: boolean): string | never {
-  if(typeof(rawValue) !== 'number' && typeof(rawValue) !== 'string' && !BN.isBigNumber(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
+  if(typeof rawValue !== 'number' && typeof rawValue !== 'string' && !BN.isBigNumber(rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue)); // Runtime type check.
   if(isNaN(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
   if(typeof(rawValue === 'number') && !isFinite(<any>rawValue)) throw new Error(ERROR_MESSAGE(type, rawValue));
-  if(typeof(rawValue) === 'string') rawValue = (<string>rawValue).toLowerCase();
+  if(typeof rawValue === 'string') rawValue = (<string>rawValue).toLowerCase();
   // Funnel everything through bignumber.js.
   const bn = BN.isBigNumber(rawValue) ? <BN>rawValue : new BN(rawValue);
   if(bn.isNaN()) throw new Error(ERROR_MESSAGE(type, rawValue));

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -1,4 +1,4 @@
-import encodeCall from '../helpers/encodeCall';
+import encodeCall, { parseCallValues } from '../helpers/encodeCall';
 import ContractAST, { Node } from './ContractAST';
 import ContractFactory from '../artifacts/ContractFactory';
 
@@ -20,7 +20,7 @@ interface FunctionInfo {
 export function buildCallData(contractClass: ContractFactory, methodName: string, args: any[]): CalldataInfo {
   const method = getABIFunction(contractClass, methodName, args);
   const argTypes = method.inputs.map((input) => input.type);
-  const callData = encodeCall(method.name, argTypes, args);
+  const callData = encodeCall(method.name, argTypes, parseCallValues(argTypes, args));
   return { method, callData };
 }
 

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -70,7 +70,25 @@ describe('encodeCall helper', function() {
         encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3']);
       }).to.throw(/Invalid parameter/);
     });
-    
+
+    it('should accept array parameters', function() {
+      expect(function() {
+        encodeCall('myFunction', ['uint256[]'], [[20, 30]]);
+      }).to.not.throw();
+    });
+
+    it('should accept empty bytes', function() {
+      expect(function() {
+        encodeCall('myFunction', ['bytes'], ['']);
+      }).to.not.throw();
+    });
+
+    it('should understand scientific notation numbers', function() {
+      expect(function() {
+        encodeCall('myFunction', ['uint256'], ['20e70']);
+      }).to.not.throw();
+    });
+
   });
 
   describe('parseValuePair function', function() {
@@ -83,6 +101,11 @@ describe('encodeCall helper', function() {
       it('should return a large integer as a string', function() {
         expect(parseTypeValuePair('uint', Number.MAX_SAFE_INTEGER)).to.equal(Number.MAX_SAFE_INTEGER.toString());
       });
+
+      it('should understand scientific notation numbers', function() {
+        expect(parseTypeValuePair('int', '20e70')).to.equal(new BN('2e+71').toString(10));
+      });
+      
     });
 
     describe('on floats', function() {
@@ -100,6 +123,12 @@ describe('encodeCall helper', function() {
 
       it('should return a large bignumber as a string', function() {
         expect(parseTypeValuePair('int', new BN(Number.MAX_SAFE_INTEGER))).to.equal(Number.MAX_SAFE_INTEGER.toString());
+      });
+    });
+
+    describe('on arrays', function() {
+      it('should not parse the array in any way', function() {
+        expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal([20, 30]);
       });
     });
 

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -191,7 +191,9 @@ describe('encodeCall helper', () => {
       it('supports nested tuples/arrays', function() {
         expect(parseTypeValuePair('(uint256,string[])', [42, ['one', 'two', 'three']])).to.deep.equal(['42', ['one', 'two', 'three']]);
         expect(parseTypeValuePair('(uint256,string)[]', [[42, 'hello'], ['42', 'bye']])).to.deep.equal([['42', 'hello'], ['42', 'bye']]);
-        expect(parseTypeValuePair('(uint256,(uint256,string))', [42, 42, 'hello'])).to.deep.equal(['42', '42', 'hello']);
+        expect(parseTypeValuePair('(uint256,(uint256,string))', [42, [42, 'hello']])).to.deep.equal(['42', ['42', 'hello']]);
+        expect(parseTypeValuePair('(address,uint256,(uint256,bool),(uint256,(uint256,int,(string,bool,fixed))))', ['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', 42, [43, false], [5, [6, 1, ['hello', true, 3.14]]]])).to.deep.equal(['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '42', ['43', false], ['5', ['6', '1', ['hello', true, '3.14']]]]);
+        // 
       });
 
       it('should throw when the passed tuple types do not match', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -170,6 +170,8 @@ describe.only('encodeCall helper', () => {
       it('should handle arrays', () => {
         expect(parseTypeValuePair('uint256[]', '20,30')).to.deep.equal(['20', '30']);
         expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal(['20', '30']);
+        expect(parseTypeValuePair('address[]', ['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'])).to.deep.equal(['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0']);
+        expect(parseTypeValuePair('string[]', ['one', 'two'])).to.deep.equal(['one', 'two']);
       });
 
       it('should handle empty arrays', () => {
@@ -182,11 +184,16 @@ describe.only('encodeCall helper', () => {
         expect(() => parseTypeValuePair('uint256[]', '20,-30')).to.throw(/Encoding error/);
       });
 
-      it('should throw when array fixed size and number of elements do not match');
-      it('should parse number array elements');
-      it('should parse address elements');
-      it('should parse bytes elements');
-      it('should parse string elements');
+      it('should handle fixed sized arrays', () => {
+        expect(parseTypeValuePair('uint256[1]', [1])).to.deep.equal(['1']);
+        expect(parseTypeValuePair('uint256[2]', [1, 2])).to.deep.equal(['1', '2']);
+        expect(parseTypeValuePair('uint256[3]', [1, 2, 3])).to.deep.equal(['1', '2', '3']);
+      });
+
+      it('should throw when array fixed size and number of elements do not match', () => {
+        expect(() => parseTypeValuePair('uint[2]', [1])).to.throw(/Invalid array length/);
+        expect(() => parseTypeValuePair('uint[2]', [1, 2, 3])).to.throw(/Invalid array length/);
+      });
     });
   });
 })

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -25,8 +25,8 @@ describe('encodeCall helper', () => {
       });
 
       it('should fail with invalid type widths', () => {
-        expect(() => encodeCall('myFunction', ['uint956'], [123])).to.throw(/Invalid/);
-        expect(() => encodeCall('myFunction', ['bytes0'], [123])).to.throw(/Invalid/);
+        expect(() => encodeCall('myFunction', ['uint512'], [123])).to.throw(/Invalid/);
+        expect(() => encodeCall('myFunction', ['bytes0'], [Buffer.from('0xab', 'hex')])).to.throw(/Invalid/);
       });
     
       it('should fail with invalid non matching number of types and values', () => {
@@ -40,7 +40,7 @@ describe('encodeCall helper', () => {
         expect(() => encodeCall('myFunction', ['int'], ['-3.14'])).to.throw(/Encoding error/);
         expect(() => encodeCall('myFunction', ['string'], [32])).to.throw();
         expect(() => encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw();
+        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw(/Encoding error/);
       });
     });
   });
@@ -91,6 +91,10 @@ describe('encodeCall helper', () => {
       it('should throw when the specified numeric literal is not finite', () => {
         expect(() => parseTypeValuePair('uint', 2**2000)).to.throw(/Encoding error/);
       });
+
+      it('should throw when the passed value is not a string, not a number nor a big number', () => {
+        expect(() => parseTypeValuePair('int', {})).to.throw(/Encoding error/);
+      });
     });
 
     describe('when the specified type is a string', () => {
@@ -99,6 +103,11 @@ describe('encodeCall helper', () => {
         expect(parseTypeValuePair('string', '0x123')).to.equal('0x123');
         expect(parseTypeValuePair('string', '42')).to.equal('42');
         expect(parseTypeValuePair('string', '0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e')).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
+      });
+
+      it('should throw when the passed value is not a string nor a Buffer', () => {
+        expect(() => parseTypeValuePair('string', 42)).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('string', {})).to.throw(/Encoding error/);
       });
     });
 
@@ -111,6 +120,11 @@ describe('encodeCall helper', () => {
 
       it('should throw when a byte array expressed as a hexadecimal string is invalid', () => {
         expect(() => parseTypeValuePair('bytes', '0xabcqqq')).to.throw(/Encoding error/);
+      });
+
+      it('should throw when the passed value is not a string nor a Buffer', () => {
+        expect(() => parseTypeValuePair('bytes', 42)).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('bytes', {})).to.throw(/Encoding error/);
       });
 
       it('should accept Buffer objects', function() {
@@ -145,6 +159,11 @@ describe('encodeCall helper', () => {
       it('should accept addresses passed as buffers', () => {
         expect(parseTypeValuePair('address', Buffer.from('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e', 'utf8'))).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
       });
+
+      it('should throw when the passed value is not a string nor a Buffer', () => {
+        expect(() => parseTypeValuePair('address', 42)).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('address', {})).to.throw(/Encoding error/);
+      });
     });
 
     describe('when the specified type is a fixed non integer number', () => {
@@ -164,7 +183,11 @@ describe('encodeCall helper', () => {
 
       it('should reject invalid boolean values', () => {
         expect(() => parseTypeValuePair('bool', 'falsy')).to.throw();
-        expect(() => parseTypeValuePair('bool', 32)).to.throw();
+      });
+
+      it('should throw when the passed value is not a string nor a boolean', () => {
+        expect(() => parseTypeValuePair('bool', 42)).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('bool', {})).to.throw(/Encoding error/);
       });
     });
 
@@ -174,6 +197,8 @@ describe('encodeCall helper', () => {
         expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal(['20', '30']);
         expect(parseTypeValuePair('address[]', ['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'])).to.deep.equal(['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0']);
         expect(parseTypeValuePair('string[]', ['one', 'two'])).to.deep.equal(['one', 'two']);
+        expect(parseTypeValuePair('bool[]', ['true', 'false'])).to.deep.equal([true, false]);
+        expect(parseTypeValuePair('bool[]', [true, false])).to.deep.equal([true, false]);
       });
 
       it('should handle empty arrays', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -193,6 +193,7 @@ describe('encodeCall helper', () => {
       it('supports nested tuples/arrays', function() {
         expect(parseTypeValuePair('(uint256,string[])', [42, ['one', 'two', 'three']])).to.deep.equal(['42', ['one', 'two', 'three']]);
         expect(parseTypeValuePair('(uint256,string)[]', [[42, 'hello'], ['42', 'bye']])).to.deep.equal([['42', 'hello'], ['42', 'bye']]);
+        expect(parseTypeValuePair('(uint256,(uint256,string))', [42, 42, 'hello'])).to.deep.equal(['42', '42', 'hello']);
       });
 
       it('should throw when the passed tuple types do not match', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+require('../../setup');
+
+import encodeCall, { formatValue } from '../../../src/helpers/encodeCall';
+import BN from 'bignumber.js';
+
+describe('encodeCall helper', function() {
+
+  describe('encodeCall function', function() {
+    it('should return a string with the 0x radix', function() {
+      const enc = encodeCall('myFunction', ['uint256', 'address'], [123, '0x123']);
+      assert(enc.indexOf('0x') !== -1);
+    });
+
+    it('should be a valid hexadecimal', function() {
+      const enc = encodeCall('myFunction', ['uint256', 'address'], [123, '0x123']);
+      expect(enc.match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
+    });
+
+    // TODO: extend encoding tests...
+    
+  });
+
+  describe('formatValue function', function() {
+
+    describe('on integers', function() {
+      it('should return a small integer as a string', function() {
+        expect(formatValue(5)).to.equal('5');
+      });
+
+      it('should return a large integer as a string', function() {
+        expect(formatValue(Number.MAX_SAFE_INTEGER)).to.equal(Number.MAX_SAFE_INTEGER.toString());
+      });
+    });
+
+    describe('on floats', function() {
+      it('should throw', function() {
+        expect(function(){ 
+          formatValue(3.14) 
+        }).to.throw(/Floating point numbers are not supported on parameter encoding./);
+      });
+    });
+
+    describe('on bignumbers', function() {
+      it('should return a small bignumber as a string', function() {
+        expect(formatValue(new BN(5))).to.equal('5');
+      });
+
+      it('should return a large bignumber as a string', function() {
+        expect(formatValue(new BN(Number.MAX_SAFE_INTEGER))).to.equal(Number.MAX_SAFE_INTEGER.toString());
+      });
+    });
+
+    describe('on numeric strings', function() {
+      it('should identify numeric strings with exponents', function() {
+        expect(formatValue('1.5e9')).to.equal(new BN('1.5e9').toString(10));
+      });
+    });
+
+    describe('on strings', function() {
+      it('should just pass them along', function() {
+        expect(formatValue('hello')).to.equal('hello');
+        expect(formatValue('42')).to.equal('42');
+      });
+    });
+    
+    describe('on hexadecimal strings', function() {
+      it('should handle addresses', function() {
+        expect(formatValue('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F')).to.equal('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F');
+      });
+      
+      it('should not mistake addresses with "e" characters as exponentials', function() {
+        expect(formatValue('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e')).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
+      });
+      
+      it('should handle other hexadecimal strings', function() {
+        expect(formatValue('0x39af68cF04Abb0e18e')).to.equal('0x39af68cF04Abb0e18e');
+        expect(formatValue('0x2A')).to.equal('0x2A');
+      });
+    });
+    
+    describe('on hexadecimal numbers', function() {
+      it('should handle addresses', function() {
+        expect(formatValue(0xEB1020C2BfA170489fca37068F9c857CDCd5f19F)).to.equal(parseInt('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F', 16).toString());
+      });
+
+      it('should not mistake addresses with "e" characters as exponentials', function() {
+        expect(formatValue(0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e)).to.equal(parseInt('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e', 16).toString());
+      });
+
+      it('should handle other hexadecimal numbers', function() {
+        expect(formatValue(0x39af68cF04Abb0e18e)).to.equal(parseInt('0x39af68cF04Abb0e18e', 16).toString());
+        expect(formatValue(0x2A)).to.equal(parseInt('0x2A', 16).toString());
+      });
+    });
+  });
+})

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,175 +5,149 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe('encodeCall helper', function() {
-  describe('encodeCall function', function() {
-    it('should return a string with the 0x radix', function() {
-      const enc = encodeCall('myFunction', ['uint256'], [123]);
-      assert(enc.indexOf('0x') !== -1);
-    });
-
-    it('should be a valid hexadecimal', function() {
-      const enc = encodeCall('myFunction', ['uint256'], [123]);
-      expect(enc.match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
-    });
-
-    it('should fail with invalid types', function() {
-      expect(function() {
-        encodeCall('myFunction', ['schnitzel'], [123]);
-      }).to.throw(/Unsupported or invalid type/);
-    });
-
-    it('should fail with invalid type widths', function() {
-      expect(function() {
-        encodeCall('myFunction', ['uint956'], [123]);
-      }).to.throw(/Invalid/);
-      expect(function() {
-        encodeCall('myFunction', ['bytes0'], [123]);
-      }).to.throw(/Invalid/);
-    });
-    
-    it('should fail with invalid non matching number of types and values', function() {
-      expect(function() {
-        encodeCall('myFunction', ['uint', 'address'], [123]);
-      }).to.throw(/Supplied number of types and values do not match./);
-    });
-
-    it('should fail with invalid number type/value pairs', function() {
-      expect(function() {
-        encodeCall('myFunction', ['uint'], ['hello']);
-      }).to.throw(/Invalid parameter/);
-      expect(function() {
-        encodeCall('myFunction', ['uint'], ['-42']);
-      }).to.throw(/Invalid parameter/);
-      expect(function() {
-        encodeCall('myFunction', ['int'], ['3.14']);
-      }).to.throw(/Invalid parameter/);
-      expect(function() {
-        encodeCall('myFunction', ['int'], ['-3.14']);
-      }).to.throw(/Invalid parameter/);
-    });
-
-    it('should fail with invalid string type/value pairs', function() {
-      expect(function() {
-        encodeCall('myFunction', ['string'], [32]);
-      }).to.throw(/argument must be of type/);
-    });
-    
-    it('should fail with invalid bytes type/value pairs', function() {
-      expect(function() {
-        encodeCall('myFunction', ['bytes'], [32]);
-      }).to.throw(/Invalid parameter/);
-    });
-
-    it('should fail with invalid address type/value pairs', function() {
-      expect(function() {
-        encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3']);
-      }).to.throw(/Invalid parameter/);
-    });
-
-    it('should accept array parameters', function() {
-      expect(function() {
-        encodeCall('myFunction', ['uint256[]'], [[20, 30]]);
-      }).to.not.throw();
-    });
-
-    it('should accept empty bytes', function() {
-      expect(function() {
-        encodeCall('myFunction', ['bytes'], ['']);
-      }).to.not.throw();
-    });
-
-    it('should understand scientific notation numbers', function() {
-      expect(function() {
-        encodeCall('myFunction', ['uint256'], ['20e70']);
-      }).to.not.throw();
-    });
-
-  });
-
-  describe('parseValuePair function', function() {
-
-    describe('on integers', function() {
-      it('should return a small integer as a string', function() {
-        expect(parseTypeValuePair('uint', 5)).to.equal('5');
+describe('encodeCall helper', () => {
+  describe('encodeCall function', () => {
+    describe('regarding output', function() {
+      it('should return a string with the 0x radix', () => {
+        assert(encodeCall('myFunction', ['uint256'], [123]).startsWith('0x'));
       });
 
-      it('should return a large integer as a string', function() {
+      it('should be a valid hexadecimal', () => {
+        expect(encodeCall('myFunction', ['uint256'], [123]).match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
+      });
+
+      // TODO: We're relying on ethereumjs-abi's tests here. We might do a bit of verification on the actual output.
+    });
+
+    describe('regarding input', function() {
+      it('should throw with invalid types', () => {
+        expect(() => encodeCall('myFunction', ['schnitzel'], [123])).to.throw(/Unsupported or invalid type/);
+      });
+
+      it('should fail with invalid type widths', () => {
+        expect(() => encodeCall('myFunction', ['uint956'], [123])).to.throw(/Invalid/);
+        expect(() => encodeCall('myFunction', ['bytes0'], [123])).to.throw(/Invalid/);
+      });
+    
+      it('should fail with invalid non matching number of types and values', () => {
+        expect(() => encodeCall('myFunction', ['uint', 'address'], [123])).to.throw(/Supplied number of types and values do not match./);
+      });
+
+      it('should fail with invalid type/value pairs', () => {
+        expect(() => encodeCall('myFunction', ['uint'], ['hello'])).to.throw(/Invalid parameter/);
+        expect(() => encodeCall('myFunction', ['uint'], ['-42'])).to.throw(/Invalid parameter/);
+        expect(() => encodeCall('myFunction', ['int'], ['3.14'])).to.throw(/Invalid parameter/);
+        expect(() => encodeCall('myFunction', ['int'], ['-3.14'])).to.throw(/Invalid parameter/);
+        expect(() => encodeCall('myFunction', ['string'], [32])).to.throw(/argument must be of type/);
+        expect(() => encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3'])).to.throw(/Invalid parameter/);
+        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw(/The first argument must be one of type/);
+      });
+    });
+  });
+
+  describe('parseValuePair function', () => {
+    describe('when the specified type is a number (int, uint, etc)', () => {
+      it('should throw on NaN', () => {
+        expect(() => parseTypeValuePair('uint', 'schnitzel')).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('uint', new BN('hello'))).to.throw(/Invalid parameter/);
+      });
+      
+      it('should understand numeric literals and return them as strings', () => {
+        expect(parseTypeValuePair('int', 5)).to.equal('5');
+        expect(parseTypeValuePair('int', 42)).to.equal('42');
+        expect(parseTypeValuePair('uint', 0x2a)).to.equal('42');
+        expect(parseTypeValuePair('int', 0b11)).to.equal('3');
+        expect(parseTypeValuePair('int', 1e2)).to.equal('100');
         expect(parseTypeValuePair('uint', Number.MAX_SAFE_INTEGER)).to.equal(Number.MAX_SAFE_INTEGER.toString());
       });
 
-      it('should understand scientific notation numbers', function() {
-        expect(parseTypeValuePair('int', '20e70')).to.equal(new BN('2e+71').toString(10));
-      });
-      
-    });
-
-    describe('on floats', function() {
-      it('should throw', function() {
-        expect(function(){ 
-          parseTypeValuePair('int', 3.14) 
-        }).to.throw(/Invalid parameter/);
-      });
-    });
-
-    describe('on bignumbers', function() {
-      it('should return a small bignumber as a string', function() {
-        expect(parseTypeValuePair('uint', new BN(5))).to.equal('5');
-      });
-
-      it('should return a large bignumber as a string', function() {
+      it('should understand big numbers', () => {
+        expect(parseTypeValuePair('int', new BN(5))).to.equal('5');
+        expect(parseTypeValuePair('int', new BN('20e71'))).to.equal(new BN('2e+72').toString(10));
         expect(parseTypeValuePair('int', new BN(Number.MAX_SAFE_INTEGER))).to.equal(Number.MAX_SAFE_INTEGER.toString());
       });
-    });
 
-    describe('on arrays', function() {
-      it('should not parse the array in any way', function() {
-        expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal([20, 30]);
+      it('should throw on negative numbers when specified type is unsigned', () => {
+        expect(() => parseTypeValuePair('uint', -42)).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('uint', new BN(-42))).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('uint', '-42')).to.throw(/Invalid parameter/);
+      });
+
+      it('should throw on non integer numbers', () => {
+        expect(() => parseTypeValuePair('uint', 3.14)).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('int', -3.14)).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('uint', new BN(3.14))).to.throw(/Invalid parameter/);
+      });
+
+      it('should understand scientific notation numbers expressed as strings', () => {
+        expect(parseTypeValuePair('int', '20e70')).to.equal(new BN('2e+71').toString(10));
+      });
+
+      it('should throw when the specified numeric literal is not finite', () => {
+        expect(() => parseTypeValuePair('uint', 2**2000)).to.throw(/Invalid parameter/);
       });
     });
 
-    describe('on numeric strings', function() {
-      it('should identify numeric strings with exponents', function() {
-        expect(parseTypeValuePair('uint', '1.5e9')).to.equal(new BN('1.5e9').toString(10));
-      });
-    });
-
-    describe('on strings', function() {
-      it('should just pass them along', function() {
+    describe('when the specified type is a string', () => {
+      it('should accept any string and return the same string', () => {
         expect(parseTypeValuePair('string', 'hello')).to.equal('hello');
+        expect(parseTypeValuePair('string', '0x123')).to.equal('0x123');
         expect(parseTypeValuePair('string', '42')).to.equal('42');
+        expect(parseTypeValuePair('string', '0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e')).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
       });
     });
-    
-    describe('on addresse strings', function() {
-      it('should handle addresses', function() {
-        expect(parseTypeValuePair('address', '0xEB1020C2BfA170489fca37068F9c857CDCd5f19F')).to.equal('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F');
+
+    describe('when the specified type is bytes (includes bytes1, bytes2, etc)', () => {
+      it('should accept byte arrays expressed in hexadecimal form', () => {
+        expect(parseTypeValuePair('bytes', '0xabc')).to.equal('0xabc');
+      });
+
+      it('should throw when a byte array expressed in hexadecimal form is invalid', () => {
+        expect(() => parseTypeValuePair('bytes', '0xabcqqq')).to.throw(/Invalid parameter/);
+      });
+
+      it('should interpret empty strings as valid empty bytes', () => {
+        expect(parseTypeValuePair('bytes', '')).to.equal('');
       });
       
-      it('should not mistake addresses with "e" characters as exponentials', function() {
+      it('should accept Buffer values', () => {
+        expect(parseTypeValuePair('bytes', Buffer.from('hello', 'utf8'))).to.equal('hello');
+        expect(parseTypeValuePair('bytes', Buffer.from('123abc', 'hex'))).to.equal('\u0012:�');
+      });
+    });
+
+    describe('when the specified type is an address', () => {
+      it('should accept valid addresses (and not confuse e chars with scientific notation)', () => {
         expect(parseTypeValuePair('address', '0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e')).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
       });
-      
-      it('should handle other hexadecimal strings', function() {
-        expect(parseTypeValuePair('string', '0x39af68cF04Abb0e18e')).to.equal('0x39af68cF04Abb0e18e');
-        expect(parseTypeValuePair('string', '0x2A')).to.equal('0x2A');
-      });
-    });
-    
-    describe('on hexadecimal numbers', function() {
-      it('should handle other hexadecimal numbers as strings', function() {
-        expect(parseTypeValuePair('int', '0x2a')).to.equal(new BN('0x2a').toString(10));
-        expect(parseTypeValuePair('uint', '0x39af')).to.equal(new BN('0x39af').toString(10));
-        expect(parseTypeValuePair('int', '0x39afabcAbc')).to.equal(new BN('0x39afabcabc').toString(10));
-        expect(parseTypeValuePair('uint', '0x39af68cf04abb0e1')).to.equal(new BN('0x39af68cf04abb0e1').toString(10));
+
+      it('should throw when an invalid address is passed', () => {
+        expect(() => parseTypeValuePair('address', '0x39af68cF04Abb8f9d8191E1bD9ce18e')).to.throw(/Invalid parameter/);
+        expect(() => parseTypeValuePair('address', '0x00000000000000000000000000000000000000000000000000000000f8a8fd6d')).to.throw(/Invalid parameter/);
       });
 
-      it('should handle other hexadecimal numbers as literals', function() {
-        expect(parseTypeValuePair('int', 0x2a)).to.equal(new BN(0x2a).toString(10));
-        expect(parseTypeValuePair('uint', 0x39af)).to.equal(new BN(0x39af).toString(10));
-        expect(parseTypeValuePair('int', 0x39afabcAbc)).to.equal(new BN(0x39afabcabc).toString(10));
-        expect(parseTypeValuePair('uint', 0x39af68cf04abb0e1)).to.equal(new BN(0x39af68cf04abb0e1).toString(10));
+      it('should throw when an address with upper and lower case chars and an invalid checksum is passed', () => {
+        expect(() => parseTypeValuePair('address', '0xCF5609B003b2776699eeA1233F7C82d5695CC9AA')).to.throw(/Invalid parameter/);
       });
+
+      it('should not throw when an address with an invalid checksum is passed, if the address contains all upper or lower case strings', () => {
+        expect(() => parseTypeValuePair('address', '0xCF5609B003B2776699EEA1233F7C82D5695CC9AA')).to.not.throw;
+        expect(() => parseTypeValuePair('address', '0xcf5609b003b2776699eea1233f7c82d5695cc9aa')).to.not.throw;
+      });
+
+      it('should accept addresses passed as buffers', () => {
+        expect(parseTypeValuePair('address', Buffer.from('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e', 'utf8'))).to.equal('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e');
+      });
+    });
+
+    describe('when the specified type is an array', () => {
+      it('should simply pass them along', () => {
+        expect(parseTypeValuePair('uint256[]', '20,30')).to.equal('20,30');
+        expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal([20,30]);
+      });
+      it('should parse uint array elements');
+      it('should parse uint address elements');
+      it('should parse uint bytes elements');
     });
   });
 })

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -173,6 +173,35 @@ describe('encodeCall helper', () => {
       });
     });
 
+    describe('when the specified type is a function', () => {
+      it('treats the type as a bytes24 (address + function selector)', () => {
+        expect(parseTypeValuePair('function', '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1abcdef')).to.equal('0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1abcdef');
+      });
+
+      it('should throw when the passed value is not a valid bytes24 hex', () => {
+        expect(() => parseTypeValuePair('function', '0x123')).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('function', '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1')).to.throw(/Encoding error/);
+        expect(() => parseTypeValuePair('function', '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1abcdefabc')).to.throw(/Encoding error/);
+      });
+
+    describe('when the specified type is a tuple', () => {
+      it('identifies the individual types and treats them recursively', () => {
+        expect(parseTypeValuePair('(uint256,string)', '42,hello')).to.deep.equal(['42', 'hello']);
+        expect(parseTypeValuePair('(uint256,string)', [42, 'hello'])).to.deep.equal(['42', 'hello']);
+      });
+
+      it('supports nested tuples/arrays', function() {
+        expect(parseTypeValuePair('(uint256,string[])', [42, ['one', 'two', 'three']])).to.deep.equal(['42', ['one', 'two', 'three']]);
+        expect(parseTypeValuePair('(uint256,string)[]', [[42, 'hello'], ['42', 'bye']])).to.deep.equal([['42', 'hello'], ['42', 'bye']]);
+      });
+
+      it('should throw when the passed tuple types do not match', () => {
+        expect(() => parseTypeValuePair('(uint256,string)', 'hello,42')).to.throw();
+        expect(() => parseTypeValuePair('(uint256,string)', '42')).to.throw();
+      });
+    });
+    });
+
     describe('when the specified type is boolean', () => {
       it('should accept boolean values', () => {
         expect(parseTypeValuePair('bool', false)).to.equal(false);

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,7 +5,7 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe('encodeCall helper', () => {
+describe.only('encodeCall helper', () => {
   describe('encodeCall function', () => {
     describe('regarding output', function() {
       it('should return a string with the 0x radix', () => {
@@ -153,7 +153,17 @@ describe('encodeCall helper', () => {
     });
 
     describe('when the specified type is boolean', () => {
-      it('should accept boolean');
+      it('should accept boolean values', () => {
+        expect(parseTypeValuePair('bool', false)).to.equal(false);
+        expect(parseTypeValuePair('bool', true)).to.equal(true);
+        expect(parseTypeValuePair('bool', 'false')).to.equal(false);
+        expect(parseTypeValuePair('bool', 'true')).to.equal(true);
+      });
+
+      it('should reject invalid boolean values', () => {
+        expect(() => parseTypeValuePair('bool', 'falsy')).to.throw();
+        expect(() => parseTypeValuePair('bool', 32)).to.throw();
+      });
     });
 
     describe('when the specified type is an array', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -103,21 +103,23 @@ describe('encodeCall helper', () => {
     });
 
     describe('when the specified type is bytes (includes bytes1, bytes2, etc)', () => {
-      it('should accept byte arrays expressed in hexadecimal form', () => {
-        expect(parseTypeValuePair('bytes', '0xabc')).to.equal('0xabc');
+      it('should accept bytes expressed as hexadecimal strings', () => {
+        expect(parseTypeValuePair('bytes', '0x2a')).to.deep.equal(Buffer.from('2a', 'hex'));
+        expect(parseTypeValuePair('bytes', '0xabc')).to.deep.equal(Buffer.from('abc', 'hex'));
+        expect(parseTypeValuePair('bytes', '0xabcdef')).to.deep.equal(Buffer.from('abcdef', 'hex'));
       });
 
-      it('should throw when a byte array expressed in hexadecimal form is invalid', () => {
+      it('should throw when a byte array expressed as a hexadecimal string is invalid', () => {
         expect(() => parseTypeValuePair('bytes', '0xabcqqq')).to.throw(/Encoding error/);
       });
 
-      it('should interpret empty strings as valid empty bytes', () => {
-        expect(parseTypeValuePair('bytes', '')).to.equal('');
+      it('should accept Buffer objects', function() {
+        expect(parseTypeValuePair('bytes', Buffer.from('heya'))).to.deep.equal(Buffer.from('heya'));
+        expect(parseTypeValuePair('bytes', Buffer.from('abcdef', 'hex'))).to.deep.equal(Buffer.from('abcdef', 'hex'));
       });
-      
-      it('should accept Buffer values', () => {
-        expect(parseTypeValuePair('bytes', Buffer.from('hello', 'utf8'))).to.equal('hello');
-        expect(parseTypeValuePair('bytes', Buffer.from('123abc', 'hex'))).to.equal('\u0012:�');
+
+      it('should interpret empty strings as valid empty bytes', () => {
+        expect(parseTypeValuePair('bytes', '')).to.deep.equal(Buffer.from(''));
       });
     });
 

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,7 +5,7 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe.only('encodeCall helper', () => {
+describe('encodeCall helper', () => {
   describe('encodeCall function', () => {
     describe('regarding output', function() {
       it('should return a string with the 0x radix', () => {
@@ -193,12 +193,15 @@ describe.only('encodeCall helper', () => {
 
     describe('when the specified type is an array', () => {
       it('should handle arrays', () => {
-        expect(parseTypeValuePair('uint256[]', '20,30')).to.deep.equal(['20', '30']);
         expect(parseTypeValuePair('uint256[]', [20, 30])).to.deep.equal(['20', '30']);
         expect(parseTypeValuePair('address[]', ['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0'])).to.deep.equal(['0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1', '0xffcf8fdee72ac11b5c542428b35eef5769c409f0']);
         expect(parseTypeValuePair('string[]', ['one', 'two'])).to.deep.equal(['one', 'two']);
         expect(parseTypeValuePair('bool[]', ['true', 'false'])).to.deep.equal([true, false]);
         expect(parseTypeValuePair('bool[]', [true, false])).to.deep.equal([true, false]);
+      });
+
+      it('should be able to understand a comma separated list as an array', function() {
+        expect(parseTypeValuePair('uint256[]', '20,30')).to.deep.equal(['20', '30']);
       });
 
       it('should handle empty arrays', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -161,17 +161,18 @@ describe('encodeCall helper', function() {
     });
     
     describe('on hexadecimal numbers', function() {
-      it('should handle addresses', function() {
-        expect(parseTypeValuePair('uint', 0xEB1020C2BfA170489fca37068F9c857CDCd5f19F)).to.equal(parseInt('0xEB1020C2BfA170489fca37068F9c857CDCd5f19F', 16).toString());
+      it('should handle other hexadecimal numbers as strings', function() {
+        expect(parseTypeValuePair('int', '0x2a')).to.equal(new BN('0x2a').toString(10));
+        expect(parseTypeValuePair('uint', '0x39af')).to.equal(new BN('0x39af').toString(10));
+        expect(parseTypeValuePair('int', '0x39afabcAbc')).to.equal(new BN('0x39afabcabc').toString(10));
+        expect(parseTypeValuePair('uint', '0x39af68cf04abb0e1')).to.equal(new BN('0x39af68cf04abb0e1').toString(10));
       });
 
-      it('should not mistake addresses with "e" characters as exponentials', function() {
-        expect(parseTypeValuePair('int', 0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e)).to.equal(parseInt('0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e', 16).toString());
-      });
-
-      it('should handle other hexadecimal numbers', function() {
-        expect(parseTypeValuePair('uint', 0x39af68cF04Abb0e18e)).to.equal(parseInt('0x39af68cF04Abb0e18e', 16).toString());
-        expect(parseTypeValuePair('int', 0x2A)).to.equal(parseInt('0x2A', 16).toString());
+      it('should handle other hexadecimal numbers as literals', function() {
+        expect(parseTypeValuePair('int', 0x2a)).to.equal(new BN(0x2a).toString(10));
+        expect(parseTypeValuePair('uint', 0x39af)).to.equal(new BN(0x39af).toString(10));
+        expect(parseTypeValuePair('int', 0x39afabcAbc)).to.equal(new BN(0x39afabcabc).toString(10));
+        expect(parseTypeValuePair('uint', 0x39af68cf04abb0e1)).to.equal(new BN(0x39af68cf04abb0e1).toString(10));
       });
     });
   });

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,7 +5,7 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe('encodeCall helper', () => {
+describe.only('encodeCall helper', () => {
   describe('encodeCall function', () => {
     describe('regarding output', function() {
       it('should return a string with the 0x radix', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,7 +5,7 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe.only('encodeCall helper', function() {
+describe('encodeCall helper', function() {
   describe('encodeCall function', function() {
     it('should return a string with the 0x radix', function() {
       const enc = encodeCall('myFunction', ['uint256'], [123]);

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -2,49 +2,47 @@
 
 require('../../setup');
 
-import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
+import encodeCall, { parseCallValues, parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
 describe('encodeCall helper', () => {
   describe('encodeCall function', () => {
-    describe('regarding output', function() {
-      it('should return a string with the 0x radix', () => {
-        assert(encodeCall('myFunction', ['uint256'], [123]).startsWith('0x'));
-      });
-
-      it('should be a valid hexadecimal', () => {
-        expect(encodeCall('myFunction', ['uint256'], [123]).match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
-      });
-
-      // TODO: We're relying on ethereumjs-abi's tests here. We might do a bit of verification on the actual output.
+    it('should return a string with the 0x radix', () => {
+      assert(encodeCall('myFunction', ['uint256'], [123]).startsWith('0x'));
     });
 
-    describe('regarding input', function() {
-      it('should throw with invalid types', () => {
-        expect(() => encodeCall('myFunction', ['schnitzel'], [123])).to.throw(/Unsupported or invalid type/);
-      });
-
-      it('should fail with invalid type widths', () => {
-        expect(() => encodeCall('myFunction', ['uint512'], [123])).to.throw(/Invalid/);
-        expect(() => encodeCall('myFunction', ['bytes0'], [Buffer.from('0xab', 'hex')])).to.throw(/Invalid/);
-      });
-    
-      it('should fail with invalid non matching number of types and values', () => {
-        expect(() => encodeCall('myFunction', ['uint', 'address'], [123])).to.throw(/Supplied number of types and values do not match./);
-      });
-
-      it('should fail with invalid type/value pairs', () => {
-        expect(() => encodeCall('myFunction', ['uint'], ['hello'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['uint'], ['-42'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['int'], ['3.14'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['int'], ['-3.14'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['string'], [32])).to.throw();
-        expect(() => encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3'])).to.throw(/Encoding error/);
-        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw(/Encoding error/);
-      });
+    it('should be a valid hexadecimal', () => {
+      expect(encodeCall('myFunction', ['uint256'], [123]).match(/0[xX][0-9a-fA-F]+/)).to.not.be.empty;
     });
+
+    // TODO: We're relying on ethereumjs-abi's tests here. We might do a bit of verification on the actual output.
   });
 
+  describe('encodeCall + parseCallValues functions', function() {
+    it('should throw with invalid types', () => {
+      expect(() => encodeCall('myFunction', parseCallValues(['schnitzel'], [123]))).to.throw(/Unsupported or invalid type/);
+    });
+
+    it('should fail with invalid type widths', () => {
+      expect(() => encodeCall('myFunction', parseCallValues(['uint512'], [123]))).to.throw();
+      expect(() => encodeCall('myFunction', parseCallValues(['bytes0'], [Buffer.from('0xab', 'hex')]))).to.throw();
+    });
+  
+    it('should fail with invalid non matching number of types and values', () => {
+      expect(() => encodeCall('myFunction', parseCallValues(['uint', 'address'], [123]))).to.throw(/Supplied number of types and values do not match./);
+    });
+
+    it('should fail with invalid type/value pairs', () => {
+      expect(() => encodeCall('myFunction', parseCallValues(['uint'], ['hello']))).to.throw(/Encoding error/);
+      expect(() => encodeCall('myFunction', parseCallValues(['uint'], ['-42']))).to.throw(/Encoding error/);
+      expect(() => encodeCall('myFunction', parseCallValues(['int'], ['3.14']))).to.throw(/Encoding error/);
+      expect(() => encodeCall('myFunction', parseCallValues(['int'], ['-3.14']))).to.throw(/Encoding error/);
+      expect(() => encodeCall('myFunction', parseCallValues(['string'], [32]))).to.throw();
+      expect(() => encodeCall('myFunction', parseCallValues(['address'], ['0x0fd60495d7057689fbe8b3']))).to.throw(/Encoding error/);
+      expect(() => encodeCall('myFunction', parseCallValues(['bytes'], [32]))).to.throw(/Encoding error/);
+    });
+  });
+  
   describe('parseValuePair function', () => {
 
     it('should throw when the specified type is not recognized', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -5,7 +5,7 @@ require('../../setup');
 import encodeCall, { parseTypeValuePair } from '../../../src/helpers/encodeCall';
 import BN from 'bignumber.js';
 
-describe.only('encodeCall helper', () => {
+describe('encodeCall helper', () => {
   describe('encodeCall function', () => {
     describe('regarding output', function() {
       it('should return a string with the 0x radix', () => {

--- a/packages/lib/test/src/helpers/encodeCall.test.js
+++ b/packages/lib/test/src/helpers/encodeCall.test.js
@@ -38,9 +38,9 @@ describe('encodeCall helper', () => {
         expect(() => encodeCall('myFunction', ['uint'], ['-42'])).to.throw(/Invalid parameter/);
         expect(() => encodeCall('myFunction', ['int'], ['3.14'])).to.throw(/Invalid parameter/);
         expect(() => encodeCall('myFunction', ['int'], ['-3.14'])).to.throw(/Invalid parameter/);
-        expect(() => encodeCall('myFunction', ['string'], [32])).to.throw(/argument must be of type/);
+        expect(() => encodeCall('myFunction', ['string'], [32])).to.throw();
         expect(() => encodeCall('myFunction', ['address'], ['0x0fd60495d7057689fbe8b3'])).to.throw(/Invalid parameter/);
-        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw(/The first argument must be one of type/);
+        expect(() => encodeCall('myFunction', ['bytes'], [32])).to.throw();
       });
     });
   });


### PR DESCRIPTION
Fix #421 

Lib's encodeCall helper was failing for any hexadecimal strings that contained the character 'e'. It was interpreting these as scientific notation numbers (e.g. 1.5e9) and seeing their hexadecimal value parsed a decimal instead =S.

As a result, addresses like "0x39af68cF04Abb0eF8f9d8191E1bD9c041E80e18e" were being parsed as some weird exponential number and ending up as "0x0000000000000000000000000000000000000977" in EVM storage.

This PR goes quite far beyond simply fixing the bug; It rewrites the helper from the ground up, with type/value pair validation and adds tests for this particular helper. The validation involves comparing the expected type with its actual value and making sure that they are compatible. I.e. 'uint256' is not compatible with the value 'hello world', and 'address' is not compatible with the value '0x123'.