### PR TITLE
Rename ZosContract to Contract

### DIFF
--- a/packages/cli/src/interface/ValidationLogger.ts
+++ b/packages/cli/src/interface/ValidationLogger.ts
@@ -7,7 +7,7 @@ import {
   BuildArtifacts,
   StorageLayoutInfo,
   Operation,
-  ZosContract
+  Contract
 } from 'zos-lib';
 import { ContractInterface } from '../models/files/ZosNetworkFile';
 
@@ -20,10 +20,10 @@ const log = new Logger('Validations');
 
 export default class ValidationLogger {
 
-  public contract: ZosContract;
+  public contract: Contract;
   public existingContractInfo: ContractInterface;
 
-  constructor(contract: ZosContract, existingContractInfo?: ContractInterface) {
+  constructor(contract: Contract, existingContractInfo?: ContractInterface) {
     this.contract = contract;
     this.existingContractInfo = existingContractInfo || {};
   }

--- a/packages/cli/src/models/dependency/Dependency.ts
+++ b/packages/cli/src/models/dependency/Dependency.ts
@@ -2,7 +2,7 @@ import fromPairs from 'lodash.frompairs';
 import map from 'lodash.map';
 import flatten from 'lodash.flatten';
 import uniq from 'lodash.uniq';
-import { FileSystem as fs, PackageProject, Contracts, ZosContract, getSolidityLibNames, Logger } from 'zos-lib';
+import { FileSystem as fs, PackageProject, Contracts, Contract, getSolidityLibNames, Logger } from 'zos-lib';
 import semver from 'semver';
 import npm from 'npm-programmatic';
 
@@ -55,7 +55,7 @@ export default class Dependency {
     // this should all be handled at the Project level. Consider adding a setImplementations (plural) method
     // to Projects, which handle library deployment and linking for a set of contracts altogether.
 
-    const contracts = <Array<[ZosContract, string]>>map(this.getPackageFile().contracts, (contractName, contractAlias) =>
+    const contracts = <Array<[Contract, string]>>map(this.getPackageFile().contracts, (contractName, contractAlias) =>
       [Contracts.getFromNodeModules(this.name, contractName), contractAlias]
     );
 

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -7,7 +7,7 @@ import map from 'lodash.map';
 import filter from 'lodash.filter';
 import find from 'lodash.find';
 
-import { Logger, FileSystem as fs, bytecodeDigest, bodyCode, constructorCode, semanticVersionToString, ZosContract } from 'zos-lib';
+import { Logger, FileSystem as fs, bytecodeDigest, bodyCode, constructorCode, semanticVersionToString, Contract } from 'zos-lib';
 import { fromContractFullName, toContractFullName } from '../../utils/naming';
 import { ZOS_VERSION, checkVersion } from './ZosVersion';
 import ZosPackageFile from './ZosPackageFile.js';
@@ -144,7 +144,7 @@ export default class ZosNetworkFile {
     return this.data.solidityLibs || {};
   }
 
-  public addSolidityLib(libName: string, instance: ZosContract): void {
+  public addSolidityLib(libName: string, instance: Contract): void {
     this.data.solidityLibs[libName] = {
       address: instance.address,
       constructorCode: constructorCode(instance),
@@ -357,7 +357,7 @@ export default class ZosNetworkFile {
     this.setDependency(name, fn(this.getDependency(name)));
   }
 
-  public addContract(alias: string, instance: ZosContract, { warnings, types, storage }: { warnings?: any, types?: any, storage?: any } = {}): void {
+  public addContract(alias: string, instance: Contract, { warnings, types, storage }: { warnings?: any, types?: any, storage?: any } = {}): void {
     this.setContract(alias, {
       address: instance.address,
       constructorCode: constructorCode(instance),

--- a/packages/cli/src/models/local/LocalController.ts
+++ b/packages/cli/src/models/local/LocalController.ts
@@ -2,7 +2,7 @@
 
 import every from 'lodash.every';
 import map from 'lodash.map';
-import { Contracts, ZosContract, Logger, FileSystem as fs, getBuildArtifacts, BuildArtifacts, validate as validateContract, validationPasses} from 'zos-lib';
+import { Contracts, Contract, Logger, FileSystem as fs, getBuildArtifacts, BuildArtifacts, validate as validateContract, validationPasses} from 'zos-lib';
 
 import Session from '../network/Session';
 import Dependency from '../dependency/Dependency';
@@ -108,7 +108,7 @@ export default class LocalController {
   }
 
   // Contract model
-  public getContractClass(packageName: string, contractAlias: string): ZosContract {
+  public getContractClass(packageName: string, contractAlias: string): Contract {
     if (!packageName || packageName === this.packageFile.name) {
       const contractName = this.packageFile.contract(contractAlias);
       return Contracts.getFromLocal(contractName);

--- a/packages/cli/src/models/status/EventsFilter.ts
+++ b/packages/cli/src/models/status/EventsFilter.ts
@@ -1,4 +1,4 @@
-import { Logger, ZosContract } from 'zos-lib';
+import { Logger, Contract } from 'zos-lib';
 
 const log = new Logger('EventsFilter');
 const TIMEOUT_ERROR = 'Event filter promise timed out';
@@ -11,7 +11,7 @@ export default class EventsFilter {
     this.timeout = timeout || (process.env.NODE_ENV === 'test' ? 2000 : 60000);
   }
 
-  public async call(contract: ZosContract, eventName: string = 'allEvents'): Promise<any> {
+  public async call(contract: Contract, eventName: string = 'allEvents'): Promise<any> {
     log.info(`Looking for all the '${eventName}' events for contract ${contract.address}`);
     const promise = new Promise((resolve, reject) => {
       contract.getPastEvents(eventName, {fromBlock: 0, toBlock: 'latest'}, (error, events) => {

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -2,9 +2,9 @@ import stdout from '../utils/stdout';
 import ControllerFor from '../models/network/ControllerFor';
 import ScriptError from '../models/errors/ScriptError';
 import { CreateParams } from './interfaces';
-import { ZosContract } from 'zos-lib';
+import { Contract } from 'zos-lib';
 
-export default async function createProxy({ packageName, contractAlias, initMethod, initArgs, network, txParams = {}, force = false, networkFile }: CreateParams): Promise<ZosContract | never> {
+export default async function createProxy({ packageName, contractAlias, initMethod, initArgs, network, txParams = {}, force = false, networkFile }: CreateParams): Promise<Contract | never> {
   if (!contractAlias) throw Error('A contract alias must be provided to create a new proxy.');
 
   const controller = ControllerFor(network, txParams, networkFile);

--- a/packages/lib/src/application/ImplementationDirectory.ts
+++ b/packages/lib/src/application/ImplementationDirectory.ts
@@ -1,14 +1,14 @@
 import Logger from '../utils/Logger';
 import Transactions from '../utils/Transactions';
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
 const log = new Logger('ImplementationDirectory');
 
 // TS-TODO: review which members could be private
 export default class ImplementationDirectory {
 
-  public directoryContract: ZosContract;
+  public directoryContract: Contract;
   public txParams: any;
 
   public static async deploy(txParams: any = {}): Promise<ImplementationDirectory> {
@@ -26,16 +26,16 @@ export default class ImplementationDirectory {
     return new this(directory, txParams);
   }
 
-  public static getContract(): ZosContract {
+  public static getContract(): Contract {
     return Contracts.getFromLib('ImplementationDirectory');
   }
 
-  constructor(directory: ZosContract, txParams: any = {}) {
+  constructor(directory: Contract, txParams: any = {}) {
     this.directoryContract = directory;
     this.txParams = txParams;
   }
 
-  get contract(): ZosContract {
+  get contract(): Contract {
     return this.directoryContract;
   }
 

--- a/packages/lib/src/application/Package.ts
+++ b/packages/lib/src/application/Package.ts
@@ -3,13 +3,13 @@ import Contracts from '../artifacts/Contracts';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import { toSemanticVersion, SemanticVersion } from '../utils/Semver';
 import { toAddress, isZeroAddress } from '../utils/Addresses';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import Transactions from '../utils/Transactions';
 
 const log: Logger = new Logger('Package');
 
 export default class Package {
-  private packageContract: ZosContract;
+  private packageContract: Contract;
   private txParams: any;
 
   public static fetch(address: string, txParams: any = {}): Package | null {
@@ -21,18 +21,18 @@ export default class Package {
 
   public static async deploy(txParams: any = {}): Promise<Package> {
     log.info('Deploying new Package...');
-    const PackageContract: ZosContract = Contracts.getFromLib('Package');
+    const PackageContract: Contract = Contracts.getFromLib('Package');
     const packageContract = await Transactions.deployContract(PackageContract, [], txParams);
     log.info(`Deployed Package ${packageContract.address}`);
     return new this(packageContract, txParams);
   }
 
-  constructor(packageContract: ZosContract, txParams: any = {}) {
+  constructor(packageContract: Contract, txParams: any = {}) {
     this.packageContract = packageContract;
     this.txParams = txParams;
   }
 
-  get contract(): ZosContract {
+  get contract(): Contract {
     return this.packageContract;
   }
 

--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -1,6 +1,6 @@
 import glob from 'glob';
 import path from 'path';
-import ZosContract, { createZosContract } from './ZosContract';
+import Contract, { createZosContract } from './Contract';
 import ZWeb3 from './ZWeb3';
 import { getSolidityLibNames, hasUnlinkedVariables } from '../utils/Bytecode';
 
@@ -49,15 +49,15 @@ export default class Contracts {
     return `${process.cwd()}/node_modules/${dependency}/build/contracts/${contractName}.json`;
   }
 
-  public static getFromLocal(contractName: string): ZosContract {
+  public static getFromLocal(contractName: string): Contract {
     return Contracts._getFromPath(Contracts.getLocalPath(contractName));
   }
 
-  public static getFromLib(contractName: string): ZosContract {
+  public static getFromLib(contractName: string): Contract {
     return Contracts._getFromPath(Contracts.getLibPath(contractName));
   }
 
-  public static getFromNodeModules(dependency: string, contractName: string): ZosContract {
+  public static getFromNodeModules(dependency: string, contractName: string): Contract {
     return Contracts._getFromPath(Contracts.getNodeModulesPath(dependency, contractName));
   }
 
@@ -88,7 +88,7 @@ export default class Contracts {
     Contracts.artifactDefaults = { ...Contracts.getArtifactsDefaults(), ...defaults };
   }
 
-  private static _getFromPath(targetPath: string): ZosContract {
+  private static _getFromPath(targetPath: string): Contract {
     const schema = require(targetPath);
     if(schema.bytecode === '') throw new Error(`A bytecode must be provided for contract ${schema.contractName}.`);
     if(!hasUnlinkedVariables(schema.bytecode)) {

--- a/packages/lib/src/helpers/copyContract.ts
+++ b/packages/lib/src/helpers/copyContract.ts
@@ -2,7 +2,7 @@ import { promisify } from 'util';
 
 import ZWeb3 from '../artifacts/ZWeb3';
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import Transactions from '../utils/Transactions';
 
 async function sendTransaction(params: any): Promise<any> {
@@ -10,7 +10,7 @@ async function sendTransaction(params: any): Promise<any> {
   return ZWeb3.sendTransactionWithoutReceipt(params);
 }
 
-export default async function copyContract(contract: ZosContract, address: string, txParams: any = {}): Promise<ZosContract> {
+export default async function copyContract(contract: Contract, address: string, txParams: any = {}): Promise<Contract> {
   const trimmedAddress: string = address.replace('0x', '');
 
   // This is EVM assembly will return of the code of a foreign address.

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -11,7 +11,7 @@ import Semver from './utils/Semver';
 import Logger from './utils/Logger';
 import FileSystem from './utils/FileSystem';
 import Contracts from './artifacts/Contracts';
-import ZosContract from './artifacts/ZosContract';
+import Contract from './artifacts/Contract';
 import ZWeb3 from './artifacts/ZWeb3';
 import { bodyCode, constructorCode, bytecodeDigest, replaceSolidityLibAddress, isSolidityLib, getSolidityLibNames } from './utils/Bytecode';
 import Transactions from './utils/Transactions';
@@ -87,7 +87,7 @@ export {
   PackageProject,
   AppProject,
   SimpleProject,
-  ZosContract,
+  Contract,
   ProxyAdminProject,
   ValidationInfo,
   AppProxyMigrator

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -8,7 +8,7 @@ import ProxyAdmin from '../proxy/ProxyAdmin';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import BasePackageProject from './BasePackageProject';
 import SimpleProject from './SimpleProject';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import ProxyAdminProject from './ProxyAdminProject';
 import { DeployError } from '../utils/errors/DeployError';
 import { semanticVersionToString } from '../utils/Semver';
@@ -147,13 +147,13 @@ export default class AppProject extends BasePackageProject {
   }
 
   // TODO: Testme
-  public async createContract(contract: ZosContract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<ZosContract> {
+  public async createContract(contract: Contract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<Contract> {
     if (!contractName) contractName = contract.schema.contractName;
     if (!packageName) packageName = this.name;
     return this.app.createContract(contract, packageName, contractName, initMethod, initArgs);
   }
 
-  public async createProxy(contract: ZosContract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<ZosContract> {
+  public async createProxy(contract: Contract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<Contract> {
     if (!this.proxyAdmin) this.proxyAdmin = await ProxyAdmin.deploy(this.txParams);
     if (!contractName) contractName = contract.schema.contractName;
     if (!packageName) packageName = this.name;
@@ -161,7 +161,7 @@ export default class AppProject extends BasePackageProject {
     return this.app.createProxy(contract, packageName, contractName, this.proxyAdmin.address, initMethod, initArgs);
   }
 
-  public async upgradeProxy(proxyAddress: string, contract: ZosContract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<ZosContract> {
+  public async upgradeProxy(proxyAddress: string, contract: Contract, { packageName, contractName, initMethod, initArgs }: ContractInterface = {}): Promise<Contract> {
     if (!contractName) contractName = contract.schema.contractName;
     if (!packageName) packageName = this.name;
     const implementationAddress = await this.getImplementation({ packageName, contractName });

--- a/packages/lib/src/project/BasePackageProject.ts
+++ b/packages/lib/src/project/BasePackageProject.ts
@@ -1,7 +1,7 @@
 import Transactions from '../utils/Transactions';
 import Logger from '../utils/Logger';
 import { semanticVersionToString } from '../utils/Semver';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import Package from '../application/Package';
 
@@ -35,7 +35,7 @@ export default abstract class BasePackageProject {
     log.info(`Version ${version} has been frozen`);
   }
 
-  public async setImplementation(contract: ZosContract, contractName: string): Promise<ZosContract> {
+  public async setImplementation(contract: Contract, contractName: string): Promise<Contract> {
     if (!contractName) contractName = contract.schema.contractName;
     log.info(`Setting implementation of ${contractName} in directory...`);
     const implementation: any = await Transactions.deployContract(contract, [], this.txParams);

--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -3,7 +3,7 @@ import Logger from '../utils/Logger';
 import ProxyAdmin from '../proxy/ProxyAdmin';
 import BaseSimpleProject from './BaseSimpleProject';
 import { ContractInterface } from './AppProject';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
 const log: Logger = new Logger('ProxyAdminProject');
 
@@ -20,12 +20,12 @@ export default class ProxyAdminProject extends BaseSimpleProject {
     this.proxyAdmin = proxyAdmin;
   }
 
-  public async createProxy(contract: ZosContract, contractParams: ContractInterface = {}): Promise<ZosContract> {
+  public async createProxy(contract: Contract, contractParams: ContractInterface = {}): Promise<Contract> {
     if(!this.proxyAdmin) this.proxyAdmin = await ProxyAdmin.deploy(this.txParams);
     return super.createProxy(contract, contractParams);
   }
 
-  public async upgradeProxy(proxyAddress: string, contract: ZosContract, contractParams: ContractInterface = {}): Promise<ZosContract> {
+  public async upgradeProxy(proxyAddress: string, contract: Contract, contractParams: ContractInterface = {}): Promise<Contract> {
     const { initMethod: initMethodName, initArgs } = contractParams;
     const { implementationAddress, pAddress, initCallData } = await this._setUpgradeParams(proxyAddress, contract, contractParams);
     await this.proxyAdmin.upgradeProxy(pAddress, implementationAddress, contract, initMethodName, initArgs);

--- a/packages/lib/src/project/SimpleProject.ts
+++ b/packages/lib/src/project/SimpleProject.ts
@@ -1,10 +1,9 @@
 import Proxy from '../proxy/Proxy';
 import Logger from '../utils/Logger';
 import ZWeb3 from '../artifacts/ZWeb3';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import { ContractInterface } from './AppProject';
 import BaseSimpleProject from './BaseSimpleProject';
-import Contract from 'web3-eth-contract';
 
 const log: Logger = new Logger('SimpleProject');
 
@@ -13,7 +12,7 @@ export default class SimpleProject  extends BaseSimpleProject {
     super(name, txParams);
   }
 
-  public async upgradeProxy(proxyAddress: string, contract: ZosContract, contractParams: ContractInterface = {}): Promise<Contract> {
+  public async upgradeProxy(proxyAddress: string, contract: Contract, contractParams: ContractInterface = {}): Promise<Contract> {
     const { implementationAddress, pAddress, initCallData } = await this._setUpgradeParams(proxyAddress, contract, contractParams);
     const proxy = Proxy.at(pAddress, this.txParams);
     await proxy.upgradeTo(implementationAddress, initCallData);

--- a/packages/lib/src/proxy/Proxy.ts
+++ b/packages/lib/src/proxy/Proxy.ts
@@ -2,14 +2,14 @@ import ZWeb3 from '../artifacts/ZWeb3';
 import Contracts from '../artifacts/Contracts';
 import { toAddress, uint256ToAddress } from '../utils/Addresses';
 import Transactions from '../utils/Transactions';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
 export default class Proxy {
-  private contract: ZosContract;
+  private contract: Contract;
   private txParams: any;
   public address: string;
 
-  public static at(contractOrAddress: string | ZosContract, txParams: any = {}): Proxy {
+  public static at(contractOrAddress: string | Contract, txParams: any = {}): Proxy {
     const ProxyContract = Contracts.getFromLib('AdminUpgradeabilityProxy');
     const contract = ProxyContract.at(toAddress(contractOrAddress));
     return new this(contract, txParams);
@@ -22,7 +22,7 @@ export default class Proxy {
     return new this(contract, txParams);
   }
 
-  constructor(contract: ZosContract, txParams: any = {}) {
+  constructor(contract: Contract, txParams: any = {}) {
     this.address = toAddress(contract);
     this.contract = contract;
     this.txParams = txParams;

--- a/packages/lib/src/proxy/ProxyAdmin.ts
+++ b/packages/lib/src/proxy/ProxyAdmin.ts
@@ -4,12 +4,12 @@ import Contracts from '../artifacts/Contracts';
 import { toAddress } from '../utils/Addresses';
 import { buildCallData, callDescription, CalldataInfo } from '../utils/ABIs';
 import Transactions from '../utils/Transactions';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
 const log: Logger = new Logger('ProxyAdmin');
 
 export default class ProxyAdmin {
-  public contract: ZosContract;
+  public contract: Contract;
   public address: string;
   public txParams: any;
 
@@ -41,7 +41,7 @@ export default class ProxyAdmin {
     log.info(`Admin for proxy ${proxyAddress} set to ${newAdmin}`);
   }
 
-  public async upgradeProxy(proxyAddress: string, implementationAddress: string, contract: ZosContract, initMethodName: string, initArgs: any): Promise<ZosContract> {
+  public async upgradeProxy(proxyAddress: string, implementationAddress: string, contract: Contract, initMethodName: string, initArgs: any): Promise<Contract> {
     const receipt: any = typeof(initArgs) === 'undefined'
       ? await this._upgradeProxy(proxyAddress, implementationAddress)
       : await this._upgradeProxyAndCall(proxyAddress, implementationAddress, contract, initMethodName, initArgs);

--- a/packages/lib/src/utils/Bytecode.ts
+++ b/packages/lib/src/utils/Bytecode.ts
@@ -1,12 +1,12 @@
 import crypto from 'crypto';
 import { ZERO_ADDRESS } from './Addresses';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
-export function bodyCode(contract: ZosContract): string {
+export function bodyCode(contract: Contract): string {
   return splitCode(contract).body;
 }
 
-export function constructorCode(contract: ZosContract): string {
+export function constructorCode(contract: Contract): string {
   return splitCode(contract).constructor;
 }
 
@@ -47,7 +47,7 @@ export function isSolidityLib(bytecode: string): boolean {
   return matches == null ? false : matches.length > 0;
 }
 
-function splitCode(contract: ZosContract): {constructor: string, body: string} {
+function splitCode(contract: Contract): {constructor: string, body: string} {
   const binary = contract.schema.linkedBytecode.replace(/^0x/, '');
   const bytecode = contract.schema.bytecode.replace(/^0x/, '');
   const deployedBytecode = contract.schema.deployedBytecode.replace(/^0x/, '');

--- a/packages/lib/src/utils/ContractAST.ts
+++ b/packages/lib/src/utils/ContractAST.ts
@@ -4,7 +4,7 @@ import includes from 'lodash.includes';
 import isEqual from 'lodash.isequal';
 
 import { getBuildArtifacts, BuildArtifacts } from '../artifacts/BuildArtifacts';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
 // TS-TODO: Many of the interfaces defined here come from Solidity's AST output schema.
 // cli has Solidity schema definitions in @types/solc.d.ts. If such file was moved to the lib
@@ -47,13 +47,13 @@ interface ContractASTProps {
 export default class ContractAST {
 
   private artifacts: BuildArtifacts;
-  private contract: ZosContract;
+  private contract: Contract;
   private imports: Set<any>;
   private nodes: NodeMapping;
   private types: TypeInfoMapping;
   private nodesFilter: string[];
 
-  constructor(contract: ZosContract, artifacts?: BuildArtifacts, props?: ContractASTProps) {
+  constructor(contract: Contract, artifacts?: BuildArtifacts, props?: ContractASTProps) {
 
     this.artifacts = artifacts || getBuildArtifacts();
     this.contract = contract;

--- a/packages/lib/src/utils/Transactions.ts
+++ b/packages/lib/src/utils/Transactions.ts
@@ -10,7 +10,7 @@ import BN from 'bignumber.js';
 import sleep from '../helpers/sleep';
 import ZWeb3 from '../artifacts/ZWeb3';
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 import { TransactionReceipt } from 'web3/types';
 import { buildDeploymentCallData } from './ABIs';
 
@@ -85,7 +85,7 @@ export default {
    * @param txParams other transaction parameters (from, gasPrice, etc)
    * @param retries number of deploy retries
    */
-  async deployContract(contract: ZosContract, args: any[] = [], txParams: any = {}, retries: number = RETRY_COUNT): Promise<any> {
+  async deployContract(contract: Contract, args: any[] = [], txParams: any = {}, retries: number = RETRY_COUNT): Promise<any> {
     await this._fixGasPrice(txParams);
 
     try {
@@ -102,7 +102,7 @@ export default {
    * @param txParams all transaction parameters (data, from, gasPrice, etc)
    * @param retries number of data transaction retries
    */
-  async sendDataTransaction(contract: ZosContract, txParams: any, retries: number = RETRY_COUNT): Promise<TransactionReceipt> {
+  async sendDataTransaction(contract: Contract, txParams: any, retries: number = RETRY_COUNT): Promise<TransactionReceipt> {
     await this._fixGasPrice(txParams);
 
     try {
@@ -190,7 +190,7 @@ export default {
    * @param contract contract instance to send the tx to
    * @param txParams all transaction parameters (data, from, gasPrice, etc)
    */
-  async _sendDataTransaction(contract: ZosContract, txParams: any = {}): Promise<TransactionReceipt> {
+  async _sendDataTransaction(contract: Contract, txParams: any = {}): Promise<TransactionReceipt> {
     // If gas is set explicitly, use it
     const defaultGas = Contracts.getArtifactsDefaults().gas;
     if (!txParams.gas && defaultGas) txParams.gas = defaultGas;
@@ -201,7 +201,7 @@ export default {
     return this._sendContractDataTransaction(contract, { gas, ...txParams });
   },
 
-  async _sendContractDataTransaction(contract: ZosContract, txParams: any): Promise<TransactionReceipt> {
+  async _sendContractDataTransaction(contract: Contract, txParams: any): Promise<TransactionReceipt> {
     const defaults = await Contracts.getDefaultTxParams();
     const tx = { to: contract.address, ...defaults, ...txParams };
     const txHash = await ZWeb3.sendTransactionWithoutReceipt(tx);
@@ -215,7 +215,7 @@ export default {
    * @param args arguments of the constructor (if any)
    * @param txParams other transaction parameters (from, gasPrice, etc)
    */
-  async _deployContract(contract: ZosContract, args: any[] = [], txParams: any = {}): Promise<ZosContract> {
+  async _deployContract(contract: Contract, args: any[] = [], txParams: any = {}): Promise<Contract> {
     // If gas is set explicitly, use it
     const defaultGas = Contracts.getArtifactsDefaults().gas;
     if (!txParams.gas && defaultGas) txParams.gas = defaultGas;

--- a/packages/lib/src/validations/InitialValues.ts
+++ b/packages/lib/src/validations/InitialValues.ts
@@ -1,18 +1,18 @@
 import isEmpty from 'lodash.isempty';
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract.js';
+import Contract from '../artifacts/Contract.js';
 import { Node } from '../utils/ContractAST';
 
-export function hasInitialValuesInDeclarations(contract: ZosContract): boolean {
+export function hasInitialValuesInDeclarations(contract: Contract): boolean {
   return detectInitialValues(contract);
 }
 
-function detectInitialValues(contract: ZosContract): boolean {
+function detectInitialValues(contract: Contract): boolean {
   const nodes = contract.schema.ast.nodes.filter((n) => n.name === contract.schema.contractName);
   for (const node of nodes) {
     if (hasInitialValues(node)) return true;
     for (const baseContract of node.baseContracts || []) {
-      const parentContract: ZosContract = Contracts.getFromLocal(baseContract.baseName.name);
+      const parentContract: Contract = Contracts.getFromLocal(baseContract.baseName.name);
       return detectInitialValues(parentContract);
     }
   }

--- a/packages/lib/src/validations/Initializers.ts
+++ b/packages/lib/src/validations/Initializers.ts
@@ -1,6 +1,6 @@
 import invertBy from 'lodash.invertby';
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract.js';
+import Contract from '../artifacts/Contract.js';
 import { Node } from '../utils/ContractAST';
 
 /**
@@ -8,13 +8,13 @@ import { Node } from '../utils/ContractAST';
  * to an array of base contracts that are uninitialized.
  * @param {*} contract contract class to check (including all its ancestors)
  */
-export function getUninitializedBaseContracts(contract: ZosContract): string[] {
+export function getUninitializedBaseContracts(contract: Contract): string[] {
   const uninitializedBaseContracts = {};
   getUninitializedDirectBaseContracts(contract, uninitializedBaseContracts);
   return invertBy(uninitializedBaseContracts);
 }
 
-function getUninitializedDirectBaseContracts(contract: ZosContract, uninitializedBaseContracts: any): void {
+function getUninitializedDirectBaseContracts(contract: Contract, uninitializedBaseContracts: any): void {
   // Check whether the contract has base contracts
   const baseContracts: any = contract.schema.ast.nodes.find((n) => n.name === contract.schema.contractName).baseContracts;
   if (baseContracts.length === 0) return;
@@ -22,7 +22,7 @@ function getUninitializedDirectBaseContracts(contract: ZosContract, uninitialize
   // Run check for the base contracts
   for (const baseContract of baseContracts) {
     const baseContractName: string = baseContract.baseName.name;
-    const baseContractClass: ZosContract = Contracts.getFromLocal(baseContractName);
+    const baseContractClass: Contract = Contracts.getFromLocal(baseContractName);
     getUninitializedDirectBaseContracts(baseContractClass, uninitializedBaseContracts);
   }
 
@@ -31,7 +31,7 @@ function getUninitializedDirectBaseContracts(contract: ZosContract, uninitialize
   const baseContractInitializers: any = {};
   for (const baseContract of baseContracts) {
     const baseContractName: string = baseContract.baseName.name;
-    const baseContractClass: ZosContract = Contracts.getFromLocal(baseContractName);
+    const baseContractClass: Contract = Contracts.getFromLocal(baseContractName);
     // TS-TODO: define type?
     const baseContractInitializer = getContractInitializer(baseContractClass);
     if (baseContractInitializer !== undefined) {
@@ -76,7 +76,7 @@ function getUninitializedDirectBaseContracts(contract: ZosContract, uninitialize
   return;
 }
 
-function getContractInitializer(contract: ZosContract): Node | undefined {
+function getContractInitializer(contract: Contract): Node | undefined {
   const contractDefinition: Node = contract.schema.ast.nodes
     .find((n: Node) => n.nodeType === 'ContractDefinition' && n.name === contract.schema.contractName);
   const contractFunctions: Node[] = contractDefinition.nodes.filter((n) => n.nodeType === 'FunctionDefinition');

--- a/packages/lib/src/validations/Instructions.ts
+++ b/packages/lib/src/validations/Instructions.ts
@@ -1,15 +1,15 @@
 import Contracts from '../artifacts/Contracts';
-import ZosContract from '../artifacts/ZosContract';
+import Contract from '../artifacts/Contract';
 
-export function hasSelfDestruct(contract: ZosContract): boolean {
+export function hasSelfDestruct(contract: Contract): boolean {
   return hasTypeIdentifier(contract, 't_function_selfdestruct_nonpayable$_t_address_$returns$__$');
 }
 
-export function hasDelegateCall(contract: ZosContract): boolean {
+export function hasDelegateCall(contract: Contract): boolean {
   return hasTypeIdentifier(contract, 't_function_baredelegatecall_nonpayable$__$returns$_t_bool_$');
 }
 
-function hasTypeIdentifier(contract: ZosContract, typeIdentifier: string): boolean {
+function hasTypeIdentifier(contract: Contract, typeIdentifier: string): boolean {
   for (const node of contract.schema.ast.nodes.filter((n) => n.name === contract.schema.contractName)) {
     if (hasKeyValue(node, 'typeIdentifier', typeIdentifier)) return true;
     for (const baseContract of node.baseContracts || []) {

--- a/packages/lib/src/validations/Storage.ts
+++ b/packages/lib/src/validations/Storage.ts
@@ -4,7 +4,7 @@ import reverse from 'lodash.reverse';
 import path from 'path';
 import process from 'process';
 import { getBuildArtifacts } from '../artifacts/BuildArtifacts';
-import ZosContract from '../artifacts/ZosContract.js';
+import Contract from '../artifacts/Contract.js';
 import { BuildArtifacts } from '../artifacts/BuildArtifacts.js';
 import {
   Node,
@@ -15,7 +15,7 @@ import {
 } from '../utils/ContractAST';
 
 // TS-TODO: define return type after typing class members below.
-export function getStorageLayout(contract: ZosContract, artifacts: BuildArtifacts): StorageLayoutInfo {
+export function getStorageLayout(contract: Contract, artifacts: BuildArtifacts): StorageLayoutInfo {
 
   if (!artifacts) artifacts = getBuildArtifacts();
 
@@ -60,7 +60,7 @@ export interface StorageLayoutInfo {
 class StorageLayout {
 
   private artifacts: BuildArtifacts;
-  private contract: ZosContract;
+  private contract: Contract;
   private imports: Set<any>;
 
   private nodes: NodeMapping;
@@ -69,7 +69,7 @@ class StorageLayout {
   public types: TypeInfoMapping;
   public storage: StorageInfo[];
 
-  constructor(contract: ZosContract, artifacts: BuildArtifacts) {
+  constructor(contract: Contract, artifacts: BuildArtifacts) {
 
     this.artifacts = artifacts;
     this.contract = contract;

--- a/packages/lib/src/validations/index.ts
+++ b/packages/lib/src/validations/index.ts
@@ -13,7 +13,7 @@ import { getUninitializedBaseContracts } from './Initializers';
 import { getStorageLayout, getStructsOrEnums } from './Storage';
 import { compareStorageLayouts, Operation } from './Layout';
 import { hasInitialValuesInDeclarations } from './InitialValues';
-import ZosContract from '../artifacts/ZosContract.js';
+import Contract from '../artifacts/Contract.js';
 import { StorageInfo } from '../utils/ContractAST';
 
 const log = new Logger('validate');
@@ -28,7 +28,7 @@ export interface ValidationInfo {
   storageDiff?: Operation[];
 }
 
-export function validate(contract: ZosContract, existingContractInfo: any = {}, buildArtifacts?: any): any {
+export function validate(contract: Contract, existingContractInfo: any = {}, buildArtifacts?: any): any {
   const storageValidation = validateStorage(contract, existingContractInfo, buildArtifacts);
   const uninitializedBaseContracts = [];
 
@@ -63,7 +63,7 @@ export function validationPasses(validations: any): boolean {
     && isEmpty(validations.uninitializedBaseContracts);
 }
 
-function validateStorage(contract: ZosContract, existingContractInfo: any = {}, buildArtifacts: any = null): { storageUncheckedVars?: StorageInfo[], storageDiff?: Operation[] } {
+function validateStorage(contract: Contract, existingContractInfo: any = {}, buildArtifacts: any = null): { storageUncheckedVars?: StorageInfo[], storageDiff?: Operation[] } {
   const originalStorageInfo = pick(existingContractInfo, 'storage', 'types');
   if (isEmpty(originalStorageInfo.storage)) return {};
 
@@ -77,7 +77,7 @@ function validateStorage(contract: ZosContract, existingContractInfo: any = {}, 
   };
 }
 
-function tryGetUninitializedBaseContracts(contract: ZosContract): string[] {
+function tryGetUninitializedBaseContracts(contract: Contract): string[] {
   try {
     const pipeline = [
       (contracts) => values(contracts),

--- a/packages/lib/test/src/ProxyAdmin.test.js
+++ b/packages/lib/test/src/ProxyAdmin.test.js
@@ -5,7 +5,7 @@ import utils from 'web3-utils';
 import ProxyAdmin from '../../src/proxy/ProxyAdmin';
 import Proxy from '../../src/proxy/Proxy';
 import Contracts from '../../src/artifacts/Contracts';
-import ZosContract from '../../src/artifacts/ZosContract';
+import Contract from '../../src/artifacts/Contract';
 
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');


### PR DESCRIPTION
For simplicity, renames ZosContract.ts to Contract.ts, which implies that all imports in the rest of the code are now:
```
import Contract from '../artifacts/Contract';
```

Note: The only file that imports Web3's Contract is Contract.ts, and it does so using an alias to avoid collision:
```
import { Contract as Web3Contract, TransactionObject, BlockType } from 'web3-eth-contract';
```

Also note: There are now two files with a very similar name, which could be confusing: Contract.ts and Contract*s*.ts. I suggest that we rename this file as well (since all it does is retrieve contract schemas from disk) to something like:
* Artifacts
* ContractsSchema
* ArtifactsLoader
* ...