### PR TITLE
Remove truffle resolver from CLI

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -4,33 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@mrmlnc/readdir-enhanced": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"glob-to-regexp": "^0.3.0"
-			}
-		},
-		"@nodelib/fs.stat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
-		},
-		"@samverschueren/stream-to-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-			"requires": {
-				"any-observable": "^0.3.0"
-			}
-		},
-		"@sindresorhus/is": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
-		},
 		"@sinonjs/commons": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -107,44 +80,6 @@
 				"@types/underscore": "*"
 			}
 		},
-		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-			"optional": true
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"optional": true
-		},
-		"abi-decoder": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.2.0.tgz",
-			"integrity": "sha512-y2OKSEW4gf2838Eavc56vQY9V46zaXkf3Jl1WpTfUBbzAVrXSr4JRZAAWv55Tv9s5WNz1rVgBgz5d2aJIL1QCg==",
-			"requires": {
-				"web3": "^0.18.4"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					}
-				}
-			}
-		},
 		"abstract-leveldown": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
@@ -162,45 +97,10 @@
 				"negotiator": "0.6.1"
 			}
 		},
-		"acorn": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-			"integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
-		},
-		"acorn-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-			"integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
-			"optional": true,
-			"requires": {
-				"acorn": "^2.1.0"
-			}
-		},
-		"adm-zip": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-			"integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
-		},
 		"aes-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
 			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-		},
-		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
-			}
-		},
-		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -215,117 +115,21 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"any-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
-		},
 		"any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-		},
-		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"optional": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"optional": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
-		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
-		},
-		"arr-flatten": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-		},
-		"arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
 		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"requires": {
-				"array-uniq": "^1.0.1"
-			}
-		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-		},
-		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -353,17 +157,8 @@
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-		},
-		"assign-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-		},
-		"ast-types": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async": {
 			"version": "2.6.1",
@@ -372,11 +167,6 @@
 			"requires": {
 				"lodash": "^4.17.10"
 			}
-		},
-		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"async-eventemitter": {
 			"version": "0.2.4",
@@ -396,11 +186,6 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
-		"atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -418,28 +203,6 @@
 			"requires": {
 				"follow-redirects": "^1.3.0",
 				"is-buffer": "^1.1.5"
-			}
-		},
-		"babel-cli": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-polyfill": "^6.26.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"chokidar": "^1.6.1",
-				"commander": "^2.11.0",
-				"convert-source-map": "^1.5.0",
-				"fs-readdir-recursive": "^1.0.0",
-				"glob": "^7.1.2",
-				"lodash": "^4.17.4",
-				"output-file-sync": "^1.1.2",
-				"path-is-absolute": "^1.0.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6",
-				"v8flags": "^2.1.1"
 			}
 		},
 		"babel-code-frame": {
@@ -534,16 +297,6 @@
 				}
 			}
 		},
-		"babel-helper-bindify-decorators": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
@@ -581,17 +334,6 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-explode-class": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-			"requires": {
-				"babel-helper-bindify-decorators": "^6.24.1",
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
 				"babel-types": "^6.24.1"
@@ -701,65 +443,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
-		"babel-plugin-syntax-async-generators": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
-		},
-		"babel-plugin-syntax-class-constructor-call": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
-		},
-		"babel-plugin-syntax-class-properties": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-		},
-		"babel-plugin-syntax-decorators": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
-		},
-		"babel-plugin-syntax-dynamic-import": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
-		"babel-plugin-syntax-export-extensions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
-		},
-		"babel-plugin-syntax-flow": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
 			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-		},
-		"babel-plugin-transform-async-generator-functions": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-generators": "^6.5.0",
-				"babel-runtime": "^6.22.0"
-			}
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
@@ -769,39 +461,6 @@
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
 				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-class-constructor-call": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-class-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-decorators": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-			"requires": {
-				"babel-helper-explode-class": "^6.24.1",
-				"babel-plugin-syntax-decorators": "^6.13.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1026,33 +685,6 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
-		"babel-plugin-transform-export-extensions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-			"requires": {
-				"babel-plugin-syntax-export-extensions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-flow-strip-types": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
-			}
-		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1068,23 +700,6 @@
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-				}
 			}
 		},
 		"babel-preset-env": {
@@ -1122,70 +737,6 @@
 				"browserslist": "^3.2.6",
 				"invariant": "^2.2.2",
 				"semver": "^5.3.0"
-			}
-		},
-		"babel-preset-es2015": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-				"babel-plugin-transform-es2015-classes": "^6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-				"babel-plugin-transform-es2015-for-of": "^6.22.0",
-				"babel-plugin-transform-es2015-function-name": "^6.24.1",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-				"babel-plugin-transform-es2015-object-super": "^6.24.1",
-				"babel-plugin-transform-es2015-parameters": "^6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-				"babel-plugin-transform-regenerator": "^6.24.1"
-			}
-		},
-		"babel-preset-stage-1": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-			"requires": {
-				"babel-plugin-transform-class-constructor-call": "^6.24.1",
-				"babel-plugin-transform-export-extensions": "^6.22.0",
-				"babel-preset-stage-2": "^6.24.1"
-			}
-		},
-		"babel-preset-stage-2": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-plugin-transform-class-properties": "^6.24.1",
-				"babel-plugin-transform-decorators": "^6.24.1",
-				"babel-preset-stage-3": "^6.24.1"
-			}
-		},
-		"babel-preset-stage-3": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-generator-functions": "^6.24.1",
-				"babel-plugin-transform-async-to-generator": "^6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
-				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1287,71 +838,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"base": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
-		"base-64": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-			"integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
-		},
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -1364,21 +850,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"big.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-		},
-		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
-		},
-		"binaryextensions": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
-			"integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
 		},
 		"bindings": {
 			"version": "1.3.1",
@@ -1395,7 +866,7 @@
 		},
 		"bl": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -1493,16 +964,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
-			}
-		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -1550,7 +1011,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -1654,55 +1115,6 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
-		"cache-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"cacheable-request": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"requires": {
-				"clone-response": "1.0.2",
-				"get-stream": "3.0.0",
-				"http-cache-semantics": "3.8.1",
-				"keyv": "3.0.0",
-				"lowercase-keys": "1.0.0",
-				"normalize-url": "2.0.1",
-				"responselike": "1.0.2"
-			},
-			"dependencies": {
-				"lowercase-keys": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-				}
-			}
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-		},
 		"camelcase": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -1757,15 +1169,11 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"checkpoint-store": {
 			"version": "1.1.0",
@@ -1788,28 +1196,6 @@
 				"parse5": "^3.0.1"
 			}
 		},
-		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
-			}
-		},
-		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-			"optional": true
-		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1818,74 +1204,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"class-utils": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"requires": {
-				"restore-cursor": "^2.0.0"
-			}
-		},
-		"cli-spinners": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
-		},
-		"cli-table": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-			"requires": {
-				"colors": "1.0.3"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-				}
-			}
-		},
-		"cli-truncate": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"requires": {
-				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -1902,76 +1220,10 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
-		"clone-stats": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-		},
-		"cloneable-readable": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"collection-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
-			}
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -1981,20 +1233,10 @@
 				"color-name": "1.1.3"
 			}
 		},
-		"color-logger": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.6.tgz",
-			"integrity": "sha1-5WJF7ymCJlcRDHy3WpzXhstp7Rs="
-		},
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"combined-stream": {
 			"version": "1.0.7",
@@ -2008,16 +1250,6 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-		},
-		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2073,9 +1305,9 @@
 			},
 			"dependencies": {
 				"write-file-atomic": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+					"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -2083,11 +1315,6 @@
 					}
 				}
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -2122,11 +1349,6 @@
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
 			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
 		},
-		"copy-descriptor": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-		},
 		"core-js": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
@@ -2144,38 +1366,6 @@
 			"requires": {
 				"object-assign": "^4",
 				"vary": "^1"
-			}
-		},
-		"cpr": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/cpr/-/cpr-0.4.3.tgz",
-			"integrity": "sha1-CiPktuwj87jMekBey1z9x3j33iU=",
-			"requires": {
-				"graceful-fs": "~4.1.2",
-				"mkdirp": "~0.5.0",
-				"rimraf": "~2.4.3"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.4.5",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-					"integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-					"requires": {
-						"glob": "^6.0.1"
-					}
-				}
 			}
 		},
 		"create-ecdh": {
@@ -2221,18 +1411,6 @@
 				"whatwg-fetch": "2.0.4"
 			}
 		},
-		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2250,11 +1428,6 @@
 				"randombytes": "^2.0.0",
 				"randomfill": "^1.0.3"
 			}
-		},
-		"crypto-js": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-			"integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
 		},
 		"crypto-random-string": {
 			"version": "1.0.0",
@@ -2277,25 +1450,6 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
 			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
 		},
-		"cssom": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
-		},
-		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"optional": true,
-			"requires": {
-				"cssom": "0.3.x"
-			}
-		},
-		"dargs": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2303,16 +1457,6 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-		},
-		"dateformat": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "3.1.0",
@@ -2407,12 +1551,12 @@
 			"dependencies": {
 				"file-type": {
 					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
 					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
 				},
 				"get-stream": {
 					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"requires": {
 						"object-assign": "^4.0.1",
@@ -2425,6 +1569,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
@@ -2433,32 +1578,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
-		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"optional": true
-		},
-		"defaults": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"requires": {
-				"clone": "^1.0.2"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-				}
-			}
 		},
 		"deferred-leveldown": {
 			"version": "1.2.2",
@@ -2476,82 +1595,15 @@
 				"object-keys": "^1.0.12"
 			}
 		},
-		"define-property": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
 		},
-		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
-			}
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"optional": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -2572,11 +1624,6 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
-		"detect-conflict": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
-		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -2585,49 +1632,20 @@
 				"repeating": "^2.0.0"
 			}
 		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"optional": true
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
-			}
-		},
-		"dir-glob": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-			"requires": {
-				"arrify": "^1.0.1",
-				"path-type": "^3.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
 			}
 		},
 		"dom-serializer": {
@@ -2696,11 +1714,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
-		"easy-stack": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
-			"integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g="
-		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2710,34 +1723,15 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"editions": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-			"integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
-			"requires": {
-				"errlop": "^1.1.1",
-				"semver": "^5.6.0"
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
-		"ejs": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
-		},
 		"electron-to-chromium": {
 			"version": "1.3.92",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.92.tgz",
 			"integrity": "sha512-En051LMzMl3/asMWGZEtU808HOoVWIpmmZx1Ep8N+TT9e7z/X8RcLeBU2kLSNLGQ+5SuKELzMx+MVuTBXk6Q9w=="
-		},
-		"elegant-spinner": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -2752,11 +1746,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
-		},
-		"emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -2779,33 +1768,10 @@
 				"once": "^1.4.0"
 			}
 		},
-		"enhanced-resolve": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"tapable": "^1.0.0"
-			}
-		},
 		"entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-		},
-		"envinfo": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.12.1.tgz",
-			"integrity": "sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w=="
-		},
-		"errlop": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
-			"integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
-			"requires": {
-				"editions": "^2.1.2"
-			}
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -2813,15 +1779,6 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
@@ -2863,87 +1820,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"escodegen": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
-			"optional": true,
-			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"optional": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"optional": true
-				}
-			}
-		},
-		"esdoc": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esdoc/-/esdoc-1.1.0.tgz",
-			"integrity": "sha512-vsUcp52XJkOWg9m1vDYplGZN2iDzvmjDL5M/Mp8qkoDG3p2s0yIQCIjKR5wfPBaM3eV14a6zhQNYiNTCVzPnxA==",
-			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-traverse": "6.26.0",
-				"babylon": "6.18.0",
-				"cheerio": "1.0.0-rc.2",
-				"color-logger": "0.0.6",
-				"escape-html": "1.0.3",
-				"fs-extra": "5.0.0",
-				"ice-cap": "0.0.4",
-				"marked": "0.3.19",
-				"minimist": "1.2.0",
-				"taffydb": "2.7.3"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-		},
-		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"optional": true
 		},
 		"esutils": {
 			"version": "2.0.2",
@@ -3381,19 +2257,9 @@
 				},
 				"uuid": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
 				}
