### PR TITLE
Update truffle-flattener version

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -20,6 +20,104 @@
       "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw==",
       "dev": true
     },
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -2040,7 +2138,8 @@
     "crypto-js": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU=",
+      "dev": true
     },
     "dargs": {
       "version": "5.1.0",
@@ -2604,28 +2703,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "ethjs-abi": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
-      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
         }
       }
     },
@@ -3905,8 +3982,7 @@
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-      "dev": true
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "http-cache-semantics": {
       "version": "3.8.1",
@@ -5975,7 +6051,8 @@
     "original-require": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
+      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
+      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -7278,9 +7355,9 @@
       }
     },
     "solidity-parser-antlr": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.3.2.tgz",
-      "integrity": "sha512-aO/lbnc14A81cQigN5sKNuwbxohPyJOq7kpLirYT/6emCw5Gjb0TJoZ3TzL1tYdIX6gjTAMlQ1UZwOcrzOAp4w=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.0.tgz",
+      "integrity": "sha512-RrIsh5VoHmrMQia6yLY8u8rx3JPREhSiCFz4Xb0h1Oh0prUYU2ukyWO8gG892V0UMHIXCWqvdZ3wSctNwdWThg=="
     },
     "solidity-parser-sc": {
       "version": "0.4.7",
@@ -7915,121 +7992,16 @@
         "solc": "0.4.24"
       }
     },
-    "truffle-blockchain-utils": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
-      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc="
-    },
-    "truffle-config": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
-      "integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
-      "requires": {
-        "find-up": "^2.1.0",
-        "lodash": "4.17.10",
-        "original-require": "1.0.1",
-        "truffle-error": "^0.0.3",
-        "truffle-provider": "^0.0.6"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        }
-      }
-    },
-    "truffle-contract": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
-      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
-      "requires": {
-        "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "^0.0.5",
-        "truffle-contract-schema": "^2.0.1",
-        "truffle-error": "^0.0.3",
-        "web3": "0.20.6"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-        },
-        "web3": {
-          "version": "0.20.6",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-            }
-          }
-        }
-      }
-    },
-    "truffle-contract-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
-      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
-      "requires": {
-        "ajv": "^5.1.1",
-        "crypto-js": "^3.1.9-1",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "crypto-js": {
-          "version": "3.1.9-1",
-          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "truffle-error": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
-      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
-    },
-    "truffle-expect": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.4.tgz",
-      "integrity": "sha1-1bJ63qTFUvQ7cNwAh3I2t7aMdcg="
-    },
     "truffle-flattener": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.2.8.tgz",
-      "integrity": "sha512-HEudiSihgc1avD1sitfMjQU62LaOCMGykQULwt3TD4ESHYDr/ETOc3oYMdm63RBTwB+ucL0sG/mEvGDDimxnxg==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.2.12.tgz",
+      "integrity": "sha512-WLH9u7qEYb06dvJSpVHWUu/JXSZdb+Ush6SmSY7PvXsDF//lR/XW9INsBYT9fqYX2QFOpgGcrh7nP8r7vmvlsA==",
       "requires": {
-        "chalk": "^2.4.1",
+        "@resolver-engine/imports-fs": "^0.2.2",
         "find-up": "^2.1.0",
         "mkdirp": "^0.5.1",
-        "semver": "^5.4.1",
-        "solidity-parser-antlr": "^0.3.1",
-        "truffle-config": "^1.0.6",
-        "truffle-resolver": "^4.0.4",
+        "semver": "^5.6.0",
+        "solidity-parser-antlr": "^0.4.0",
         "tsort": "0.0.1"
       },
       "dependencies": {
@@ -8040,70 +8012,11 @@
           "requires": {
             "locate-path": "^2.0.0"
           }
-        }
-      }
-    },
-    "truffle-provider": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
-      "integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
-      "requires": {
-        "truffle-error": "^0.0.3",
-        "web3": "0.20.6"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
-        "web3": {
-          "version": "0.20.6",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-            }
-          }
-        }
-      }
-    },
-    "truffle-provisioner": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
-      "integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo="
-    },
-    "truffle-resolver": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.4.tgz",
-      "integrity": "sha1-39mo28pcWHPXeS0UREc9B3Csl9Q=",
-      "requires": {
-        "async": "2.6.1",
-        "truffle-contract": "^3.0.6",
-        "truffle-expect": "^0.0.4",
-        "truffle-provisioner": "^0.1.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         }
       }
     },
@@ -8446,7 +8359,8 @@
     "utf8": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -9315,7 +9229,8 @@
     "xhr2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+      "dev": true
     },
     "xhr2-cookies": {
       "version": "1.1.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -68,7 +68,7 @@
     "lodash.without": "^4.4.0",
     "openzeppelin-solidity": "~1.10.0",
     "semver": "^5.5.1",
-    "truffle-flattener": "^1.2.8",
+    "truffle-flattener": "^1.2.12",
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated `truffle-flattener` version to `1.2.12`, which includes https://github.com/nomiclabs/truffle-flattener/pull/36 :raised_hands: .