### PR TITLE
Fix doc guides to support Truffle 5 environment

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -147,7 +147,7 @@
 		},
 		"axios": {
 			"version": "0.18.0",
-			"resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
 			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
 			"requires": {
 				"follow-redirects": "^1.3.0",
@@ -171,7 +171,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -389,12 +389,12 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
@@ -762,7 +762,7 @@
 		},
 		"babelify": {
 			"version": "7.3.0",
-			"resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
 			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
 			"requires": {
 				"babel-core": "^6.0.14",
@@ -849,7 +849,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -1091,7 +1091,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -1103,7 +1103,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -1141,7 +1141,7 @@
 		},
 		"css-select": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"requires": {
 				"boolbase": "~1.0.0",
@@ -1241,7 +1241,7 @@
 			"dependencies": {
 				"domelementtype": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
 					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
@@ -1408,7 +1408,7 @@
 		},
 		"eth-json-rpc-middleware": {
 			"version": "1.6.0",
-			"resolved": "http://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+			"resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
 			"integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
 			"requires": {
 				"async": "^2.5.0",
@@ -1500,7 +1500,7 @@
 				},
 				"ethereumjs-vm": {
 					"version": "2.3.4",
-					"resolved": "http://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+					"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
 					"integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
 					"requires": {
 						"async": "^2.1.2",
@@ -1552,7 +1552,7 @@
 				},
 				"web3-provider-engine": {
 					"version": "13.8.0",
-					"resolved": "http://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
 					"integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
 					"requires": {
 						"async": "^2.5.0",
@@ -1603,7 +1603,7 @@
 		},
 		"ethereumjs-block": {
 			"version": "1.7.1",
-			"resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
 			"integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
 			"requires": {
 				"async": "^2.0.1",
@@ -1783,7 +1783,7 @@
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
 			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
@@ -1851,7 +1851,7 @@
 		},
 		"fs-extra": {
 			"version": "0.30.0",
-			"resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
 			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -2125,7 +2125,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
@@ -2290,12 +2290,12 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "2.4.0",
-			"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
@@ -2365,7 +2365,7 @@
 		},
 		"level-iterator-stream": {
 			"version": "1.3.1",
-			"resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
 			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -2381,7 +2381,7 @@
 				},
 				"readable-stream": {
 					"version": "1.1.14",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -2392,7 +2392,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -2418,7 +2418,7 @@
 				},
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -2429,7 +2429,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xtend": {
@@ -2465,7 +2465,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -2681,12 +2681,12 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -2894,12 +2894,12 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
 				"lcid": "^1.0.0"
@@ -2907,7 +2907,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-finally": {
@@ -2969,7 +2969,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
@@ -3023,7 +3023,7 @@
 		},
 		"pify": {
 			"version": "2.3.0",
-			"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
@@ -3198,7 +3198,7 @@
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
 				"regenerate": "^1.2.1",
@@ -3208,12 +3208,12 @@
 		},
 		"regjsgen": {
 			"version": "0.2.0",
-			"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
 			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
-			"resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -3380,7 +3380,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -3612,7 +3612,7 @@
 		},
 		"string-width": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
 				"code-point-at": "^1.0.0",
@@ -3640,7 +3640,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -3705,13 +3705,13 @@
 		},
 		"text-encoding": {
 			"version": "0.6.4",
-			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
 			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
@@ -3986,7 +3986,7 @@
 		},
 		"utf8": {
 			"version": "2.1.2",
-			"resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
 			"integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
 		},
 		"util-deprecate": {
@@ -4020,7 +4020,7 @@
 		},
 		"web3": {
 			"version": "0.20.6",
-			"resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
 			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
 				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
@@ -4084,7 +4084,7 @@
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
-			"resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"which": {
@@ -4108,7 +4108,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -4167,7 +4167,7 @@
 		},
 		"yargs": {
 			"version": "4.8.1",
-			"resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 			"requires": {
 				"cliui": "^3.2.0",
@@ -4188,7 +4188,7 @@
 		},
 		"yargs-parser": {
 			"version": "2.4.1",
-			"resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"requires": {
 				"camelcase": "^3.0.0",

--- a/packages/docs/docs/docs/erc20_onboarding.md
+++ b/packages/docs/docs/docs/erc20_onboarding.md
@@ -220,8 +220,8 @@ or open a new one against the network where your legacy token is deployed. Then,
 commands of the previous step:
 
 ```console
-truffle(local)> erc20Migrator = ERC20Migrator.at('ERC20_MIGRATOR_ADDRESS')
-truffle(local)> upgradeableToken = MyUpgradeableToken.at('UPGRADEABLE_TOKEN_ADDRESS')
+truffle(local)> ERC20Migrator.at('ERC20_MIGRATOR_ADDRESS').then(i => erc20Migrator = i)
+truffle(local)> MyUpgradeableToken.at('UPGRADEABLE_TOKEN_ADDRESS').then(i => upgradeableToken = i)
 truffle(local)> erc20Migrator.beginMigration(upgradeableToken.address, { from: owner })
 truffle(local)> legacyToken.balanceOf(owner).then(b => balance = b)
 truffle(local)> legacyToken.approve(erc20Migrator.address, balance, { from: owner })

--- a/packages/docs/docs/docs/linking.md
+++ b/packages/docs/docs/docs/linking.md
@@ -109,7 +109,8 @@ and `StandaloneERC721` respectively. Both addresses were returned by the `create
 commands we ran above._
 
 ```console
-truffle(local)> MyLinkedContract.at('<my-linked-contract-address>').setToken('<my-erc721-address>')
+truffle(local)> MyLinkedContract.at('<my-linked-contract-address>').then(i => myLinkedContract = i)
+truffle(local)> myLinkedContract.setToken('<my-erc721-address>')
 ```
 
 Remember that the addresses of both your contract and the token, can also be 

--- a/packages/docs/docs/docs/upgrading.md
+++ b/packages/docs/docs/docs/upgrading.md
@@ -72,7 +72,7 @@ that our instance is working as expected:
 by the `create` command we ran above._
 
 ```console
-truffle(local)> myContract = MyContract.at('<your-contract-address>')
+truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
 truffle(local)> myContract.x().then(x => x.toString())
 '42'
 
@@ -154,9 +154,9 @@ returned by the `create` command we ran in the previous section, which
 is the same as the one returned by the `update` command we ran above._
 
 ```console
-truffle(local)> myContract = MyContract.at('<your-contract-address>')
+truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
 truffle(local)> myContract.increment()
-truffle(local)> myContract.x()
+truffle(local)> myContract.x().then(x => x.toString())
 43
 ```
 

--- a/packages/docs/docs/website/versioned_docs/version-2.0.0/erc20_onboarding.md
+++ b/packages/docs/docs/website/versioned_docs/version-2.0.0/erc20_onboarding.md
@@ -221,8 +221,8 @@ or open a new one against the network where your legacy token is deployed. Then,
 commands of the previous step:
 
 ```console
-truffle(local)> erc20Migrator = ERC20Migrator.at('ERC20_MIGRATOR_ADDRESS')
-truffle(local)> upgradeableToken = MyUpgradeableToken.at('UPGRADEABLE_TOKEN_ADDRESS')
+truffle(local)> ERC20Migrator.at('ERC20_MIGRATOR_ADDRESS').then(i => erc20Migrator = i)
+truffle(local)> MyUpgradeableToken.at('UPGRADEABLE_TOKEN_ADDRESS').then(i => upgradeableToken = i)
 truffle(local)> erc20Migrator.beginMigration(upgradeableToken.address, { from: owner })
 truffle(local)> legacyToken.balanceOf(owner).then(b => balance = b)
 truffle(local)> legacyToken.approve(erc20Migrator.address, balance, { from: owner })

--- a/packages/docs/docs/website/versioned_docs/version-2.0.0/linking.md
+++ b/packages/docs/docs/website/versioned_docs/version-2.0.0/linking.md
@@ -110,7 +110,8 @@ and `StandaloneERC721` respectively. Both addresses were returned by the `create
 commands we ran above._
 
 ```console
-truffle(local)> MyLinkedContract.at('<my-linked-contract-address>').setToken('<my-erc721-address>')
+truffle(local)> MyLinkedContract.at('<my-linked-contract-address>').then(i => myLinkedContract = i)
+truffle(local)> myLinkedContract.setToken('<my-erc721-address>')
 ```
 
 Remember that the addresses of both, your contract and the token, can also be 

--- a/packages/docs/docs/website/versioned_docs/version-2.0.0/upgrading.md
+++ b/packages/docs/docs/website/versioned_docs/version-2.0.0/upgrading.md
@@ -73,7 +73,7 @@ our instance is working as expected:
 by the `create` command we ran above._
 
 ```console
-truffle(local)> myContract = MyContract.at('<your-contract-address>')
+truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
 truffle(local)> myContract.x().then(x => x.toString())
 42
 
@@ -155,9 +155,9 @@ returned by the `create` command we ran in the previous section, which
 is the same as the one returned by the `update` command we ran above._
 
 ```console
-truffle(local)> myContract = MyContract.at('<your-contract-address>')
+truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
 truffle(local)> myContract.increment()
-truffle(local)> myContract.x()
+truffle(local)> myContract.x().then(x => x.toString())
 43
 ```
 

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -115,7 +115,7 @@ contract('Transactions', function([_account1, account2]) {
     });
 
     it('uses specified gas', async function () {
-      const { tx } = await sendTransaction(this.instance.initialize, [42, 'foo', [1,2,3]], { gas: 800000});
+      const { tx } = await sendTransaction(this.instance.initialize, [42, 'foo', [1,2,3]], { gas: 800000 });
       await assertGas(tx, 800000);
     });
 


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/562

We are telling the user to run `npx truffle console` to test their upgradeable contract. Therefore, if the user is running a Truffle 5 project, the steps we are telling them to reproduce won't work: we are using `at` which is now async.