### PR TITLE
Fix issue with gas estimation on geth

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -5018,6 +5018,11 @@
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -59,6 +59,7 @@
     "lodash.isstring": "^4.0.1",
     "lodash.keys": "^4.2.0",
     "lodash.map": "^4.6.0",
+    "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "lodash.reverse": "^4.0.1",
     "lodash.some": "^4.6.0",

--- a/packages/lib/src/utils/Transactions.ts
+++ b/packages/lib/src/utils/Transactions.ts
@@ -10,6 +10,7 @@ import sleep from '../helpers/sleep';
 import ZWeb3 from '../artifacts/ZWeb3';
 import Contracts from '../artifacts/Contracts';
 import ContractFactory, { ContractWrapper, TransactionReceiptWrapper } from '../artifacts/ContractFactory';
+import omit from 'lodash.omit';
 import { TransactionReceipt } from 'web3/types';
 
 // Cache, exported for testing
@@ -150,8 +151,11 @@ export async function estimateGas(txParams: any, retries: number = RETRY_COUNT):
   // we are working with, if the txs are routed to different nodes.
   // See https://github.com/zeppelinos/zos/issues/192 for more info.
   try {
+    // Remove gas from estimateGas call, which may cause Geth to fail
+    // See https://github.com/ethereum/go-ethereum/issues/18973 for more info
+    const txParamsWithoutGas = omit(txParams, 'gas');
     // Use json-rpc method estimateGas to retrieve estimated value
-    return await ZWeb3.estimateGas(txParams);
+    return await ZWeb3.estimateGas(txParamsWithoutGas);
   } catch (error) {
     if (retries <= 0) throw Error(error);
     await sleep(RETRY_SLEEP_TIME);


### PR DESCRIPTION
Calls to estimateGas on geth fail if a gas parameter is provided which is lower than the required gas to execute the tx (but higher than the minimum of 21k). See https://github.com/ethereum/go-ethereum/issues/18973 for more info. Removing the gas parameter fixes this issue, and works on geth, parity, and ganache. Note that using a very low or very high gas value also works on geth and parity, but not on ganache.