### PR TITLE
Set up a shared pre-commit hook that runs a linter when committing changes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+lerna run lint

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": [
+    "./",
     "examples/*",
     "packages/*",
     "tests/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "private": true,
+  "scripts": {
+    "prepare": "git config core.hooksPath .githooks"
+  },
   "devDependencies": {
     "lerna": "~3.3.2",
     "tslint": "^5.11.0",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1933,7 +1933,7 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
-				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
 				"ethereumjs-util": "^5.1.1"
 			}
 		},
@@ -2077,7 +2077,7 @@
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
 		},
 		"ethereumjs-abi": {
-			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
 			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
 			"requires": {
 				"bn.js": "^4.10.0",

--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -17,7 +17,7 @@ const Compiler = {
         } else {
           if (stdout) console.log(stdout);
           if (stderr) console.error(stderr);
-          resolve({ stdout, stderr });  
+          resolve({ stdout, stderr });
         }
       });
     });

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -51,7 +51,7 @@ export interface DependencyInterface {
   customDeploy?: boolean;
 }
 
-type addressWrapper = { address?: string };
+interface AddressWrapper { address?: string; }
 
 export default class ZosNetworkFile {
 
@@ -63,10 +63,10 @@ export default class ZosNetworkFile {
     solidityLibs: { [libAlias: string]: SolidityLibInterface };
     proxies: { [contractName: string]: ProxyInterface[] };
     zosversion: string;
-    proxyAdmin: addressWrapper;
-    app: addressWrapper;
-    package: addressWrapper;
-    provider: addressWrapper;
+    proxyAdmin: AddressWrapper;
+    app: AddressWrapper;
+    package: AddressWrapper;
+    provider: AddressWrapper;
     version: string;
     frozen: boolean;
     dependencies: { [dependencyName: string]: DependencyInterface };
@@ -84,7 +84,7 @@ export default class ZosNetworkFile {
     checkVersion(this.data.zosversion, this.fileName);
   }
 
-  get proxyAdmin(): addressWrapper {
+  get proxyAdmin(): AddressWrapper {
     return this.data.proxyAdmin || {};
   }
 
@@ -92,7 +92,7 @@ export default class ZosNetworkFile {
     return this.proxyAdmin.address;
   }
 
-  get app(): addressWrapper {
+  get app(): AddressWrapper {
     return this.data.app || {};
   }
 
@@ -100,7 +100,7 @@ export default class ZosNetworkFile {
     return this.app.address;
   }
 
-  get package(): addressWrapper {
+  get package(): AddressWrapper {
     return this.data.package || {};
   }
 
@@ -108,7 +108,7 @@ export default class ZosNetworkFile {
     return this.package.address;
   }
 
-  get provider(): addressWrapper {
+  get provider(): AddressWrapper {
     return this.data.provider || {};
   }
 
@@ -310,20 +310,20 @@ export default class ZosNetworkFile {
     this.data.frozen = frozen;
   }
 
-  set proxyAdmin(admin: addressWrapper) {
+  set proxyAdmin(admin: AddressWrapper) {
     this.data.proxyAdmin = admin;
 
   }
 
-  set app(app: addressWrapper) {
+  set app(app: AddressWrapper) {
     this.data.app = app;
   }
 
-  set provider(provider: addressWrapper) {
+  set provider(provider: AddressWrapper) {
     this.data.provider = provider;
   }
 
-  set package(_package: addressWrapper) {
+  set package(_package: AddressWrapper) {
     this.data.package = _package;
   }
 

--- a/packages/lib/src/project/BaseSimpleProject.ts
+++ b/packages/lib/src/project/BaseSimpleProject.ts
@@ -6,7 +6,7 @@ import Package from '../application/Package';
 import { deploy } from '../utils/Transactions';
 import { toAddress } from '../utils/Addresses';
 import { bytecodeDigest } from '../utils/Bytecode';
-import { toSemanticVersion }from '../utils/Semver';
+import { toSemanticVersion } from '../utils/Semver';
 import { buildCallData, callDescription, CalldataInfo } from '../utils/ABIs';
 import { ContractInterface } from './AppProject';
 import ContractFactory, { ContractWrapper } from '../artifacts/ContractFactory';

--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -27,7 +27,7 @@ export default class ProxyAdminProject extends BaseSimpleProject {
 
   public async upgradeProxy(proxyAddress: string, contractClass: ContractFactory, contractParams: ContractInterface = {}): Promise<ContractWrapper> {
     const { initMethod: initMethodName, initArgs } = contractParams;
-    const { implementationAddress, pAddress, initCallData } = await this._setUpgradeParams(proxyAddress, contractClass, contractParams)
+    const { implementationAddress, pAddress, initCallData } = await this._setUpgradeParams(proxyAddress, contractClass, contractParams);
     await this.proxyAdmin.upgradeProxy(pAddress, implementationAddress, contractClass, initMethodName, initArgs);
     log.info(`Instance at ${pAddress} upgraded`);
     return contractClass.at(pAddress);

--- a/packages/lib/src/validations/Layout.ts
+++ b/packages/lib/src/validations/Layout.ts
@@ -52,14 +52,14 @@ function levenshtein(originalStorage: StorageInfo[], updatedStorage: StorageInfo
   const matrix: any[] = Array(a.length + 1);
 
   type CostFunction = (i: number, j: number) => number;
-  const insertionCost : CostFunction = (_i,j) => (j > a.length ? 0 : INSERTION_COST);
-  const diagonalCost : CostFunction = (i,j) => (areEqualFn(a[i-1], b[j-1]) ? 0 : SUBSTITUTION_COST);
-  const deletionCost : CostFunction = (_i,_j) => DELETION_COST;
+  const insertionCost: CostFunction = (_i,j) => (j > a.length ? 0 : INSERTION_COST);
+  const diagonalCost: CostFunction = (i,j) => (areEqualFn(a[i-1], b[j-1]) ? 0 : SUBSTITUTION_COST);
+  const deletionCost: CostFunction = (_i,_j) => DELETION_COST;
 
   // increment along the first column of each row
   for (let i = 0; i <= a.length; i++) {
     matrix[i] = Array(b.length + 1);
-    matrix[i][0] = i * deletionCost(i, 0); 
+    matrix[i][0] = i * deletionCost(i, 0);
   }
 
   // increment each column in the first row
@@ -71,7 +71,7 @@ function levenshtein(originalStorage: StorageInfo[], updatedStorage: StorageInfo
   for (let i = 1; i <= a.length; i++) {
     for (let j = 1; j <= b.length; j++) {
       matrix[i][j] = Math.min(matrix[i-1][j-1] + diagonalCost(i,j),
-                              matrix[i][j-1] + insertionCost(i,j), 
+                              matrix[i][j-1] + insertionCost(i,j),
                               matrix[i-1][j] + deletionCost(i,j));
     }
   }


### PR DESCRIPTION
Fix #590 

This PR adds a global prepare script in `./package.json` that configures the location of git hooks in this repo to the path `./.githooks` instead of the default `.git/hooks`. That way, git hooks can be shared with all collaborators.

Then, a pre-commit hook is added, which simply runs `lerna run lint`. This command will run tslint on the cli and lib packages and, as a result, will abort commits which have linter failures.

The advantages of using a git pre-commit hook for this are:
- It doesn't slow down local testing, which would be that case if we added the linting routing to each package's `npm test` scripts.
- It avoids having to find out that your CI tests failed because of linting issues.
- Linting is performed locally, and only when you wish to commit changes to the repo.