### PR TITLE
Use global truffle for compiling (master)

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -6,11 +6,19 @@ const log = new Logger('Compiler');
 const Compiler = {
   async call(): Promise<{ stdout: string, stderr: string }> {
     log.info('Compiling contracts with Truffle...');
-    const truffleBin = `${process.cwd()}/node_modules/.bin/truffle`;
-    if (!FileSystem.exists(truffleBin)) throw new Error(`Could not find truffle in ${truffleBin}. Please make sure you're placed in the right directory.`);
+    let truffleBin = `${process.cwd()}/node_modules/.bin/truffle`;
+    if (!FileSystem.exists(truffleBin)) truffleBin = 'truffle'; // Attempt to load global truffle if local was not found
 
     return new Promise((resolve, reject) => {
       exec(`${truffleBin} compile --all`, (error, stdout, stderr) => {
+        if (error) {
+          if (error.code === 127) console.error('Could not find truffle executable. Please install it by running: npm install truffle');
+          reject(error);
+        } else {
+          if (stdout) console.log(stdout);
+          if (stderr) console.error(stderr);
+          resolve({ stdout, stderr });  
+        }
         if (stdout) console.log(stdout);
         if (stderr) console.error(stderr);
         error ? reject(error) : resolve({ stdout, stderr });


### PR DESCRIPTION
When compiling, if there is no local binary for truffle in node_modules, fall back to a global instance. Catch error 127 (file not found) and display a friendlier message.

This pull request is equivalent to #596, but against master instead of against release 2.1.0.

Disclaimer: I failed miserably in attempting to test it locally, since any attempts to run `zos` after installing from master throw `zos_lib_1.Contracts.setLocalBuildDir is not a function`. 

Fixes #579