### PR TITLE
Fix etherscan mainnet url

### DIFF
--- a/packages/cli/src/models/Verifier.ts
+++ b/packages/cli/src/models/Verifier.ts
@@ -78,7 +78,8 @@ async function publishToEtherscan(params: VerifierOptions): Promise<void | never
 
   const apiSubdomain = setEtherscanApiSubdomain(network);
   const etherscanApiUrl = `https://${apiSubdomain}.etherscan.io/api`;
-  const etherscanContractUrl = `https://${network}.etherscan.io/address`;
+  const networkSubdomain = network === 'mainnet' ? '' : `${network}.`;
+  const etherscanContractUrl = `https://${networkSubdomain}etherscan.io/address`;
 
   try {
     const response = await axios.request({


### PR DESCRIPTION
Related to https://github.com/zeppelinos/zos/issues/636. Minor fix in etherscan mainnet url found while manually testing zos.