-			}
-		},
-		"ethjs-abi": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
-			"integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
-			"requires": {
-				"bn.js": "4.11.6",
-				"js-sha3": "0.5.5",
-				"number-to-bn": "1.7.0"
 			}
 		},
 		"ethjs-unit": {
@@ -3414,256 +2280,6 @@
 				"strip-hex-prefix": "1.0.0"
 			}
 		},
-		"ethpm": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/ethpm/-/ethpm-0.0.16.tgz",
-			"integrity": "sha512-EF7LPaofPDRu7LenMn+Q64NQeH8RSowJqjcYtYTsNM7Rgs5I2/0m4OTiU0QVQqwYhAj7a1DFBZfKFBs7+eONlg==",
-			"requires": {
-				"async": "^2.1.2",
-				"ethpm-spec": "^1.0.1",
-				"fs-extra": "^6.0.1",
-				"glob": "^7.1.1",
-				"ipfs-mini": "^1.1.2",
-				"jsonschema": "^1.1.1",
-				"lodash": "^4.17.1",
-				"node-dir": "^0.1.16",
-				"semver": "^5.3.0",
-				"wget-improved": "^1.4.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-					"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				}
-			}
-		},
-		"ethpm-registry": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/ethpm-registry/-/ethpm-registry-0.0.10.tgz",
-			"integrity": "sha512-VXrC26KUL18pC0TPe2ZP9BeihXz/Ewy8qJjDVUatxiK9bKJcEuuIjRUJ8eFHvFxCGLhTq0US0CDnjWQJfac4hA==",
-			"requires": {
-				"fs-extra": "^2.0.0",
-				"left-pad": "^1.1.3",
-				"semver": "^5.3.0",
-				"solidity-sha3": "^0.4.1",
-				"truffle-artifactor": "^2.1.2",
-				"truffle-contract": "^1.1.6",
-				"web3": "^0.18.2"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"fs-extra": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0"
-					}
-				},
-				"truffle-artifactor": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/truffle-artifactor/-/truffle-artifactor-2.1.5.tgz",
-					"integrity": "sha1-k51sszOYS1ZSmFDgPD3aykkAaHA=",
-					"requires": {
-						"async": "^1.5.2",
-						"fs-extra": "^1.0.0",
-						"lodash": "^4.11.2",
-						"truffle-contract": "^2.0.3",
-						"truffle-contract-schema": "^0.0.5"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						},
-						"fs-extra": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-							"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"jsonfile": "^2.1.0",
-								"klaw": "^1.0.0"
-							}
-						},
-						"truffle-contract": {
-							"version": "2.0.5",
-							"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-2.0.5.tgz",
-							"integrity": "sha512-ItnN85wh4qVYPg6T4CpubI40c8dWEArtUcWcDoZ7xzj9DL7cwxqstJ0yRxyQIh4u8SRSlrOtm1dh0B7R8jtG+w==",
-							"requires": {
-								"ethjs-abi": "0.1.8",
-								"truffle-blockchain-utils": "^0.0.3",
-								"truffle-contract-schema": "^0.0.5",
-								"web3": "^0.20.1"
-							}
-						},
-						"web3": {
-							"version": "0.20.7",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
-							"integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
-							"requires": {
-								"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xhr2-cookies": "^1.1.0",
-								"xmlhttprequest": "*"
-							}
-						}
-					}
-				},
-				"truffle-blockchain-utils": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz",
-					"integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
-					"requires": {
-						"web3": "^0.20.1"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						},
-						"web3": {
-							"version": "0.20.7",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
-							"integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
-							"requires": {
-								"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xhr2-cookies": "^1.1.0",
-								"xmlhttprequest": "*"
-							}
-						}
-					}
-				},
-				"truffle-contract": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-1.1.11.tgz",
-					"integrity": "sha1-zh+nh/eXdYr/Vy9F6LEXRSf27ao=",
-					"requires": {
-						"ethjs-abi": "0.1.8",
-						"truffle-blockchain-utils": "0.0.1",
-						"truffle-contract-schema": "0.0.5",
-						"web3": "^0.16.0"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-							"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-						},
-						"truffle-blockchain-utils": {
-							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.1.tgz",
-							"integrity": "sha1-B6WOVbsFVaZCCMkRnAsE/+FGSqQ=",
-							"requires": {
-								"web3": "^0.18.0"
-							},
-							"dependencies": {
-								"web3": {
-									"version": "0.18.4",
-									"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-									"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-									"requires": {
-										"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-										"crypto-js": "^3.1.4",
-										"utf8": "^2.1.1",
-										"xhr2": "*",
-										"xmlhttprequest": "*"
-									}
-								}
-							}
-						},
-						"web3": {
-							"version": "0.16.0",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-							"requires": {
-								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xmlhttprequest": "*"
-							},
-							"dependencies": {
-								"bignumber.js": {
-									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-									"from": "git+https://github.com/debris/bignumber.js.git#master"
-								}
-							}
-						}
-					}
-				},
-				"truffle-contract-schema": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-0.0.5.tgz",
-					"integrity": "sha1-Xp0gvQvyon/pQxB0gknUhO7kmWE=",
-					"requires": {
-						"crypto-js": "^3.1.9-1"
-					},
-					"dependencies": {
-						"crypto-js": {
-							"version": "3.1.9-1",
-							"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-							"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-						}
-					}
-				},
-				"web3": {
-					"version": "0.18.4",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-							"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-						}
-					}
-				}
-			}
-		},
-		"ethpm-spec": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ethpm-spec/-/ethpm-spec-1.0.1.tgz",
-			"integrity": "sha1-rTwJrgSSrT0+x7lLf1/YBX1N65E=",
-			"requires": {
-				"json-schema-to-markdown": "^1.0.3"
-			}
-		},
-		"event-pubsub": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
-			"integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ=="
-		},
 		"eventemitter3": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
@@ -3681,56 +2297,6 @@
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				}
-			}
-		},
-		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"requires": {
-				"is-posix-bracket": "^0.1.0"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "^2.1.0"
-			}
-		},
-		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"requires": {
-				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"express": {
@@ -3809,43 +2375,6 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
-		"extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"dependencies": {
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "^2.0.4"
-					}
-				}
-			}
-		},
-		"external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
-			}
-		},
-		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"requires": {
-				"is-extglob": "^1.0.0"
-			}
-		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3859,323 +2388,10 @@
 				"checkpoint-store": "^1.1.0"
 			}
 		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-glob": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
-			"requires": {
-				"@mrmlnc/readdir-enhanced": "^2.2.1",
-				"@nodelib/fs.stat": "^1.1.2",
-				"glob-parent": "^3.1.0",
-				"is-glob": "^4.0.0",
-				"merge2": "^1.2.3",
-				"micromatch": "^3.1.10"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
-			}
-		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-		},
-		"fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -4204,61 +2420,10 @@
 				}
 			}
 		},
-		"figures": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
-			}
-		},
 		"file-type": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-		},
-		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
-			}
-		},
-		"finalhandler": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
-			"integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
-			"requires": {
-				"debug": "~2.2.0",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				}
-			}
 		},
 		"find-up": {
 			"version": "2.1.0",
@@ -4267,43 +2432,6 @@
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
-		},
-		"first-chunk-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-			"requires": {
-				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
-		"flow-parser": {
-			"version": "0.90.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.90.0.tgz",
-			"integrity": "sha512-a6Ohgdzvf2e1/F8sI98qcPLtDIjLayRkRgAwrWHzHFMHCNq92jyRbRG0w5fGjs6xdI320Ud39HkI0Dk5OPs17g=="
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
@@ -4320,24 +2448,6 @@
 			"requires": {
 				"is-callable": "^1.1.3"
 			}
-		},
-		"for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"requires": {
-				"for-in": "^1.0.1"
-			}
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -4359,51 +2469,10 @@
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
-		"fragment-cache": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"requires": {
-				"map-cache": "^0.2.2"
-			}
-		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"from2": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -4420,15 +2489,6 @@
 				"klaw": "^1.0.0",
 				"path-is-absolute": "^1.0.0",
 				"rimraf": "^2.2.8"
-			}
-		},
-		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-			"optional": true,
-			"requires": {
-				"minipass": "^2.2.1"
 			}
 		},
 		"fs-promise": {
@@ -4453,25 +2513,10 @@
 				}
 			}
 		},
-		"fs-readdir-recursive": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.6.tgz",
-			"integrity": "sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==",
-			"optional": true,
-			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
-			}
 		},
 		"fstream": {
 			"version": "1.0.11",
@@ -4494,47 +2539,6 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
-		"ganache-cli": {
-			"version": "6.1.0-beta.4",
-			"resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.0-beta.4.tgz",
-			"integrity": "sha512-0a22Ma8NqPvo5g8o86q0TatBi+oPIBydAnwJ8FKtU97I/CYZZVSJTPlsFRwWE2EgaMSTw5LHOqeG9694+xbASw==",
-			"requires": {
-				"source-map-support": "^0.5.3",
-				"webpack-cli": "^2.0.9"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				}
-			}
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"optional": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			}
-		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -4543,22 +2547,13 @@
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
-		"get-params": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
-			"integrity": "sha1-uuDfq6WIoMYNeDTA2Nwv9g7u8v4="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-		},
-		"get-value": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -4566,96 +2561,6 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
-			}
-		},
-		"gh-got": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-			"requires": {
-				"got": "^7.0.0",
-				"is-plain-obj": "^1.1.0"
-			},
-			"dependencies": {
-				"got": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-					"requires": {
-						"decompress-response": "^3.2.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-plain-obj": "^1.1.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"isurl": "^1.0.0-alpha5",
-						"lowercase-keys": "^1.0.0",
-						"p-cancelable": "^0.3.0",
-						"p-timeout": "^1.1.1",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"url-parse-lax": "^1.0.0",
-						"url-to-options": "^1.0.1"
-					}
-				},
-				"p-cancelable": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-				},
-				"p-timeout": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-					"requires": {
-						"p-finally": "^1.0.0"
-					}
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-				},
-				"url-parse-lax": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-					"requires": {
-						"prepend-http": "^1.0.1"
-					}
-				}
-			}
-		},
-		"github-download": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/github-download/-/github-download-0.5.0.tgz",
-			"integrity": "sha1-92R6cKrEMm+wkeV4bI9mrhV9pRs=",
-			"requires": {
-				"adm-zip": "~0.4.3",
-				"fs-extra": "^0.24.0",
-				"request": "^2.12.0",
-				"vcsurl": "~0.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
-					"integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0",
-						"path-is-absolute": "^1.0.0",
-						"rimraf": "^2.2.8"
-					}
-				}
-			}
-		},
-		"github-username": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-			"requires": {
-				"gh-got": "^6.0.0"
 			}
 		},
 		"glob": {
@@ -4671,52 +2576,6 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-all": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
-			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-			"requires": {
-				"glob": "^7.0.5",
-				"yargs": "~1.2.6"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
-				},
-				"yargs": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
-					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-					"requires": {
-						"minimist": "^0.1.0"
-					}
-				}
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "^2.0.0"
-			}
-		},
-		"glob-to-regexp": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
-		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
@@ -4726,45 +2585,10 @@
 				"process": "~0.5.1"
 			}
 		},
