### PR TITLE
Remove lightweight terminology

### DIFF
--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -121,8 +121,8 @@ export default class ZosNetworkFile {
     return Object.keys(this.contracts);
   }
 
-  get isLightweight(): boolean {
-    return this.packageFile.isLightweight;
+  get isPublished(): boolean {
+    return this.packageFile.isPublished;
   }
 
   get solidityLibs(): { [libAlias: string]: SolidityLibInterface } {

--- a/packages/cli/src/models/files/ZosPackageFile.ts
+++ b/packages/cli/src/models/files/ZosPackageFile.ts
@@ -67,8 +67,8 @@ export default class ZosPackageFile {
     return Object.values(this.contracts);
   }
 
-  get isLightweight(): boolean {
-    return !this.data.publish;
+  get isPublished(): boolean {
+    return !!this.data.publish;
   }
 
   public contract(alias: string): string {

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -402,7 +402,7 @@ export default class NetworkController {
   }
 
   // DeployerController
-  public async toFullApp(): Promise<void> {
+  public async publish(): Promise<void> {
     if (this.appAddress) {
       log.info(`Project is already published to ${this.network}`);
       return;

--- a/packages/cli/src/scripts/publish.ts
+++ b/packages/cli/src/scripts/publish.ts
@@ -6,7 +6,7 @@ export default async function publish({ network, txParams = {}, networkFile }: P
   const controller = ControllerFor(network, txParams, networkFile);
 
   try {
-    await controller.toFullApp();
+    await controller.publish();
     controller.writeNetworkPackageIfNeeded();
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();

--- a/packages/cli/src/scripts/status.ts
+++ b/packages/cli/src/scripts/status.ts
@@ -21,7 +21,7 @@ export default async function status({ network, txParams = {}, networkFile }: St
 
 // TODO: Find a nice home for all these functions :)
 async function appInfo(controller: NetworkController): Promise<boolean> {
-  if (controller.isLightweight) return true;
+  if (!controller.isPublished) return true;
 
   if (!controller.appAddress) {
     log.warn(`Application is not yet deployed to the network`);
@@ -35,7 +35,7 @@ async function appInfo(controller: NetworkController): Promise<boolean> {
 }
 
 async function versionInfo(networkFile: ZosNetworkFile): Promise<boolean> {
-  if (networkFile.isLightweight) return true;
+  if (!networkFile.isPublished) return true;
   if (networkFile.hasMatchingVersion()) {
     log.info(`- Deployed version ${networkFile.version} matches the latest one defined`);
     return true;
@@ -74,7 +74,7 @@ async function contractsInfo(controller: NetworkController): Promise<void> {
 }
 
 async function dependenciesInfo(networkFile: ZosNetworkFile): Promise<void> {
-  if (networkFile.isLightweight) return;
+  if (!networkFile.isPublished) return;
   const packageFile = networkFile.packageFile;
   if (!packageFile.hasDependencies() && !networkFile.hasDependencies()) return;
   log.info('Application dependencies:');

--- a/packages/cli/test/models/TestHelper.test.js
+++ b/packages/cli/test/models/TestHelper.test.js
@@ -18,11 +18,11 @@ contract('TestHelper', function ([_, owner]) {
     beforeEach(async function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts-and-multiple-stdlibs.zos.json')
       this.networkFile = this.packageFile.networkFile('test')
-      this.app = await TestHelper(txParams, this.networkFile)
+      this.project = await TestHelper(txParams, this.networkFile)
     })
 
     it('deploys all contracts', async function() {
-      const { app, directory, package: thePackage } = this.app
+      const { app, directory, package: thePackage } = this.project
 
       app.address.should.not.be.null
       directory.address.should.not.be.null
@@ -30,50 +30,50 @@ contract('TestHelper', function ([_, owner]) {
     })
 
     it('sets app at initial version', async function () {
-      (await this.app.getCurrentVersion()).should.eq(initialVersion)
+      (await this.project.getCurrentVersion()).should.eq(initialVersion)
     })
 
     it('registers initial version in package', async function () {
-      (await this.app.package.hasVersion(initialVersion)).should.be.true
+      (await this.project.package.hasVersion(initialVersion)).should.be.true
     })
 
     it('initializes all app properties', async function () {
-      const { version, name } = this.app
+      const { version, name } = this.project
 
       version.should.eq(initialVersion)
       name.should.eq(projectName)
     })
 
     it('returns the current directory', async function () {
-      (await this.app.getCurrentDirectory()).address.should.not.be.null
+      (await this.project.getCurrentDirectory()).address.should.not.be.null
     })
 
     it('has dependencies deployed', async function () {
-      const dep1 = await this.app.getDependencyPackage('mock-stdlib-undeployed')
-      const dep2 = await this.app.getDependencyPackage('mock-stdlib-undeployed-2')
+      const dep1 = await this.project.getDependencyPackage('mock-stdlib-undeployed')
+      const dep2 = await this.project.getDependencyPackage('mock-stdlib-undeployed-2')
 
       dep1.should.not.be.null
       dep2.should.not.be.null
     })
 
     it('retrieves a mock from app', async function () {
-      const proxy = await this.app.createProxy(ImplV1, { contractName: 'Impl' })
+      const proxy = await this.project.createProxy(ImplV1, { contractName: 'Impl' })
       const say = await proxy.say()
 
       say.should.eq('V1')
     })
   })
 
-  describe('for lightweight app project', function() {
+  describe('for an unpublished project', function() {
     beforeEach(async function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
       this.packageFile.publish = false
       this.networkFile = this.packageFile.networkFile('test')
-      this.app = await TestHelper(txParams, this.networkFile)
+      this.project = await TestHelper(txParams, this.networkFile)
     })
 
     it('retrieves a mock from app', async function () {
-      const proxy = await this.app.createProxy(ImplV1, { contractName: 'Impl' })
+      const proxy = await this.project.createProxy(ImplV1, { contractName: 'Impl' })
       const say = await proxy.say()
       say.should.eq('V1')
     })

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -236,7 +236,7 @@ contract('create script', function([_, owner]) {
     });
   }
   
-  describe('on lightweight app', function () {
+  describe('on unpublished project', function () {
     beforeEach('setup', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
       this.packageFile.version = version
@@ -246,7 +246,7 @@ contract('create script', function([_, owner]) {
     shouldHandleCreateScript();
   })
 
-  describe('on full app', function () {
+  describe('on published project', function () {
     beforeEach('setup', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
       this.packageFile.version = version

--- a/packages/cli/test/scripts/init.test.js
+++ b/packages/cli/test/scripts/init.test.js
@@ -19,15 +19,15 @@ contract('init script', function() {
     this.packageFile = new ZosPackageFile(`${tmpDir}/zos.json`)
   })
 
-  it('should default to lightweight apps', async function () {
+  it('should default to unpublished apps', async function () {
     await init({ name, version, packageFile: this.packageFile });
-    this.packageFile.isLightweight.should.eq(true)
+    this.packageFile.isPublished.should.eq(false)
   });
 
   function testInit(publish) {
     it('should have correct publish mark', async function () {
       await init({ publish, name, version, packageFile: this.packageFile });
-      this.packageFile.isLightweight.should.eq(!publish)
+      this.packageFile.isPublished.should.eq(publish)
     });
 
     it('should have the appropriate app name', async function() {

--- a/packages/cli/test/scripts/init.test.js
+++ b/packages/cli/test/scripts/init.test.js
@@ -73,11 +73,11 @@ contract('init script', function() {
     });
   };
 
-  describe('for app', function () {
+  describe('when not publishing the project', function () {
     testInit(false)
   })
 
-  describe('for full', function () {
+  describe('when publishing the project', function () {
     testInit(true)
   })
 });

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -462,7 +462,7 @@ contract('push script', function([_, owner]) {
     })
   });
 
-  describe('an empty lightweight app', function() {
+  describe('an empty unpublished project', function() {
     beforeEach('pushing package-empty-lite', async function () {
       const packageFile = new ZosPackageFile('test/mocks/packages/package-empty-lite.zos.json')
       this.networkFile = packageFile.networkFile(network)
@@ -473,7 +473,7 @@ contract('push script', function([_, owner]) {
     });
   });
 
-  describe('a lightweight app with contracts', function() {
+  describe('an unpublished project with contracts', function() {
     beforeEach('pushing package-with-contracts', async function () {
       const packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts.zos.json')
       packageFile.publish = false
@@ -496,7 +496,7 @@ contract('push script', function([_, owner]) {
     })
   });
 
-  describe('a lightweight app with dependencies', function() {
+  describe('an unpublished project with dependencies', function() {
     deployingDependency();
 
     beforeEach('pushing package-with-stdlib', async function () {

--- a/packages/cli/test/scripts/status.test.js
+++ b/packages/cli/test/scripts/status.test.js
@@ -232,7 +232,7 @@ contract('status script', function([_, owner]) {
     })
   });
 
-  describe('on lightweight app project', function () {
+  describe('on unpublished project', function () {
     beforeEach('creating package and network files', function () {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
       this.packageFile.publish = false

--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -276,7 +276,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
     shouldHandleUpdateScript();
   })
 
-  describe('on application contract in lightweight mode', function () {
+  describe('on application contract in unpublished mode', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
       this.packageFile.publish = false
@@ -295,7 +295,7 @@ contract('update script', function([_skipped, owner, anotherAccount]) {
     shouldHandleUpdateOnDependency();
   })
 
-  describe('on dependency contract in lightweight mode', function () {
+  describe('on dependency contract in unpublished mode', function () {
     beforeEach('setup package', async function() {
       this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-undeployed-stdlib.zos.json')
       this.packageFile.publish = false


### PR DESCRIPTION
This PR removes some deprecated terminology related to the state of a zos project. Basically, all references to a `full project` and `lightweight project` were renamed in favor of  `published project` and `unpublished project`.
