### PR TITLE
Run lib, cli, vouching, examples, and integration tests in parallel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ cache:
 
 stages:
   - prepare cache
-  - lib tests
   - tests
-  - integration tests
 
 jobs:
   include:
@@ -38,7 +36,8 @@ jobs:
         - npx lerna bootstrap --loglevel=debug
 
     # Initial stage with lib tests
-    - stage: lib tests
+    - stage: tests
+      name: Lib tests
       install: pwd # Override to avoid npm install.
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos-lib
 
@@ -73,7 +72,7 @@ jobs:
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos-lib-complex-example
 
     # Integration tests on local geth
-    - stage: integration tests
+    - stage: tests
       name: Local geth node
       env: NETWORK=geth-dev
       before_install:
@@ -86,7 +85,7 @@ jobs:
       script: cd tests/cli-app && ./scripts/test.sh
 
     # Integration tests on local geth with hdwallet-provider
-    - stage: integration tests
+    - stage: tests
       name: HDWallet on local geth node
       env: NETWORK=geth-dev-hdwallet
       before_install:


### PR DESCRIPTION
Fix #549 

Even though it looked cleaner to have separate stages for the tests, running only 2 stages (bootstrapping and testing) makes the whole test suite run at about half the time (23 mins vs 50 mins).

![screenshot from 2019-01-08 11-18-28](https://user-images.githubusercontent.com/550409/50836512-1f8de500-1338-11e9-89da-2f167f5ea3e4.png)