-		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
-			}
-		},
-		"global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
-			}
-		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-		},
-		"globby": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			}
 		},
 		"got": {
 			"version": "7.1.0",
@@ -4796,22 +2620,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
-		"graphlib": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.7.tgz",
-			"integrity": "sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==",
-			"requires": {
-				"lodash": "^4.17.5"
-			}
-		},
-		"grouped-queue": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
-			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
-			"requires": {
-				"lodash": "^4.17.2"
-			}
 		},
 		"growl": {
 			"version": "1.10.3",
@@ -4872,11 +2680,6 @@
 				"ansi-regex": "^2.0.0"
 			}
 		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4900,66 +2703,6 @@
 				"has-symbol-support-x": "^1.4.1"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"optional": true
-		},
-		"has-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"has-values": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"hash-base": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -4981,7 +2724,8 @@
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -5002,14 +2746,6 @@
 				"os-tmpdir": "^1.0.1"
 			}
 		},
-		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-			"requires": {
-				"parse-passwd": "^1.0.0"
-			}
-		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -5027,11 +2763,6 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^3.0.6"
 			}
-		},
-		"http-cache-semantics": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
 			"version": "1.6.3",
@@ -5057,83 +2788,6 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
-			}
-		},
-		"ice-cap": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/ice-cap/-/ice-cap-0.0.4.tgz",
-			"integrity": "sha1-im0xq0ysjUtW3k+pRt8zUlYbbhg=",
-			"requires": {
-				"cheerio": "0.20.0",
-				"color-logger": "0.0.3"
-			},
-			"dependencies": {
-				"cheerio": {
-					"version": "0.20.0",
-					"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
-					"integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
-					"requires": {
-						"css-select": "~1.2.0",
-						"dom-serializer": "~0.1.0",
-						"entities": "~1.1.1",
-						"htmlparser2": "~3.8.1",
-						"jsdom": "^7.0.2",
-						"lodash": "^4.1.0"
-					}
-				},
-				"color-logger": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/color-logger/-/color-logger-0.0.3.tgz",
-					"integrity": "sha1-2bIt0dlz4Waxi/MT+fSBu6TfIBg="
-				},
-				"domhandler": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-					"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-					"requires": {
-						"domelementtype": "1"
-					}
-				},
-				"htmlparser2": {
-					"version": "3.8.3",
-					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-					"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-					"requires": {
-						"domelementtype": "1",
-						"domhandler": "2.3",
-						"domutils": "1.5",
-						"entities": "1.0",
-						"readable-stream": "1.1"
-					},
-					"dependencies": {
-						"entities": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-							"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-						}
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
 			}
 		},
 		"iconv-lite": {
@@ -5164,43 +2818,15 @@
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
 			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
 		},
-		"ignore": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
-		},
-		"ignore-walk": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-			"optional": true,
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
-		},
 		"immediate": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
 			"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 		},
-		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
-			}
-		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-		},
-		"indent-string": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -5215,74 +2841,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-		},
-		"inquirer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.1.0",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
-				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^5.5.2",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"interpret": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
-		},
-		"into-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"requires": {
-				"from2": "^2.1.1",
-				"p-is-promise": "^1.1.0"
-			}
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -5302,34 +2860,10 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
 			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
-		"ipfs-mini": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/ipfs-mini/-/ipfs-mini-1.1.2.tgz",
-			"integrity": "sha1-nA+tP6AKgsgsrtGuBLO5ntOz6V0=",
-			"requires": {
-				"xmlhttprequest": "^1.8.0"
-			}
-		},
-		"is-accessor-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"requires": {
-				"kind-of": "^3.0.2"
-			}
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-		},
-		"is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"requires": {
-				"binary-extensions": "^1.0.0"
-			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -5349,58 +2883,10 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
 			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
-		"is-data-descriptor": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"requires": {
-				"kind-of": "^3.0.2"
-			}
-		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-		},
-		"is-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
-			}
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
-		"is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-		},
-		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -5428,14 +2914,6 @@
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
 			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
-		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"requires": {
-				"is-extglob": "^1.0.0"
-			}
-		},
 		"is-hex-prefixed": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
@@ -5445,14 +2923,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-		},
-		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"requires": {
-				"kind-of": "^3.0.2"
-			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -5464,76 +2934,10 @@
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
 			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
-		"is-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"requires": {
-				"symbol-observable": "^1.1.0"
-			},
-			"dependencies": {
-				"symbol-observable": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-				}
-			}
-		},
-		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-		},
-		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"requires": {
-				"is-path-inside": "^1.0.0"
-			}
-		},
-		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"requires": {
-				"path-is-inside": "^1.0.1"
-			}
-		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-		},
-		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -5547,14 +2951,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-		},
-		"is-scoped": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
-			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-			"requires": {
-				"scoped-regex": "^1.0.0"
-			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -5579,51 +2975,15 @@
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
-		"is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"isbinaryfile": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-			"requires": {
-				"buffer-alloc": "^1.2.0"
-			}
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
-		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
-		"istextorbinary": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.3.0.tgz",
-			"integrity": "sha512-xs+IFjzw1/5n45nMYUh2ipLWGarmE0bDVR85WAiYUXzawc8NYn1WW0qaq2rSEFIR3NoNkaAvOr3FVMojFz5uUg==",
-			"requires": {
-				"binaryextensions": "^2.1.2",
-				"editions": "^2.0.2",
-				"textextensions": "^2.4.0"
-			}
 		},
 		"isurl": {
 			"version": "1.0.0",
@@ -5634,126 +2994,20 @@
 				"is-object": "^1.0.1"
 			}
 		},
-		"js-message": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
-			"integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU="
-		},
-		"js-queue": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
-			"integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
-			"requires": {
-				"easy-stack": "^1.0.0"
-			}
-		},
-		"js-sha3": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-			"integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"jsan": {
-			"version": "3.1.13",
-			"resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
-			"integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g=="
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
-		"jscodeshift": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
-			"integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
-			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.8.0",
-				"babel-preset-es2015": "^6.9.0",
-				"babel-preset-stage-1": "^6.5.0",
-				"babel-register": "^6.9.0",
-				"babylon": "^7.0.0-beta.47",
-				"colors": "^1.1.2",
-				"flow-parser": "^0.*",
-				"lodash": "^4.13.1",
-				"micromatch": "^2.3.7",
-				"neo-async": "^2.5.0",
-				"node-dir": "0.1.8",
-				"nomnom": "^1.8.1",
-				"recast": "^0.15.0",
-				"temp": "^0.8.1",
-				"write-file-atomic": "^1.2.0"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.47",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-				},
-				"node-dir": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-					"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
-				}
-			}
-		},
-		"jsdom": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
-			"integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
-			"optional": true,
-			"requires": {
-				"abab": "^1.0.0",
-				"acorn": "^2.4.0",
-				"acorn-globals": "^1.0.4",
-				"cssom": ">= 0.3.0 < 0.4.0",
-				"cssstyle": ">= 0.2.29 < 0.3.0",
-				"escodegen": "^1.6.1",
-				"nwmatcher": ">= 1.3.7 < 2.0.0",
-				"parse5": "^1.5.1",
-				"request": "^2.55.0",
-				"sax": "^1.1.4",
-				"symbol-tree": ">= 3.1.0 < 4.0.0",
-				"tough-cookie": "^2.2.0",
-				"webidl-conversions": "^2.0.0",
-				"whatwg-url-compat": "~0.6.5",
-				"xml-name-validator": ">= 2.0.1 < 3.0.0"
-			},
-			"dependencies": {
-				"parse5": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-					"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-					"optional": true
-				}
-			}
-		},
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-		},
-		"json-parse-better-errors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-		},
-		"json-pointer": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
-			"integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
-			"requires": {
-				"foreach": "^2.0.4"
-			}
 		},
 		"json-rpc-engine": {
 			"version": "3.8.0",
@@ -5786,16 +3040,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
-		"json-schema-to-markdown": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/json-schema-to-markdown/-/json-schema-to-markdown-1.0.3.tgz",
-			"integrity": "sha1-RBHKIisrZ2DmFmY/C7K9drsm67g="
-		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -5826,11 +3070,6 @@
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -5869,22 +3108,6 @@
 				"sha3": "^1.2.2"
 			}
 		},
-		"keyv": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"requires": {
-				"json-buffer": "3.0.0"
-			}
-		},
-		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
-		},
 		"klaw": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -5900,11 +3123,6 @@
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
-		},
-		"left-pad": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
 		},
 		"level-codec": {
 			"version": "7.0.1",
@@ -6019,119 +3237,6 @@
 				}
 			}
 		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"optional": true,
-			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			}
-		},
-		"linked-list": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
-			"integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78="
-		},
-		"listr": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.5.0",
-				"listr-verbose-renderer": "^0.5.0",
-				"p-map": "^2.0.0",
-				"rxjs": "^6.3.3"
-			},
-			"dependencies": {
-				"rxjs": {
-					"version": "6.3.3",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-					"requires": {
-						"tslib": "^1.9.0"
-					}
-				}
-			}
-		},
-		"listr-silent-renderer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-		},
-		"listr-update-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^2.3.0",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"listr-verbose-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-			"requires": {
-				"chalk": "^2.4.1",
-				"cli-cursor": "^2.1.0",
-				"date-fns": "^1.27.2",
-				"figures": "^2.0.0"
-			}
-		},
 		"load-json-file": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -6142,31 +3247,6 @@
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0",
 				"strip-bom": "^2.0.0"
-			}
-		},
-		"loader-utils": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-			"requires": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^2.0.0",
-				"json5": "^1.0.1"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"locate-path": {
@@ -6191,20 +3271,10 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
-		"lodash-es": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-			"integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
-		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
 		"lodash.compact": {
 			"version": "3.0.1",
@@ -6308,11 +3378,6 @@
 			"integrity": "sha1-3yz6Ix18V8eorQA6va1dc9PqUZU=",
 			"dev": true
 		},
-		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-		},
 		"lodash.omit": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -6338,11 +3403,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
 			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
 		},
-		"lodash.toarray": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-		},
 		"lodash.topairs": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
@@ -6357,62 +3417,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
 			"integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
-		},
-		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"requires": {
-				"chalk": "^2.0.1"
-			}
-		},
-		"log-update": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"cli-cursor": "^2.0.0",
-				"wrap-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0"
-					}
-				}
-			}
 		},
 		"lolex": {
 			"version": "2.7.5",
@@ -6432,22 +3436,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-		},
-		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
-			}
 		},
 		"ltgt": {
 			"version": "2.2.1",
@@ -6475,29 +3463,6 @@
 			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
 			"dev": true
 		},
-		"map-cache": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-		},
-		"map-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"requires": {
-				"object-visit": "^1.0.0"
-			}
-		},
-		"marked": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6512,85 +3477,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"requires": {
-				"mimic-fn": "^1.0.0"
-			}
-		},
-		"mem-fs": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
-			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-			"requires": {
-				"through2": "^2.0.0",
-				"vinyl": "^1.1.0",
-				"vinyl-file": "^2.0.0"
-			}
-		},
-		"mem-fs-editor": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
-			"integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
-			"requires": {
-				"commondir": "^1.0.1",
-				"deep-extend": "^0.6.0",
-				"ejs": "^2.5.9",
-				"glob": "^7.0.3",
-				"globby": "^7.1.1",
-				"isbinaryfile": "^3.0.2",
-				"mkdirp": "^0.5.0",
-				"multimatch": "^2.0.0",
-				"rimraf": "^2.2.8",
-				"through2": "^2.0.0",
-				"vinyl": "^2.0.1"
-			},
-			"dependencies": {
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"globby": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
 		},
 		"memdown": {
 			"version": "1.4.1",
@@ -6615,39 +3501,6 @@
 				}
 			}
 		},
