### PR TITLE
Avoid transferring proxies to `app` on publish

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -434,15 +434,6 @@ export default class NetworkController {
     const deployer = new AppProjectDeployer(this, this.packageVersion);
     this.project = await deployer.fromProxyAdminProject(proxyAdminProject);
     log.info(`Publish to ${this.network} successful`);
-
-    const proxies = this._fetchOwnedProxies();
-    if (proxies.length !== 0) {
-      log.info(`Awaiting confirmations before transferring proxies to published project (this may take a few minutes)`);
-      const app = this.project.getApp();
-      await awaitConfirmations(app.contract.transactionHash);
-      await this._changeProxiesAdmin(proxies, app.address, proxyAdminProject);
-      log.info(`${proxies.length} proxies have been successfully transferred`);
-    }
   }
 
   // Proxy model

--- a/packages/cli/test/scripts/publish.test.js
+++ b/packages/cli/test/scripts/publish.test.js
@@ -14,7 +14,7 @@ const should = require('chai').should();
 
 contract('publish script', function(accounts) {
   accounts = accounts.map(utils.toChecksumAddress);
-  const [_, owner, otherAddress] = accounts;
+  const [_, owner] = accounts;
 
   const network = 'test';
   const txParams = { from: owner };
@@ -93,23 +93,20 @@ contract('publish script', function(accounts) {
   });
 
   describe('publishing with proxies', async function () {
-    it('should transfer ownership of own proxy to app', async function () {
-      this.ownProxy = await create({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await publish({ network, txParams, networkFile: this.networkFile });
-      (await Proxy.at(this.ownProxy.address).admin()).should.eq(this.networkFile.appAddress);
-    });
+    context('for implementation proxy', function() {
+      it('should be owned by proxyAdmin', async function () {
+        this.ownProxy = await create({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+        await publish({ network, txParams, networkFile: this.networkFile });
+        (await Proxy.at(this.ownProxy.address).admin()).should.eq(this.networkFile.proxyAdminAddress);
+      });
+    })
 
-    it('should transfer ownership of dependency proxy to app', async function () {
-      this.dependencyProxy = await create({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-      await publish({ network, txParams, networkFile: this.networkFile });
-      (await Proxy.at(this.dependencyProxy.address).admin()).should.eq(this.networkFile.appAddress);
-    });
-
-    it('should not transfer ownership of transferred proxy to app', async function () {
-      this.transferredProxy = await create({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await setAdmin({ newAdmin: otherAddress, contractAlias: 'Impl', packageName: 'Herbs', network, txParams, networkFile: this.networkFile })
-      await publish({ network, txParams, networkFile: this.networkFile });
-      (await Proxy.at(this.transferredProxy.address).admin()).should.eq(otherAddress);
-    });
+    context('for dependency proxy', function() {
+      it('should be owned by proxyAdmin', async function () {
+        this.dependencyProxy = await create({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+        await publish({ network, txParams, networkFile: this.networkFile });
+        (await Proxy.at(this.dependencyProxy.address).admin()).should.eq(this.networkFile.proxyAdminAddress);
+      });
+    })
   });
 });


### PR DESCRIPTION
After implementing #588 and while implementing the migration between zosversion 2 and zosversion 2.2, I noticed that all owned proxy contracts were being transferred from `ProxyAdmin` to `App`, and that's not the intended behaviour, as proxies should be always owned by the `ProxyAdmin`.