### PR TITLE
Adds ability to receive false booleans via the cli

### DIFF
--- a/packages/cli/contracts/mocks/Boolean.sol
+++ b/packages/cli/contracts/mocks/Boolean.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.24;
+
+contract Boolean {
+  bool public value;
+
+  function initialize(bool _value) public {
+    value = _value;
+  }
+}

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1933,8 +1933,17 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
-				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
 				"ethereumjs-util": "^5.1.1"
+			},
+			"dependencies": {
+				"ethereumjs-abi": {
+					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+					"requires": {
+						"bn.js": "^4.10.0",
+						"ethereumjs-util": "^5.0.0"
+					}
+				}
 			}
 		},
 		"eth-tx-summary": {
@@ -2075,14 +2084,6 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-		},
-		"ethereumjs-abi": {
-			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-			"requires": {
-				"bn.js": "^4.10.0",
-				"ethereumjs-util": "^5.0.0"
-			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -5166,14 +5167,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"requires": {
-				"is-typedarray": "^1.0.0"
-			}
-		},
 		"typescript": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
@@ -5589,8 +5582,27 @@
 			"integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.37",
-				"websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+				"web3-core-helpers": "1.0.0-beta.37"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"websocket": {
+					"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+					"from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+					"requires": {
+						"debug": "^2.2.0",
+						"nan": "^2.3.3",
+						"typedarray-to-buffer": "^3.1.2",
+						"yaeti": "^0.0.6"
+					}
+				}
 			}
 		},
 		"web3-shh": {
@@ -5616,26 +5628,6 @@
 				"randomhex": "0.1.5",
 				"underscore": "1.8.3",
 				"utf8": "2.1.1"
-			}
-		},
-		"websocket": {
-			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-			"requires": {
-				"debug": "^2.2.0",
-				"nan": "^2.3.3",
-				"typedarray-to-buffer": "^3.1.2",
-				"yaeti": "^0.0.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"whatwg-fetch": {
@@ -5735,11 +5727,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-		},
-		"yaeti": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
 		},
 		"yargs": {
 			"version": "4.8.1",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1933,17 +1933,8 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
+				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
 				"ethereumjs-util": "^5.1.1"
-			},
-			"dependencies": {
-				"ethereumjs-abi": {
-					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-					"requires": {
-						"bn.js": "^4.10.0",
-						"ethereumjs-util": "^5.0.0"
-					}
-				}
 			}
 		},
 		"eth-tx-summary": {
@@ -2084,6 +2075,14 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+		},
+		"ethereumjs-abi": {
+			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+			"requires": {
+				"bn.js": "^4.10.0",
+				"ethereumjs-util": "^5.0.0"
+			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",
@@ -5167,6 +5166,14 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
 		"typescript": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
@@ -5582,25 +5589,8 @@
 			"integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.37"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"websocket": {
-					"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-					"from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-					"requires": {
-						"debug": "^2.2.0",
-						"nan": "^2.3.3"
-					}
-				}
+				"web3-core-helpers": "1.0.0-beta.37",
+				"websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
 			}
 		},
 		"web3-shh": {
@@ -5626,6 +5616,26 @@
 				"randomhex": "0.1.5",
 				"underscore": "1.8.3",
 				"utf8": "2.1.1"
+			}
+		},
+		"websocket": {
+			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+			"requires": {
+				"debug": "^2.2.0",
+				"nan": "^2.3.3",
+				"typedarray-to-buffer": "^3.1.2",
+				"yaeti": "^0.0.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
 			}
 		},
 		"whatwg-fetch": {
@@ -5725,6 +5735,11 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yaeti": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
 		},
 		"yargs": {
 			"version": "4.8.1",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -5598,9 +5598,7 @@
 					"from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
 					"requires": {
 						"debug": "^2.2.0",
-						"nan": "^2.3.3",
-						"typedarray-to-buffer": "^3.1.2",
-						"yaeti": "^0.0.6"
+						"nan": "^2.3.3"
 					}
 				}
 			}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,7 @@
     "npm-programmatic": "0.0.10",
     "semver": "^5.5.0",
     "truffle-config": "1.1.2",