-		"memory-fs": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
 		"memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -6657,11 +3510,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
-		"merge2": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
 		},
 		"merkle-patricia-tree": {
 			"version": "2.3.2",
@@ -6712,26 +3560,6 @@
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
-		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
-			}
-		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -6758,11 +3586,6 @@
 			"requires": {
 				"mime-db": "~1.37.0"
 			}
-		},
-		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -6799,43 +3622,6 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-		},
-		"minipass": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
-		},
-		"minizlib": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-			"optional": true,
-			"requires": {
-				"minipass": "^2.2.1"
-			}
-		},
-		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
-			},
-			"dependencies": {
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "^2.0.4"
-					}
-				}
-			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -6957,22 +3743,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
-			}
-		},
-		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-		},
 		"mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -6993,82 +3763,10 @@
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
 		},
-		"nanoid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
-			"integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
-		},
-		"nanomatch": {
-			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
-		"needle": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
-			"integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
-			"optional": true,
-			"requires": {
-				"debug": "^2.1.2",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-		},
-		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
-		},
-		"nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
 			"version": "1.4.8",
@@ -7083,117 +3781,10 @@
 				"text-encoding": "^0.6.4"
 			}
 		},
-		"node-dir": {
-			"version": "0.1.17",
-			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-			"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-			"requires": {
-				"minimatch": "^3.0.2"
-			}
-		},
-		"node-emoji": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-			"integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-			"requires": {
-				"lodash.toarray": "^4.4.0"
-			}
-		},
 		"node-fetch": {
 			"version": "2.1.2",
 			"resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
 			"integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
-		},
-		"node-ipc": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz",
-			"integrity": "sha512-FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==",
-			"requires": {
-				"event-pubsub": "4.3.0",
-				"js-message": "1.0.5",
-				"js-queue": "2.0.0"
-			}
-		},
-		"node-pre-gyp": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-			"integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-			"optional": true,
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4"
-			},
-			"dependencies": {
-				"tar": {
-					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
-					}
-				}
-			}
-		},
-		"nomnom": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-				},
-				"underscore": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-				}
-			}
-		},
-		"nopt": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-			"optional": true,
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
@@ -7206,73 +3797,12 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
-		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
-		},
-		"normalize-url": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-			"requires": {
-				"prepend-http": "^2.0.0",
-				"query-string": "^5.0.1",
-				"sort-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"prepend-http": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-				}
-			}
-		},
-		"npm-bundled": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
-			"optional": true
-		},
-		"npm-packlist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
-			"integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
-			"optional": true,
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1"
-			}
-		},
 		"npm-programmatic": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/npm-programmatic/-/npm-programmatic-0.0.10.tgz",
 			"integrity": "sha512-SklCZ26RRGi7hLIz/oaSnHy8ZT0gh8r6N3FMuKRye3ZcRo4HI/saldc8b7OqlY/Ov8FXnA1+I+Od+WtesWEp2Q==",
 			"requires": {
 				"bluebird": "^3.4.1"
-			}
-		},
-		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"requires": {
-				"path-key": "^2.0.0"
-			}
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"optional": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
 			}
 		},
 		"nth-check": {
@@ -7297,12 +3827,6 @@
 				"strip-hex-prefix": "1.0.0"
 			}
 		},
-		"nwmatcher": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
-			"optional": true
-		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -7313,26 +3837,6 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"object-copy": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				}
-			}
-		},
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -7342,45 +3846,6 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
 			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
-		},
-		"object-visit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"requires": {
-				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
-			}
-		},
-		"object.pick": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"requires": {
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
 		},
 		"oboe": {
 			"version": "2.1.3",
@@ -7406,56 +3871,6 @@
 				"wrappy": "1"
 			}
 		},
-		"onetime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"requires": {
-				"mimic-fn": "^1.0.0"
-			}
-		},
-		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"optional": true,
-			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
-			}
-		},
-		"ora": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-3.0.0.tgz",
-			"integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
-			"requires": {
-				"chalk": "^2.3.1",
-				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^1.1.0",
-				"log-symbols": "^2.2.0",
-				"strip-ansi": "^4.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
 		"original-require": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
@@ -7479,53 +3894,15 @@
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"optional": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
-		},
-		"output-file-sync": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-			"requires": {
-				"graceful-fs": "^4.1.4",
-				"mkdirp": "^0.5.1",
-				"object-assign": "^4.1.0"
-			}
-		},
 		"p-cancelable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
 			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 		},
-		"p-each-series": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-			"requires": {
-				"p-reduce": "^1.0.0"
-			}
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-		},
-		"p-is-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
-		},
-		"p-lazy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
-			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
 		},
 		"p-limit": {
 			"version": "1.3.0",
@@ -7543,16 +3920,6 @@
 				"p-limit": "^1.1.0"
 			}
 		},
-		"p-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-			"integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w=="
-		},
-		"p-reduce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
-		},
 		"p-timeout": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
@@ -7568,7 +3935,7 @@
 		},
 		"parse-asn1": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -7576,17 +3943,6 @@
 				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-headers": {
@@ -7606,11 +3962,6 @@
 				"error-ex": "^1.2.0"
 			}
 		},
-		"parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-		},
 		"parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
@@ -7624,16 +3975,6 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
-		"pascalcase": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-		},
-		"path-dirname": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
-		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -7643,16 +3984,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-		},
-		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -7689,7 +4020,8 @@
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
@@ -7731,48 +4063,15 @@
 				"pinkie": "^2.0.0"
 			}
 		},
-		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"requires": {
-				"find-up": "^2.1.0"
-			}
-		},
-		"posix-character-classes": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-		},
 		"precond": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
 			"integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
 		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-		},
-		"prettier": {
-			"version": "1.15.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
-		},
-		"pretty-bytes": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
 		},
 		"private": {
 			"version": "0.1.8",
@@ -7822,11 +4121,6 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"psl": {
 			"version": "1.1.31",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -7863,33 +4157,6 @@
 				"decode-uri-component": "^0.2.0",
 				"object-assign": "^4.1.0",
 				"strict-uri-encode": "^1.0.0"
-			}
-		},
-		"querystring": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
 			}
 		},
 		"randombytes": {
@@ -7940,26 +4207,6 @@
 				}
 			}
 		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"optional": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"optional": true
-				}
-			}
-		},
 		"react": {
 			"version": "16.6.3",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
@@ -7982,22 +4229,6 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"scheduler": "^0.11.2"
-			}
-		},
-		"read-chunk": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-			"requires": {
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
 			}
 		},
 		"read-pkg": {
@@ -8048,381 +4279,6 @@
 				"util-deprecate": "^1.0.1"
 			}
 		},
-		"readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
-		"recast": {
-			"version": "0.15.5",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.15.5.tgz",
-			"integrity": "sha512-nkAYNqarh73cMWRKFiPQ8I9dOLFvFk6SnG8u/LUlOYfArDOD/EjsVRAs860TlBLrpxqAXHGET/AUAVjdEymL5w==",
-			"requires": {
-				"ast-types": "0.11.5",
-				"esprima": "~4.0.0",
-				"private": "~0.1.5",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"requires": {
-				"resolve": "^1.1.6"
-			}
-		},
-		"redux": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-			"requires": {
-				"lodash": "^4.2.1",
-				"lodash-es": "^4.2.1",
-				"loose-envify": "^1.1.0",
-				"symbol-observable": "^1.0.3"
-			},
-			"dependencies": {
-				"symbol-observable": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-				}
-			}
-		},
-		"redux-cli-logger": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/redux-cli-logger/-/redux-cli-logger-2.1.0.tgz",
-			"integrity": "sha512-75mVsggAJRSykWy2qxdGI7osocDWvc3RCMeN93hlvS/FxgdRww12NaXslez+W6gBOrSJKO7W16V0IzuISSfCxg==",
-			"requires": {
-				"colors": "^1.1.2"
-			}
-		},
-		"redux-devtools-core": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
-			"integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
-			"requires": {
-				"get-params": "^0.1.2",
-				"jsan": "^3.1.13",
-				"lodash": "^4.17.11",
-				"nanoid": "^2.0.0",
-				"remotedev-serialize": "^0.1.8"
-			}
-		},
-		"redux-devtools-instrument": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.4.tgz",
-			"integrity": "sha512-jS/xyhepBmtsqAt+bIEusVAtgNTcYl2ac7DAfCDrTSX84C77D0DMjpCh45RntaVfa2bVpNkn9vKWUMQBzTKNRg==",
-			"requires": {
-				"lodash": "^4.2.0",
-				"symbol-observable": "^1.0.2"
-			},
-			"dependencies": {
-				"symbol-observable": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-				}
-			}
-		},
-		"redux-saga": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.2.tgz",
-			"integrity": "sha512-iIjKnRThI5sKPEASpUvySemjzwqwI13e3qP7oLub+FycCRDysLSAOwt958niZW6LhxfmS6Qm1BzbU70w/Koc4w=="
-		},
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -8441,23 +4297,6 @@
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
 				"private": "^0.1.6"
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
-			}
-		},
-		"regex-not": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -8483,42 +4322,6 @@
 				"jsesc": "~0.5.0"
 			}
 		},
-		"remote-redux-devtools": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
-			"integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
-			"requires": {
-				"jsan": "^3.1.13",
-				"querystring": "^0.2.0",
-				"redux-devtools-core": "^0.2.1",
-				"redux-devtools-instrument": "^1.9.4",
-				"rn-host-detect": "^1.1.5",
-				"socketcluster-client": "^14.2.1"
-			}
-		},
-		"remotedev-serialize": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz",
-			"integrity": "sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==",
-			"requires": {
-				"jsan": "^3.1.13"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-		},
-		"repeat-element": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
-		},
-		"repeat-string": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -8526,11 +4329,6 @@
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
-		},
-		"replace-ext": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -8574,89 +4372,12 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
-		"reselect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
-		},
-		"reselect-tree": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/reselect-tree/-/reselect-tree-1.2.0.tgz",
-			"integrity": "sha512-jdM46p0LKFmSpdW9mUrgY8WIbK9icIWPdWrP1WcFMklroq2hHaIHrJLbytlF+jlVFpV5lAbxoAuUkQ9XbUys8A==",
-			"requires": {
-				"debug": "^3.1.0",
-				"esdoc": "^1.0.4",
-				"json-pointer": "^0.6.0",
-				"reselect": "^3.0.1",
-				"source-map-support": "^0.5.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				}
-			}
-		},
 		"resolve": {
 			"version": "1.7.1",
 			"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"requires": {
 				"path-parse": "^1.0.5"
-			}
-		},
-		"resolve-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"requires": {
-				"resolve-from": "^3.0.0"
-			}
-		},
-		"resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
-			}
-		},
-		"resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-		},
-		"resolve-url": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"requires": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
-		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
 			}
 		},
 		"resumer": {
@@ -8666,11 +4387,6 @@
 			"requires": {
 				"through": "~2.3.4"
 			}
-		},
-		"ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "2.6.2",
@@ -8697,41 +4413,15 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"rn-host-detect": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
-			"integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg=="
-		},
-		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
-		},
 		"rustbn.js": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
 			"integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
 		},
-		"rxjs": {
-			"version": "5.5.12",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-			"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-			"requires": {
-				"symbol-observable": "1.0.1"
-			}
-		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"safe-eval": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.3.0.tgz",
-			"integrity": "sha1-Bs4RHuvZwYWrr/AI7A/P/Fxb4Aw="
 		},
 		"safe-event-emitter": {
 			"version": "1.0.1",
@@ -8741,42 +4431,10 @@
 				"events": "^3.0.0"
 			}
 		},
