### PR TITLE
Force lerna bootstrap in some CI scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,18 +51,16 @@ jobs:
     - stage: tests
       name: CLI tests on Linux
       os: linux
-      install:
-        - npx lerna run compile-contracts --scope zos-lib
-        - npx lerna run compile-ts --scope zos-lib
+      install: npx lerna run compile-contracts --scope zos-lib
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos
 
     # Test stage for CLI on OSX
     - stage: tests
       name: CLI tests on OSX
       os: osx
-      install: 
-        - npx lerna run compile-contracts --scope zos-lib
-        - npx lerna run compile-ts --scope zos-lib
+      install:
+        # Travis is not finding some dependencies when running on OSX, running lerna again here to avoid that
+        - npx lerna bootstrap --loglevel=debug
       script: npx lerna run test --concurrency=1 --stream=true --scope=zos
 
     # Test stage for complex-example
@@ -79,8 +77,9 @@ jobs:
         - sudo add-apt-repository -y ppa:ethereum/ethereum
         - sudo apt-get update
         - sudo apt-get install -y ethereum
-      install: 
-        - npx lerna run compile-contracts --scope zos-lib
+      install:
+        # Travis is not finding some dependencies when running the integration tests, running lerna again here to avoid that
+        - npx lerna bootstrap --loglevel=debug
         - npm --prefix tests/cli-app install tests/cli-app
       script: cd tests/cli-app && ./scripts/test.sh
 
@@ -92,8 +91,9 @@ jobs:
         - sudo add-apt-repository -y ppa:ethereum/ethereum
         - sudo apt-get update
         - sudo apt-get install -y ethereum
-      install: 
-        - npx lerna run compile-contracts --scope zos-lib
+      install:
+        # Travis is not finding some dependencies when running the integration tests, running lerna again here to avoid that
+        - npx lerna bootstrap --loglevel=debug
         - npm --prefix tests/cli-app install tests/cli-app
       script: cd tests/cli-app && ./scripts/test.sh
 


### PR DESCRIPTION
Travis is not finding some dependencies when running some particular stages. I'm adding new installation steps for those stages in order to re-run `lerna bootstrap`. This should be considered a temporal solution, it increases the execution time of those stages in 10 minutes. 