### PR TITLE
Refactor/travis less bootstraps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ cache:
   - "$HOME/.npm"
   - node_modules
   - packages/lib/node_modules
+  - packages/lib/lib
   - packages/cli/node_modules
+  - packages/cli/lib
+  - packages/vouching/node_modules
   - packages/docs/node_modules
   - examples/lib-simple/node_modules
   - examples/lib-complex/node_modules
@@ -36,35 +39,37 @@ jobs:
 
     # Initial stage with lib tests
     - stage: lib tests
-      install: npx lerna bootstrap --loglevel=debug
+      install: pwd # Override to avoid npm install.
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos-lib
 
     # Test stage for Vouching
     - stage: tests
       name: Vouching tests
-      install: npx lerna bootstrap --loglevel=debug
+      install: npx lerna run compile-contracts
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos-vouching
 
     # Test stage for CLI on Linux
     - stage: tests
       name: CLI tests on Linux
       os: linux
-      install: npx lerna bootstrap --loglevel=debug
+      install:
+        - npx lerna run compile-contracts --scope zos-lib
+        - npx lerna run compile-ts --scope zos-lib
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos
 
     # Test stage for CLI on OSX
     - stage: tests
       name: CLI tests on OSX
       os: osx
-      install:
-        - npm install
-        - npx lerna bootstrap --loglevel=debug
+      install: 
+        - npx lerna run compile-contracts --scope zos-lib
+        - npx lerna run compile-ts --scope zos-lib
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos
 
     # Test stage for complex-example
     - stage: tests
       name: Complex example tests
-      install: npx lerna bootstrap --loglevel=debug
+      install: npx lerna run compile-contracts
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos-lib-complex-example
 
     # Integration tests on local geth

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,9 @@ jobs:
         - sudo add-apt-repository -y ppa:ethereum/ethereum
         - sudo apt-get update
         - sudo apt-get install -y ethereum
-      install: npx lerna bootstrap --loglevel=debug && npm --prefix tests/cli-app install tests/cli-app
+      install: 
+        - npx lerna run compile-contracts --scope zos-lib
+        - npm --prefix tests/cli-app install tests/cli-app
       script: cd tests/cli-app && ./scripts/test.sh
 
     # Integration tests on local geth with hdwallet-provider
@@ -91,7 +93,9 @@ jobs:
         - sudo add-apt-repository -y ppa:ethereum/ethereum
         - sudo apt-get update
         - sudo apt-get install -y ethereum
-      install: npx lerna bootstrap --loglevel=debug && npm --prefix tests/cli-app install tests/cli-app
+      install: 
+        - npx lerna run compile-contracts --scope zos-lib
+        - npm --prefix tests/cli-app install tests/cli-app
       script: cd tests/cli-app && ./scripts/test.sh
 
     # Rinkeby integration tests are temporarily disabled


### PR DESCRIPTION
*Restoring https://github.com/zeppelinos/zos/pull/557 against master*

Fix #549 (partially)

This PR makes a few modifications to .travis.yml, with the intention of shaving a few minutes of the CI tests:
1) Fewer lerna bootstraps are performed. 
~2) Use the apt addon to cache apt packages. I'm still not sure if this speeds up or slows down the tests, since Travis' performance is non-deterministic and seems to have it's own mood. Will have to experiment a bit.~

In total, the tests are run aprox. 10 minutes faster.