-		"safe-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"requires": {
-				"ret": "~0.1.10"
-			}
-		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"optional": true
-		},
-		"sc-channel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
-			"integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
-			"requires": {
-				"component-emitter": "1.2.1"
-			}
-		},
-		"sc-errors": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.1.tgz",
-			"integrity": "sha512-dBn92iIonpChTxYLgKkIT/PCApvmYT6EPIbRvbQKTgY6tbEbIy8XVUv4pGyKwEK4nCmvX4TKXcN0iXC6tNW6rQ=="
-		},
-		"sc-formatter": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
-			"integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A=="
 		},
 		"scheduler": {
 			"version": "0.11.3",
@@ -8788,11 +4446,6 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"scoped-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
-		},
 		"scrypt": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
@@ -8803,12 +4456,12 @@
 		},
 		"scrypt-js": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
 			"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
 		},
 		"scrypt.js": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
 			"integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
 			"requires": {
 				"scrypt": "^6.0.2",
@@ -8848,7 +4501,7 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+					"resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 					"requires": {
 						"graceful-readlink": ">= 1.0.0"
@@ -8934,27 +4587,6 @@
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
-		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
-			}
-		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -8987,29 +4619,6 @@
 					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
 					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
 				}
-			}
-		},
-		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"requires": {
-				"shebang-regex": "^1.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"shelljs": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-			"requires": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
 			}
 		},
 		"signal-exit": {
@@ -9060,162 +4669,11 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
-		"slice-ansi": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-		},
-		"slide": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-		},
-		"snapdragon": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
-			}
-		},
-		"snapdragon-node": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "^1.0.0"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
-		"snapdragon-util": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"requires": {
-				"kind-of": "^3.2.0"
-			}
-		},
-		"socketcluster-client": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.2.1.tgz",
-			"integrity": "sha512-peCBfewW1silqvLecFpLz5u2xr85r8b7A24mXaNTsXLnG9QR3zxecYtKS/odszzJSu2j2YyQPR4avy77tZSjZw==",
-			"requires": {
-				"base-64": "0.1.0",
-				"clone": "2.1.1",
-				"component-emitter": "1.2.1",
-				"linked-list": "0.1.0",
-				"querystring": "0.2.0",
-				"sc-channel": "^1.2.0",
-				"sc-errors": "^1.4.1",
-				"sc-formatter": "^3.0.1",
-				"uuid": "3.2.1",
-				"ws": "5.1.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-				},
-				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-				},
-				"ws": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
-					"integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
-				}
-			}
-		},
 		"solc": {
 			"version": "0.4.25",
 			"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.25.tgz",
 			"integrity": "sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==",
+			"dev": true,
 			"requires": {
 				"fs-extra": "^0.30.0",
 				"memorystream": "^0.3.1",
@@ -9224,65 +4682,10 @@
 				"yargs": "^4.7.1"
 			}
 		},
-		"solidity-sha3": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
-			"integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
-			"requires": {
-				"babel-cli": "*",
-				"babel-preset-es2015": "*",
-				"babel-register": "*",
-				"left-pad": "^1.1.1",
-				"web3": "^0.16.0"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-					"from": "git+https://github.com/debris/bignumber.js.git#master"
-				},
-				"web3": {
-					"version": "0.16.0",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-							"from": "git+https://github.com/debris/bignumber.js.git#master"
-						}
-					}
-				}
-			}
-		},
-		"sort-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"requires": {
-				"is-plain-obj": "^1.0.0"
-			}
-		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"source-map-resolve": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
-			}
 		},
 		"source-map-support": {
 			"version": "0.4.18",
@@ -9291,16 +4694,6 @@
 			"requires": {
 				"source-map": "^0.5.6"
 			}
-		},
-		"source-map-url": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-		},
-		"spawn-args": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.1.0.tgz",
-			"integrity": "sha1-PgIyoFcbOHkH+LP1RKpTHGIkhIw="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -9330,14 +4723,6 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
 			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
 		},
-		"split-string": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"requires": {
-				"extend-shallow": "^3.0.0"
-			}
-		},
 		"sshpk": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
@@ -9354,25 +4739,6 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
-		"static-extend": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				}
-			}
-		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -9382,11 +4748,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-		},
-		"string-template": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -9432,15 +4793,6 @@
 				"is-utf8": "^0.2.0"
 			}
 		},
-		"strip-bom-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
-			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-			"requires": {
-				"first-chunk-stream": "^2.0.0",
-				"strip-bom": "^2.0.0"
-			}
-		},
 		"strip-dirs": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -9449,11 +4801,6 @@
 				"is-natural-number": "^4.0.1"
 			}
 		},
-		"strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-		},
 		"strip-hex-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
@@ -9461,12 +4808,6 @@
 			"requires": {
 				"is-hex-prefixed": "1.0.0"
 			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"optional": true
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -9507,27 +4848,6 @@
 				}
 			}
 		},
-		"symbol-observable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-		},
-		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"optional": true
-		},
-		"taffydb": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-			"integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ="
-		},
-		"tapable": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
-		},
 		"tape": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
@@ -9557,7 +4877,7 @@
 		},
 		"tar": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
 				"block-stream": "*",
@@ -9617,24 +4937,8 @@
 			"dependencies": {
 				"bluebird": {
 					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+					"resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
 					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-				}
-			}
-		},
-		"temp": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.2.8",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
 				}
 			}
 		},
@@ -9643,16 +4947,6 @@
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
 			"dev": true
-		},
-		"text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-		},
-		"textextensions": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
-			"integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
 		},
 		"thenify": {
 			"version": "3.3.0",
@@ -9713,14 +5007,6 @@
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
-		},
 		"to-buffer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
@@ -9730,44 +5016,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-		},
-		"to-object-path": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"requires": {
-				"kind-of": "^3.0.2"
-			}
-		},
-		"to-regex": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
-			}
-		},
-		"to-regex-range": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
-			}
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -9785,12 +5033,6 @@
 				}
 			}
 		},
-		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-			"optional": true
-		},
 		"treeify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -9807,846 +5049,33 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"truffle": {
-			"version": "4.1.14",
-			"resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
-			"integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.15.tgz",
+			"integrity": "sha512-6gaNn9ZjvNjdalJMF/qEDUDoRdieKfdYcyFVpVxd+ogAta5kgJxI3XlEmS79Ih0vBhb00tKa9rBweVJ5892sYg==",
 			"dev": true,
 			"requires": {
 				"mocha": "^4.1.0",
 				"original-require": "1.0.1",
-				"solc": "0.4.24"
-			},
-			"dependencies": {
-				"solc": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-					"integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
-					"dev": true,
-					"requires": {
-						"fs-extra": "^0.30.0",
-						"memorystream": "^0.3.1",
-						"require-from-string": "^1.1.0",
-						"semver": "^5.3.0",
-						"yargs": "^4.7.1"
-					}
-				}
-			}
-		},
-		"truffle-artifactor": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/truffle-artifactor/-/truffle-artifactor-3.0.8.tgz",
-			"integrity": "sha512-FlJp5qIyqrBkmuNOxhe/m4Bnj/QPMdkL6idSsY4qQhsKK94CcF1YVyd1odcxjUNo60gCHSKdbGiW4umCdfwD9g==",
-			"requires": {
-				"async": "2.6.1",
-				"debug": "^3.1.0",
-				"fs-extra": "6.0.1",
-				"lodash": "4.17.10",
-				"truffle-contract": "^3.0.7",
-				"truffle-contract-schema": "^2.0.2",
-				"truffle-expect": "^0.0.4"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"crypto-js": {
-					"version": "3.1.9-1",
-					"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-					"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-				},
-				"fs-extra": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-					"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"truffle-contract": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.7.tgz",
-					"integrity": "sha512-av4MTJDP29PI3oVh8TrvRzRHt+nZJH8ODSiil/TfcXrKMSes52DTA5LHj00siLvcadkxUgoEZfEZ04qqhNGoiA==",
-					"requires": {
-						"ethjs-abi": "0.1.8",
-						"truffle-blockchain-utils": "^0.0.5",
-						"truffle-contract-schema": "^2.0.2",
-						"truffle-error": "^0.0.3",
-						"web3": "0.20.6"
-					}
-				},
-				"truffle-contract-schema": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.2.tgz",
-					"integrity": "sha512-8mYAu0Y7wgMqcIa612dxiN9pzr6rq2YxZCzPizvqyDq+/rGWy8s0irl/T7i92a/4ME1V5ddNFf3+86uIlYbPUg==",
-					"requires": {
-						"ajv": "^5.1.1",
-						"crypto-js": "^3.1.9-1",
-						"debug": "^3.1.0"
-					}
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						},
-						"crypto-js": {
-							"version": "3.1.8",
-							"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-							"integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
-						}
-					}
-				}
-			}
-		},
-		"truffle-blockchain-utils": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
-			"integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc="
-		},
-		"truffle-box": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/truffle-box/-/truffle-box-1.0.9.tgz",
-			"integrity": "sha512-2ZEHpWIA3hdQ/dSpJQ9t/6vpL6pUfGt3MijmcI8EimKcd/hHOBX1X8LxwciVMwglTxHF9waaORk0vEu0pZh2MQ==",
-			"requires": {
-				"fs-extra": "6.0.1",
-				"github-download": "^0.5.0",
-				"ora": "^3.0.0",
-				"request": "^2.85.0",
-				"tmp": "0.0.33",
-				"vcsurl": "^0.1.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-					"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				}
-			}
-		},
-		"truffle-code-utils": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/truffle-code-utils/-/truffle-code-utils-1.1.3.tgz",
-			"integrity": "sha512-3m8lSZF1Ek0lW/+1by3+099Jm/EqQ2yvAR9ykWRLStMx6S3hPiw/9SIkLip2IlPbV6gjv+JDLpRSNnjcPuRTDg=="
-		},
-		"truffle-compile": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/truffle-compile/-/truffle-compile-3.0.14.tgz",
-			"integrity": "sha512-eU6DOVsgdz6EhoHCbqqcm0MnVghCERyBgfhJJM/PA7tjvWSbhQLKcYtVZqxOJ2qs40A13svpt2Ks3ufQqOvh5A==",
-			"requires": {
-				"async": "2.6.1",
-				"colors": "^1.1.2",
-				"debug": "^3.1.0",
-				"graphlib": "^2.1.1",
-				"solc": "0.4.25",
-				"truffle-config": "^1.0.7",
-				"truffle-contract-sources": "^0.0.2",
-				"truffle-error": "^0.0.3",
-				"truffle-expect": "^0.0.4"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"truffle-config": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.1.tgz",
-					"integrity": "sha512-ErCQbFvjnWAENPqCjwBu026YAMKzLV2XsEOHV29nPF6wlHFfPEZzFLk0oWBemHs/k8Hmy+srSZw+ba88zYBWCQ==",
-					"requires": {
-						"configstore": "^4.0.0",
-						"find-up": "^2.1.0",
-						"lodash": "4.17.10",
-						"original-require": "1.0.1",
-						"truffle-error": "^0.0.3",
-						"truffle-provider": "^0.1.1"
-					}
-				},
-				"truffle-provider": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.1.tgz",
-					"integrity": "sha512-0cEQBo81VxZLtlx6fZxhLQiUfU5IJn6Pla+HQGlkQV8sTzrLYxKxnTn0ZXBYsFTqgDFjIDBb11nxH4ny1WY6BA==",
-					"requires": {
-						"truffle-error": "^0.0.3",
-						"web3": "^1.0.0-beta.37"
-					}
-				},
-				"web3": {
-					"version": "1.0.0-beta.37",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-					"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.37",
-						"web3-core": "1.0.0-beta.37",
-						"web3-eth": "1.0.0-beta.37",
-						"web3-eth-personal": "1.0.0-beta.37",
-						"web3-net": "1.0.0-beta.37",
-						"web3-shh": "1.0.0-beta.37",
-						"web3-utils": "1.0.0-beta.37"
-					}
-				}
+				"solc": "0.4.25"
 			}
 		},
 		"truffle-config": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