-    "web3": "^1.0.0-beta.37",
+    "web3": "1.0.0-beta.37",
     "web3-provider-engine": "14.0.6",
     "zos-lib": "^2.1.0"
   },

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -10,7 +10,17 @@ export function parseArgs(args: string): string[] | never {
     const MATCH_WORDS = /(^|([,[]\s*))(\w+)/g;
     args = args.replace(MATCH_WORDS, '$2"$3"'); // replace non quoted number by quoted number
 
-    return JSON.parse('[' + args + ']');
+    // Parse string to array.
+    let parsedArgs = JSON.parse('[' + args + ']');
+
+    // Replace boolean strings with boolean literals.
+    parsedArgs = parsedArgs.map((value) => {
+      if(value === 'false') return false;
+      else if(value === 'true') return true;
+      return value;
+    });
+
+    return parsedArgs;
   } catch (e) {
     throw Error(`Error parsing arguments: ${e}`);
   }

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -11,16 +11,16 @@ export function parseArgs(args: string): string[] | never {
     args = args.replace(MATCH_WORDS, '$2"$3"'); // replace non quoted number by quoted number
 
     // Parse string to array.
-    let parsedArgs = JSON.parse('[' + args + ']');
+    const parsedArgs = JSON.parse('[' + args + ']');
 
     // Replace boolean strings with boolean literals.
-    parsedArgs = parsedArgs.map((value) => {
-      if(value === 'false') return false;
-      else if(value === 'true') return true;
+    return parsedArgs.map((value) => {
+      if(typeof value === 'string') {
+        if(value.toLowerCase() === 'false') return false;
+        else if(value.toLowerCase() === 'true') return true;
+      }
       return value;
     });
-
-    return parsedArgs;
   } catch (e) {
     throw Error(`Error parsing arguments: ${e}`);
   }

--- a/packages/cli/test/commands/create.test.js
+++ b/packages/cli/test/commands/create.test.js
@@ -11,6 +11,10 @@ contract('create command', function() {
     create.should.have.been.calledWithExactly( { contractAlias: 'Impl', initMethod: 'setup', initArgs: ['42'], force: true, network: 'test', txParams: { from: '0x40'} })
   })
 
+  itShouldParse('should call create script with options', 'create', 'zos create Boolean --network test --init initialize --args false --force --from 0x40', function(create) {
+    create.should.have.been.calledWithExactly( { contractAlias: 'Boolean', initMethod: 'initialize', initArgs: [false], force: true, network: 'test', txParams: { from: '0x40'} })
+  })
+
   itShouldParse('should call create script with default init method', 'create', 'zos create Impl --network test --init --args 42 --force --from 0x40', function(create) {
     create.should.have.been.calledWithExactly( { contractAlias: 'Impl', initMethod: 'initialize', initArgs: ['42'], force: true, network: 'test', txParams: { from: '0x40'} })
   })

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -11,6 +11,8 @@ describe('input', function () {
 
     it('should parse a false boolean', testFn("false", false));
     it('should parse a true boolean', testFn("true", true));
+    it('should parse a FALSE boolean', testFn("FALSE", false));
+    it('should parse a TRUE boolean', testFn("TRUE", true));
     it('should parse a number', testFn("42", "42"));
     it('should parse a string', testFn("foo", 'foo'));
     it('should parse a number+string', testFn("42pepe", "42pepe"));

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -9,6 +9,8 @@ describe('input', function () {
       () => parseArgs(input).should.deep.eq(expected)
     );
 
+    it('should parse a false boolean', testFn("false", false));
+    it('should parse a true boolean', testFn("true", true));
     it('should parse a number', testFn("42", "42"));
     it('should parse a string', testFn("foo", 'foo'));
     it('should parse a number+string', testFn("42pepe", "42pepe"));

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -7963,6 +7963,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -7971,7 +7972,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
             }
           }
         }
@@ -8055,6 +8056,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -8063,7 +8065,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
             }
           }
         }
@@ -8175,6 +8177,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
+      }
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "typescript": {
@@ -8919,21 +8929,14 @@
       "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.37"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3"
-          }
         }
       }
     },
@@ -9198,6 +9201,16 @@
         }
       }
     },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
+      }
+    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -9322,6 +9335,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -7963,7 +7963,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -7972,7 +7971,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
             }
           }
         }
@@ -8056,7 +8055,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -8065,7 +8063,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
             }
           }
         }
@@ -8177,14 +8175,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
-      }
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
       }
     },
     "typescript": {
@@ -8929,14 +8919,23 @@
       "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.37"
       },
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
         }
       }
     },
@@ -9201,16 +9200,6 @@
         }
       }
     },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
-      }
-    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -9335,11 +9324,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -8932,9 +8932,7 @@
           "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
+            "nan": "^2.3.3"
           }
         }
       }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -68,7 +68,7 @@
     "openzeppelin-solidity": "~1.10.0",
     "semver": "^5.5.1",
     "truffle-flattener": "^1.2.8",
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
Fix #558 

This PR solves the issue "Ability to pass false booleans via the cli" by:
1) Modifying input.ts so that incoming string values that are either "false" or "true" are converted into `false` and `true` literals respectively. Notice that this makes booleans the only type of values that do not exit as strings from input.ts. The file input.test.js is also modified to test for this change.
2) Adds a test to the create command, ensuring that a "false" argument does indeed get parsed into `false` instead of `true`.
3) Adds tests to the create script, with a new Booleans.sol contract, ensuring that calling the script with boolean literals produces the expected results.

This does not modify encodeCall in any way to maintain compatibility with Web3's encoder. If "false" is passed to encodeCall, it will still interpret it as `true`.

Despite my belief that this should solve the issue at hand, please note that we could go a little further, and introduce a new type of test in the suite that tests end-to-end parameter parsing, from the cli, to the values obtained back from a contract. The implemented solution touches a few isolated components that, _in theory_, should produce the expected result, but we don't have a way to test all the components together at once.