### PR TITLE
Remove duplicated output from truffle compile

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -19,9 +19,6 @@ const Compiler = {
           if (stderr) console.error(stderr);
           resolve({ stdout, stderr });  
         }
-        if (stdout) console.log(stdout);
-        if (stderr) console.error(stderr);
-        error ? reject(error) : resolve({ stdout, stderr });
       });
     });
   }


### PR DESCRIPTION
We were outputting the stdout and stderr from truffle compile twice. This PR fixes that.