-			"integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.2.tgz",
+			"integrity": "sha512-TfvE5KCTZSXPfEZ8xgs25sOY7uR1xnE52dYPj+arLlaMw1UmMWcIts97HqqK+jVGeKlMPQu2/PwN5m18c+91Fg==",
 			"requires": {
+				"configstore": "^4.0.0",
 				"find-up": "^2.1.0",
 				"lodash": "4.17.10",
 				"original-require": "1.0.1",
 				"truffle-error": "^0.0.3",
-				"truffle-provider": "^0.0.6"
+				"truffle-provider": "^0.1.2"
 			},
 			"dependencies": {
 				"lodash": {
 					"version": "4.17.10",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
 					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				}
-			}
-		},
-		"truffle-contract": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
-			"integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
-			"requires": {
-				"ethjs-abi": "0.1.8",
-				"truffle-blockchain-utils": "^0.0.5",
-				"truffle-contract-schema": "^2.0.1",
-				"truffle-error": "^0.0.3",
-				"web3": "0.20.6"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						}
-					}
-				}
-			}
-		},
-		"truffle-contract-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
-			"integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
-			"requires": {
-				"ajv": "^5.1.1",
-				"crypto-js": "^3.1.9-1",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"crypto-js": {
-					"version": "3.1.9-1",
-					"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-					"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-				}
-			}
-		},
-		"truffle-contract-sources": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/truffle-contract-sources/-/truffle-contract-sources-0.0.2.tgz",
-			"integrity": "sha1-zTdOlbM4gF5NG3Z8FEm26o/lGeQ=",
-			"requires": {
-				"node-dir": "0.1.17"
-			}
-		},
-		"truffle-core": {
-			"version": "4.1.14",
-			"resolved": "https://registry.npmjs.org/truffle-core/-/truffle-core-4.1.14.tgz",
-			"integrity": "sha512-JodjHqoTrstN7+HtHVXQV3mghObGy33KuS8Gl72etWyB8qMDKQhLQTPL0njk5Ur4S9a1AslRsCiOlTy5s7wrFA==",
-			"requires": {
-				"async": "2.6.1",
-				"chai": "4.1.2",
-				"chokidar": "^1.4.2",
-				"colors": "^1.1.2",
-				"cpr": "^0.4.3",
-				"debug": "^3.1.0",
-				"del": "^2.2.0",
-				"diff": "1.4.0",
-				"ethpm": "0.0.16",
-				"ethpm-registry": "0.0.10",
-				"finalhandler": "^0.4.0",
-				"fs-extra": "6.0.1",
-				"ganache-cli": "6.1.0-beta.4",
-				"lodash": "4.17.10",
-				"mkdirp": "^0.5.1",
-				"mocha": "5.2.0",
-				"node-dir": "0.1.17",
-				"node-emoji": "^1.8.1",
-				"node-ipc": "^9.1.1",
-				"original-require": "1.0.1",
-				"safe-eval": "^0.3.0",
-				"serve-static": "^1.10.0",
-				"source-map-support": "^0.5.3",
-				"spawn-args": "^0.1.0",
-				"temp": "^0.8.3",
-				"truffle-artifactor": "^3.0.7",
-				"truffle-box": "^1.0.7",
-				"truffle-compile": "^3.0.13",
-				"truffle-config": "^1.0.6",
-				"truffle-contract": "^3.0.6",
-				"truffle-contract-sources": "^0.0.2",
-				"truffle-debug-utils": "^1.0.6",
-				"truffle-debugger": "^4.0.3",
-				"truffle-deployer": "^2.0.7",
-				"truffle-error": "^0.0.3",
-				"truffle-expect": "^0.0.4",
-				"truffle-init": "^1.0.7",
-				"truffle-migrate": "^2.0.8",
-				"truffle-provider": "^0.0.6",
-				"truffle-provisioner": "^0.1.1",
-				"truffle-require": "^1.0.7",
-				"truffle-resolver": "^4.0.4",
-				"truffle-solidity-utils": "^1.1.2",
-				"truffle-workflow-compile": "^1.0.6",
-				"web3": "0.20.6",
-				"yargs": "^8.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"browser-stdout": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-					"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chai": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-					"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-					"requires": {
-						"assertion-error": "^1.0.1",
-						"check-error": "^1.0.1",
-						"deep-eql": "^3.0.0",
-						"get-func-name": "^2.0.0",
-						"pathval": "^1.0.0",
-						"type-detect": "^4.0.0"
-					}
-				},
-				"commander": {
-					"version": "2.15.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-				},
-				"diff": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
-				},
-				"fs-extra": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-					"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"growl": {
-					"version": "1.10.5",
-					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-					"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"mocha": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-					"requires": {
-						"browser-stdout": "1.3.1",
-						"commander": "2.15.1",
-						"debug": "3.1.0",
-						"diff": "3.5.0",
-						"escape-string-regexp": "1.0.5",
-						"glob": "7.1.2",
-						"growl": "1.10.5",
-						"he": "1.1.1",
-						"minimatch": "3.0.4",
-						"mkdirp": "0.5.1",
-						"supports-color": "5.4.0"
-					},
-					"dependencies": {
-						"diff": {
-							"version": "3.5.0",
-							"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-							"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-						}
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"requires": {
-						"pify": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"source-map-support": {
-					"version": "0.5.10",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						}
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
-			}
-		},
-		"truffle-debug-utils": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/truffle-debug-utils/-/truffle-debug-utils-1.0.8.tgz",
-			"integrity": "sha512-EbmDb9BluFSPV8G9ZoVfPry7xfaVLtnv0Y0yHZq7NlSERLyEuTNSjNdKJMTOeJ6SoZAS8+Tl1Q844YqbTRDrwg==",
-			"requires": {
-				"async": "2.6.1",
-				"debug": "^4.1.0",
-				"node-dir": "0.1.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
-			}
-		},
-		"truffle-debugger": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/truffle-debugger/-/truffle-debugger-4.1.1.tgz",
-			"integrity": "sha512-sUJ59LjygFBFKUYA7f/a8wZ4GwxvXF7ZkBTVPoojGF5NvPIS34blGbSEssbO5DXb4aI2o27dsR3N1BwPPN6ixg==",
-			"requires": {
-				"bn.js": "^4.11.8",
-				"debug": "^4.1.0",
-				"fast-levenshtein": "^2.0.6",
-				"json-pointer": "^0.6.0",
-				"redux": "^3.7.2",
-				"redux-cli-logger": "^2.0.1",
-				"redux-saga": "^0.16.0",
-				"remote-redux-devtools": "^0.5.12",
-				"reselect-tree": "^1.2.0",
-				"truffle-code-utils": "^1.1.3",
-				"truffle-decode-utils": "^1.0.1",
-				"truffle-decoder": "^1.0.1",
-				"truffle-expect": "^0.0.6",
-				"truffle-solidity-utils": "^1.2.1",
-				"web3": "^1.0.0-beta.37",
-				"web3-eth-abi": "^1.0.0-beta.37"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
-				"truffle-expect": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.6.tgz",
-					"integrity": "sha512-dD8jxrGgnN5NEvHZfC1vSBaNUTT9dsw4Ar026uFQmzYDNuBaIrM6rqgyKKSqYdyWracC0WBZhNqrWTIgeUT+Ng=="
-				},
-				"web3": {
-					"version": "1.0.0-beta.37",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-					"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.37",
-						"web3-core": "1.0.0-beta.37",
-						"web3-eth": "1.0.0-beta.37",
-						"web3-eth-personal": "1.0.0-beta.37",
-						"web3-net": "1.0.0-beta.37",
-						"web3-shh": "1.0.0-beta.37",
-						"web3-utils": "1.0.0-beta.37"
-					}
-				}
-			}
-		},
-		"truffle-decode-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/truffle-decode-utils/-/truffle-decode-utils-1.0.1.tgz",
-			"integrity": "sha512-SgAu7C72vy+4J1vG6+OnKSJ7RXjE6ALsJ3JB69HYXciMQKqZJO1SPTaAoyH9vCLXXZAwRtWOUDGguNw3FKEPCQ==",
-			"requires": {
-				"bn.js": "^4.11.8",
-				"lodash.clonedeep": "^4.5.0",
-				"web3": "^1.0.0-beta.37"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-				},
-				"web3": {
-					"version": "1.0.0-beta.37",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-					"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.37",
-						"web3-core": "1.0.0-beta.37",
-						"web3-eth": "1.0.0-beta.37",
-						"web3-eth-personal": "1.0.0-beta.37",
-						"web3-net": "1.0.0-beta.37",
-						"web3-shh": "1.0.0-beta.37",
-						"web3-utils": "1.0.0-beta.37"
-					}
-				}
-			}
-		},
-		"truffle-decoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/truffle-decoder/-/truffle-decoder-1.0.1.tgz",
-			"integrity": "sha512-vFXkL5r2Wq9g5Rf/+dNd9v6lY0HC9Z6YRaTLy1l7iID22caSPsm4etW39kCgk8TRjfqiB4HuYZhwq0ecjKYM5A==",
-			"requires": {
-				"abi-decoder": "^1.2.0",
-				"async-eventemitter": "^0.2.4",
-				"bn.js": "^4.11.8",
-				"debug": "^4.1.0",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.merge": "^4.6.1",
-				"truffle-decode-utils": "^1.0.1",
-				"web3": "^1.0.0-beta.37"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				},
-				"web3": {
-					"version": "1.0.0-beta.37",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-					"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.37",
-						"web3-core": "1.0.0-beta.37",
-						"web3-eth": "1.0.0-beta.37",
-						"web3-eth-personal": "1.0.0-beta.37",
-						"web3-net": "1.0.0-beta.37",
-						"web3-shh": "1.0.0-beta.37",
-						"web3-utils": "1.0.0-beta.37"
-					}
-				}
-			}
-		},
-		"truffle-deployer": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/truffle-deployer/-/truffle-deployer-2.0.8.tgz",
-			"integrity": "sha512-g6pGDt4ld1mY+fA7eZAwKl974LH0nCIskGJUwHgMLA4kPIeXzZCAbDNY8jOgQy1D8JzquO7TMlaa97pK3bVrCw==",
-			"requires": {
-				"truffle-contract": "^3.0.7",
-				"truffle-expect": "^0.0.4"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"crypto-js": {
-					"version": "3.1.9-1",
-					"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-					"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-				},
-				"truffle-contract": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.7.tgz",
-					"integrity": "sha512-av4MTJDP29PI3oVh8TrvRzRHt+nZJH8ODSiil/TfcXrKMSes52DTA5LHj00siLvcadkxUgoEZfEZ04qqhNGoiA==",
-					"requires": {
-						"ethjs-abi": "0.1.8",
-						"truffle-blockchain-utils": "^0.0.5",
-						"truffle-contract-schema": "^2.0.2",
-						"truffle-error": "^0.0.3",
-						"web3": "0.20.6"
-					}
-				},
-				"truffle-contract-schema": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.2.tgz",
-					"integrity": "sha512-8mYAu0Y7wgMqcIa612dxiN9pzr6rq2YxZCzPizvqyDq+/rGWy8s0irl/T7i92a/4ME1V5ddNFf3+86uIlYbPUg==",
-					"requires": {
-						"ajv": "^5.1.1",
-						"crypto-js": "^3.1.9-1",
-						"debug": "^3.1.0"
-					}
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						},
-						"crypto-js": {
-							"version": "3.1.8",
-							"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-							"integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
-						}
-					}
 				}
 			}
 		},
