### PR TITLE
fix: change pragma to be truffle-flattener compatible

### DIFF
--- a/packages/lib/contracts/Initializable.sol
+++ b/packages/lib/contracts/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.24 <0.6.0;
+pragma solidity ^0.4.24;
 
 
 /**


### PR DESCRIPTION
While extending Initializable pragma version to support solc 0.5 on [commit](https://github.com/zeppelinos/zos/pull/577/commits/912bf2dabb571716c40bb86e429153bda6ef3ad8) breaks truffle-flattener compatibility due to **'Only pinned or ^ versions are supported'** error.