@@ -10655,339 +5084,13 @@
 			"resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
 			"integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
 		},
-		"truffle-expect": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.4.tgz",
-			"integrity": "sha1-1bJ63qTFUvQ7cNwAh3I2t7aMdcg="
-		},
-		"truffle-init": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/truffle-init/-/truffle-init-1.0.7.tgz",
-			"integrity": "sha1-w95X+936d66TZCrgJfQcEVfeK6c=",
-			"requires": {
-				"fs-extra": "^2.0.0",
-				"github-download": "^0.5.0",
-				"npm-programmatic": "0.0.6",
-				"rimraf": "^2.5.4",
-				"temp": "^0.8.3",
-				"truffle-config": "^1.0.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0"
-					}
-				},
-				"npm-programmatic": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/npm-programmatic/-/npm-programmatic-0.0.6.tgz",
-					"integrity": "sha1-PI9NuyEO/WW5nualrHbye01da3g=",
-					"requires": {
-						"bluebird": "^3.4.1"
-					}
-				}
-			}
-		},
-		"truffle-migrate": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/truffle-migrate/-/truffle-migrate-2.0.9.tgz",
-			"integrity": "sha512-XN6ePwztnMUX1o8gQlcfyltU7u5ShvJ4euSAbdIwF44hIaugFi9foZuIbI1RDA8QGt16f3wFe8X9ayIIGKWdYw==",
-			"requires": {
-				"async": "2.6.1",
-				"node-dir": "0.1.17",
-				"truffle-deployer": "^2.0.8",
-				"truffle-expect": "^0.0.4",
-				"truffle-require": "^1.0.8",
-				"web3": "0.20.6"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						}
-					}
-				}
-			}
-		},
 		"truffle-provider": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
-			"integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.2.tgz",
+			"integrity": "sha512-UcHfKydFzZsVyX7uedbNduEU3Po0BlFUI4Sg4jpuLUQUkPZiY8UZkRLAdhBgwjP0W0AEDFtK8VCoffwUxNicQw==",
 			"requires": {
 				"truffle-error": "^0.0.3",
-				"web3": "0.20.6"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						}
-					}
-				}
-			}
-		},
-		"truffle-provisioner": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
-			"integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo="
-		},
-		"truffle-require": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/truffle-require/-/truffle-require-1.0.8.tgz",
-			"integrity": "sha512-popJo9mCzPta+S3+iD4GDbgFYBDP7o2q7oA26o67ljs0rGdI+XV4SrBSiSa9QWreGeFftafZp9YlkJeQIgkzMg==",
-			"requires": {
-				"original-require": "1.0.1",
-				"truffle-config": "^1.0.7",
-				"truffle-expect": "^0.0.4",
-				"web3": "0.20.6"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"truffle-config": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.1.tgz",
-					"integrity": "sha512-ErCQbFvjnWAENPqCjwBu026YAMKzLV2XsEOHV29nPF6wlHFfPEZzFLk0oWBemHs/k8Hmy+srSZw+ba88zYBWCQ==",
-					"requires": {
-						"configstore": "^4.0.0",
-						"find-up": "^2.1.0",
-						"lodash": "4.17.10",
-						"original-require": "1.0.1",
-						"truffle-error": "^0.0.3",
-						"truffle-provider": "^0.1.1"
-					}
-				},
-				"truffle-provider": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.1.tgz",
-					"integrity": "sha512-0cEQBo81VxZLtlx6fZxhLQiUfU5IJn6Pla+HQGlkQV8sTzrLYxKxnTn0ZXBYsFTqgDFjIDBb11nxH4ny1WY6BA==",
-					"requires": {
-						"truffle-error": "^0.0.3",
-						"web3": "^1.0.0-beta.37"
-					},
-					"dependencies": {
-						"web3": {
-							"version": "1.0.0-beta.37",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-							"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-							"requires": {
-								"web3-bzz": "1.0.0-beta.37",
-								"web3-core": "1.0.0-beta.37",
-								"web3-eth": "1.0.0-beta.37",
-								"web3-eth-personal": "1.0.0-beta.37",
-								"web3-net": "1.0.0-beta.37",
-								"web3-shh": "1.0.0-beta.37",
-								"web3-utils": "1.0.0-beta.37"
-							}
-						}
-					}
-				},
-				"web3": {
-					"version": "0.20.6",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-					"requires": {
-						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "^3.1.4",
-						"utf8": "^2.1.1",
-						"xhr2": "*",
-						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						}
-					}
-				}
-			}
-		},
-		"truffle-resolver": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.4.tgz",
-			"integrity": "sha1-39mo28pcWHPXeS0UREc9B3Csl9Q=",
-			"requires": {
-				"async": "2.6.1",
-				"truffle-contract": "^3.0.6",
-				"truffle-expect": "^0.0.4",
-				"truffle-provisioner": "^0.1.1"
-			}
-		},
-		"truffle-solidity-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/truffle-solidity-utils/-/truffle-solidity-utils-1.2.1.tgz",
-			"integrity": "sha512-ROITGiAgWjSLgq/2L+I8eOEaLB5YKyaOPvKdq0yhga9S20tEScbgeWx5CjtNWHjkBLUkxBKJ12xH3WIqg1AV5Q=="
-		},
-		"truffle-workflow-compile": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/truffle-workflow-compile/-/truffle-workflow-compile-1.0.7.tgz",
-			"integrity": "sha512-3RSqHs/XYNH5O2PySUARAfB6uvYwUgvSt/eF6yjPMkdIwQ84Sd3pcM/qg56bR2aeeoBVFrDAHaCQRxtltiItSA==",
-			"requires": {
-				"async": "2.6.1",
-				"lodash": "4.17.10",
-				"mkdirp": "^0.5.1",
-				"truffle-artifactor": "^3.0.8",
-				"truffle-compile": "^3.0.14",
-				"truffle-config": "^1.0.7",
-				"truffle-expect": "^0.0.4",
-				"truffle-resolver": "^4.0.5"
-			},
-			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
-				"crypto-js": {
-					"version": "3.1.9-1",
-					"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-					"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"truffle-config": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.1.tgz",
-					"integrity": "sha512-ErCQbFvjnWAENPqCjwBu026YAMKzLV2XsEOHV29nPF6wlHFfPEZzFLk0oWBemHs/k8Hmy+srSZw+ba88zYBWCQ==",
-					"requires": {
-						"configstore": "^4.0.0",
-						"find-up": "^2.1.0",
-						"lodash": "4.17.10",
-						"original-require": "1.0.1",
-						"truffle-error": "^0.0.3",
-						"truffle-provider": "^0.1.1"
-					}
-				},
-				"truffle-contract": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.7.tgz",
-					"integrity": "sha512-av4MTJDP29PI3oVh8TrvRzRHt+nZJH8ODSiil/TfcXrKMSes52DTA5LHj00siLvcadkxUgoEZfEZ04qqhNGoiA==",
-					"requires": {
-						"ethjs-abi": "0.1.8",
-						"truffle-blockchain-utils": "^0.0.5",
-						"truffle-contract-schema": "^2.0.2",
-						"truffle-error": "^0.0.3",
-						"web3": "0.20.6"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-						},
-						"crypto-js": {
-							"version": "3.1.8",
-							"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-							"integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
-						},
-						"web3": {
-							"version": "0.20.6",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-							"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-							"requires": {
-								"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xhr2": "*",
-								"xmlhttprequest": "*"
-							},
-							"dependencies": {
-								"bignumber.js": {
-									"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-									"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-								}
-							}
-						}
-					}
-				},
-				"truffle-contract-schema": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.2.tgz",
-					"integrity": "sha512-8mYAu0Y7wgMqcIa612dxiN9pzr6rq2YxZCzPizvqyDq+/rGWy8s0irl/T7i92a/4ME1V5ddNFf3+86uIlYbPUg==",
-					"requires": {
-						"ajv": "^5.1.1",
-						"crypto-js": "^3.1.9-1",
-						"debug": "^3.1.0"
-					}
-				},
-				"truffle-provider": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.1.tgz",
-					"integrity": "sha512-0cEQBo81VxZLtlx6fZxhLQiUfU5IJn6Pla+HQGlkQV8sTzrLYxKxnTn0ZXBYsFTqgDFjIDBb11nxH4ny1WY6BA==",
-					"requires": {
-						"truffle-error": "^0.0.3",
-						"web3": "^1.0.0-beta.37"
-					}
-				},
-				"truffle-resolver": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.5.tgz",
-					"integrity": "sha512-aqPxo+bpL9yjfpSptvkV35WmkceBY4HbQGiUT2Rhx9cttNi0dQnPWL89inpQnBEqr1aLP9LxbZ+sai0PHKAD0w==",
-					"requires": {
-						"async": "2.6.1",
-						"truffle-contract": "^3.0.7",
-						"truffle-expect": "^0.0.4",
-						"truffle-provisioner": "^0.1.1"
-					}
-				},
-				"web3": {
-					"version": "1.0.0-beta.37",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
-					"integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.37",
-						"web3-core": "1.0.0-beta.37",
-						"web3-eth": "1.0.0-beta.37",
-						"web3-eth-personal": "1.0.0-beta.37",
-						"web3-net": "1.0.0-beta.37",
-						"web3-shh": "1.0.0-beta.37",
-						"web3-utils": "1.0.0-beta.37"
-					}
-				}
+				"web3": "^1.0.0-beta.37"
 			}
 		},
 		"ts-node": {
@@ -11008,7 +5111,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -11030,16 +5133,6 @@
 				}
 			}
 		},
-		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-		},
-		"tunnel": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.2.tgz",
-			"integrity": "sha1-8jvNi3p7ioZCYbIIT2b5MZM5YzQ="
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -11053,18 +5146,11 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
-				"prelude-ls": "~1.1.2"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.16",
@@ -11115,7 +5201,7 @@
 				},
 				"buffer": {
 					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+					"resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
 					"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
 					"requires": {
 						"base64-js": "0.0.8",
@@ -11130,38 +5216,6 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
 			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 		},
-		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
-			}
-		},
 		"unique-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -11170,61 +5224,10 @@
 				"crypto-random-string": "^1.0.0"
 			}
 		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"unset-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"has-value": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
-					},
-					"dependencies": {
-						"isobject": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"requires": {
-								"isarray": "1.0.0"
-							}
-						}
-					}
-				},
-				"has-values": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
-			}
-		},
-		"untildify": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -11233,11 +5236,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"urix": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url-parse-lax": {
 			"version": "1.0.0",
@@ -11256,16 +5254,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-		},
-		"use": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
-		},
-		"user-home": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
 		},
 		"utf8": {
 			"version": "2.1.1",
@@ -11287,19 +5275,6 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
-		"v8-compile-cache": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
-		},
-		"v8flags": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-			"requires": {
-				"user-home": "^1.1.1"
-			}
-		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -11314,11 +5289,6 @@
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
-		"vcsurl": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/vcsurl/-/vcsurl-0.1.1.tgz",
-			"integrity": "sha1-XgChCec4G1W11FuJJTPI7DXJMgw="
-		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -11327,44 +5297,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			}
-		},
-		"vinyl": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-			"requires": {
-				"clone": "^1.0.0",
-				"clone-stats": "^0.0.1",
-				"replace-ext": "0.0.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-				}
-			}
-		},
-		"vinyl-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
-			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.3.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0",
-				"strip-bom-stream": "^2.0.0",
-				"vinyl": "^1.1.0"
-			}
-		},
-		"wcwidth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"requires": {
-				"defaults": "^1.0.3"
 			}
 		},
 		"web3": {
@@ -11514,7 +5446,7 @@
 				},
 				"uuid": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
 				}
 			}
@@ -11686,250 +5618,6 @@
 				"utf8": "2.1.1"
 			}
 		},
-		"webidl-conversions": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
-			"integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
-			"optional": true
-		},
-		"webpack-addons": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
-			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
-			"requires": {
-				"jscodeshift": "^0.4.0"
-			},
-			"dependencies": {
-				"ast-types": {
-					"version": "0.10.1",
-					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
-				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"jscodeshift": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
-					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
-					"requires": {
-						"async": "^1.5.0",
-						"babel-plugin-transform-flow-strip-types": "^6.8.0",
-						"babel-preset-es2015": "^6.9.0",
-						"babel-preset-stage-1": "^6.5.0",
-						"babel-register": "^6.9.0",
-						"babylon": "^6.17.3",
-						"colors": "^1.1.2",
-						"flow-parser": "^0.*",
-						"lodash": "^4.13.1",
-						"micromatch": "^2.3.7",
-						"node-dir": "0.1.8",
-						"nomnom": "^1.8.1",
-						"recast": "^0.12.5",
-						"temp": "^0.8.1",
-						"write-file-atomic": "^1.2.0"
-					}
-				},
-				"node-dir": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-					"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
-				},
-				"recast": {
-					"version": "0.12.9",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-					"requires": {
-						"ast-types": "0.10.1",
-						"core-js": "^2.4.1",
-						"esprima": "~4.0.0",
-						"private": "~0.1.5",
-						"source-map": "~0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"webpack-cli": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
-			"integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
-			"requires": {
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"diff": "^3.5.0",
-				"enhanced-resolve": "^4.0.0",
-				"envinfo": "^5.7.0",
-				"glob-all": "^3.1.0",
-				"global-modules": "^1.0.0",
-				"got": "^8.3.1",
-				"import-local": "^1.0.0",
-				"inquirer": "^5.2.0",
-				"interpret": "^1.1.0",
-				"jscodeshift": "^0.5.0",
-				"listr": "^0.14.1",
-				"loader-utils": "^1.1.0",
-				"lodash": "^4.17.10",
-				"log-symbols": "^2.2.0",
-				"mkdirp": "^0.5.1",
-				"p-each-series": "^1.0.0",
-				"p-lazy": "^1.0.0",
-				"prettier": "^1.12.1",
-				"supports-color": "^5.4.0",
-				"v8-compile-cache": "^2.0.0",
-				"webpack-addons": "^1.1.5",
-				"yargs": "^11.1.0",
-				"yeoman-environment": "^2.1.1",
-				"yeoman-generator": "^2.0.5"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"got": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-					"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-					"requires": {
-						"@sindresorhus/is": "^0.7.0",
-						"cacheable-request": "^2.1.1",
-						"decompress-response": "^3.3.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"into-stream": "^3.1.0",
-						"is-retry-allowed": "^1.1.0",
-						"isurl": "^1.0.0-alpha5",
-						"lowercase-keys": "^1.0.0",
-						"mimic-response": "^1.0.0",
-						"p-cancelable": "^0.4.0",
-						"p-timeout": "^2.0.1",
-						"pify": "^3.0.0",
-						"safe-buffer": "^5.1.1",
-						"timed-out": "^4.0.1",
-						"url-parse-lax": "^3.0.0",
-						"url-to-options": "^1.0.1"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"p-cancelable": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-					"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
-				},
-				"p-timeout": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-					"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-					"requires": {
-						"p-finally": "^1.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"prepend-http": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"url-parse-lax": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-					"requires": {
-						"prepend-http": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
-			}
-		},
 		"websocket": {
 			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
 			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
@@ -11950,68 +5638,20 @@
 				}
 			}
 		},
-		"wget-improved": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-1.5.0.tgz",
-			"integrity": "sha512-t+G+g9SQSy2h2+dg7h54r9adllfdI0fHHtshbl1V4jwIIBj1c10SmHwjP8vFx9fn1dr9QuF27uC7xoZr9YwEmg==",
-			"requires": {
-				"minimist": "1.2.0",
-				"tunnel": "0.0.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
-		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-		},
-		"whatwg-url-compat": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
-			"integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
-			"optional": true,
-			"requires": {
-				"tr46": "~0.0.1"
-			}
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"requires": {
-				"isexe": "^2.0.0"
-			}
 		},
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
 			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"optional": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
 		"window-size": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
 			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"optional": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
@@ -12026,16 +5666,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"write-file-atomic": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"slide": "^1.1.5"
-			}
 		},
 		"ws": {
 			"version": "5.2.2",
@@ -12083,11 +5713,6 @@
 				"xhr-request": "^1.0.1"
 			}
 		},
-		"xhr2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-			"integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
-		},
 		"xhr2-cookies": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
@@ -12095,12 +5720,6 @@
 			"requires": {
 				"cookiejar": "^2.1.1"
 			}
-		},
-		"xml-name-validator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-			"optional": true
 		},
 		"xmlhttprequest": {
 			"version": "1.8.0",
@@ -12121,11 +5740,6 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
 			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-		},
-		"yallist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 		},
 		"yargs": {
 			"version": "4.8.1",
@@ -12164,230 +5778,6 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yeoman-environment": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
-			"integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
-			"requires": {
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"debug": "^3.1.0",
-				"diff": "^3.5.0",
-				"escape-string-regexp": "^1.0.2",
-				"globby": "^8.0.1",
-				"grouped-queue": "^0.3.3",
-				"inquirer": "^6.0.0",
-				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.10",
-				"log-symbols": "^2.2.0",
-				"mem-fs": "^1.1.0",
-				"strip-ansi": "^4.0.0",
-				"text-table": "^0.2.0",
-				"untildify": "^3.0.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"chardet": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-				},
-				"external-editor": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-					"requires": {
-						"chardet": "^0.7.0",
-						"iconv-lite": "^0.4.24",
-						"tmp": "^0.0.33"
-					}
-				},
-				"globby": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "2.0.0",
-						"fast-glob": "^2.0.2",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"inquirer": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-					"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.0",
-						"figures": "^2.0.0",
-						"lodash": "^4.17.10",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.1.0",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^5.0.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-							"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-						},
-						"strip-ansi": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-							"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-							"requires": {
-								"ansi-regex": "^4.0.0"
-							}
-						}
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"rxjs": {
-					"version": "6.3.3",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-					"requires": {
-						"tslib": "^1.9.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"yeoman-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
-			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
-			"requires": {
-				"async": "^2.6.0",
-				"chalk": "^2.3.0",
-				"cli-table": "^0.3.1",
-				"cross-spawn": "^6.0.5",
-				"dargs": "^5.1.0",
-				"dateformat": "^3.0.3",
-				"debug": "^3.1.0",
-				"detect-conflict": "^1.0.0",
-				"error": "^7.0.2",
-				"find-up": "^2.1.0",
-				"github-username": "^4.0.0",
-				"istextorbinary": "^2.2.1",
-				"lodash": "^4.17.10",
-				"make-dir": "^1.1.0",
-				"mem-fs-editor": "^4.0.0",
-				"minimist": "^1.2.0",
-				"pretty-bytes": "^4.0.2",
-				"read-chunk": "^2.1.0",
-				"read-pkg-up": "^3.0.0",
-				"rimraf": "^2.6.2",
-				"run-async": "^2.0.0",
-				"shelljs": "^0.8.0",
-				"text-table": "^0.2.0",
-				"through2": "^2.0.0",
-				"yeoman-environment": "^2.0.5"
-			},
-			"dependencies": {
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				}
 			}
 		},
 		"yn": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,9 +70,7 @@
     "lodash.uniqwith": "^4.5.0",
     "npm-programmatic": "0.0.10",
     "semver": "^5.5.0",
-    "truffle-config": "1.0.6",
-    "truffle-core": "4.1.14",
-    "truffle-provider": "0.0.6",
+    "truffle-config": "1.1.2",
     "web3": "^1.0.0-beta.37",
     "web3-provider-engine": "14.0.6",
     "zos-lib": "^2.1.0"
@@ -96,7 +94,7 @@
     "react-dom": "^16.3.2",
     "sinon": "^6.1.4",
     "sinon-chai": "^3.2.0",
-    "truffle": "^4.1.13",
+    "truffle": "^4.1.15",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2"
   }

--- a/packages/cli/src/models/initializer/ConfigVariablesInitializer.ts
+++ b/packages/cli/src/models/initializer/ConfigVariablesInitializer.ts
@@ -22,7 +22,7 @@ const ConfigVariablesInitializer = {
     Contracts.setSyncTimeout(timeout * 1000);
     Contracts.setArtifactsDefaults(artifactDefaults);
 
-    const txParams = from ? { from } : { from: await ZWeb3.defaultAccount() };
+    const txParams = { from: from || artifactDefaults.from || await ZWeb3.defaultAccount() };
     return { network: await ZWeb3.getNetworkName(), txParams };
   }
 };

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -32,11 +32,9 @@ const Truffle = {
 
   getProviderAndDefaults(): any {
     const config = this.getConfig();
-    const TruffleResolver = require('truffle-resolver');
-    config.resolver = new TruffleResolver(config);
-    const { provider, resolver } = this._setNonceTrackerIfNeeded(config);
+    const provider = this._setNonceTrackerIfNeeded(config);
 
-    const artifactDefaults = pickBy(pick(resolver.options, 'from', 'gas', 'gasPrice'));
+    const artifactDefaults = pickBy(pick(config, 'from', 'gas', 'gasPrice'));
     if (artifactDefaults.from) artifactDefaults.from = artifactDefaults.from.toLowerCase();
     return { provider, artifactDefaults };
   },
@@ -60,7 +58,7 @@ const Truffle = {
   // the network provider as a function (that returns an HDWalletProvider instance) instead of
   // assigning the HDWalletProvider instance directly.
   // (see https://github.com/trufflesuite/truffle-hdwallet-provider/issues/65)
-  _setNonceTrackerIfNeeded({ resolver, provider }: any): any {
+  _setNonceTrackerIfNeeded({ provider }: any): any {
     const { engine } = provider;
     if (engine && engine.constructor.name === 'Web3ProviderEngine') {
       const NonceSubprovider = require('web3-provider-engine/subproviders/nonce-tracker');
@@ -71,9 +69,8 @@ const Truffle = {
           engine._providers.splice(index, 0, nonceTracker);
         }
       });
-      resolver.options = Object.assign({}, resolver.options, { provider });
     }
-    return { resolver, provider };
+    return provider;
   },
 };
 

--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -27,8 +27,9 @@ export default class Contracts {
   }
 
   public static async getDefaultTxParams(): Promise<any> {
-    const defaultFrom = Contracts.defaultFromAddress ? Contracts.defaultFromAddress : await ZWeb3.defaultAccount();
-    return { ...Contracts.getArtifactsDefaults(), from: defaultFrom };
+    const defaults = { ... Contracts.getArtifactsDefaults() };
+    if (!defaults.from) defaults.from = await Contracts.getDefaultFromAddress();
+    return defaults;
   }
 
   public static getArtifactsDefaults(): any {
@@ -57,6 +58,13 @@ export default class Contracts {
 
   public static getFromNodeModules(dependency: string, contractName: string): ContractFactory {
     return Contracts._getFromPath(Contracts.getNodeModulesPath(dependency, contractName));
+  }
+
+  public static async getDefaultFromAddress() {
+    if (!Contracts.defaultFromAddress) {
+      Contracts.defaultFromAddress = await ZWeb3.defaultAccount();
+    }
+    return Contracts.defaultFromAddress;
   }
 
   public static listBuildArtifacts(): string[] {


### PR DESCRIPTION
This PR removes truffle resolver from CLI (which was being unused) which removes most of the truffle packages as a dependency, and upgrades truffle config to the latest version. It also picks up the `from` setting from truffle-config, which was being ignored and overridden by the default account.