### PR TITLE
Update the quickstart section guides to work with zOS 2.1.

### DIFF
--- a/packages/docs/docs/docs/deploying.md
+++ b/packages/docs/docs/docs/deploying.md
@@ -62,7 +62,7 @@ Next, we need to install Truffle. To do so, run the following command:
 npm install truffle@4.1.15 --save
 ```
 
-> Note: We are specifically installing Truffle 4.1.15, because ZeppelinOS 2.1 only supports Truffle 5 partially. Full support is expected in ZeppelinOS 2.2, which will be released soon._
+> Note: We are specifically installing Truffle 4.1.15, as ZeppelinOS 2.1 only supports Truffle 5 for command-line usage (not programmatic usage). Full support for Truffle 5 and Web3 1.0 will be released in ZeppelinOS 2.2._
 
 That's it! Our project is now fully set up for using ZeppelinOS.
 

--- a/packages/docs/docs/docs/deploying.md
+++ b/packages/docs/docs/docs/deploying.md
@@ -5,22 +5,11 @@ title: Deploying your first project
 
 The following steps will get you started using ZeppelinOS.
 
-## Installation
+## Install Node and NPM
 
 First, let's install [Node.js](http://nodejs.org/) and
 [npm](https://npmjs.com/). On their
 respective websites you will find specific instructions for your machine.
-
-Then, install ZeppelinOS by running:
-
-```console
-npm install --global zos
-```
-
-Run `zos --help` to get a list of all the ZeppelinOS commands available. At any time
-during these guides, when we introduce a new command, run
-`zos <command-name> --help` to get more information about that command and
-its arguments.
 
 ## Setting up your project
 
@@ -40,10 +29,21 @@ npm init
 This command will ask you for details about the project. For this very basic
 guide you can just press enter to accept the default values of each field.
 
+Then, install ZeppelinOS in your project folder by running:
+
+```console
+npm install zos
+```
+
+Run `npx zos --help` to get a list of all the ZeppelinOS commands available. At any time
+during these guides, when we introduce a new command, run
+`npx zos <command-name> --help` to get more information about that command and
+its arguments.
+
 Now, we can initialize the ZeppelinOS project:
 
 ```console
-zos init my-project
+npx zos init my-project
 ```
 
 This command will create a `zos.json` file, which contains all the information
@@ -56,11 +56,15 @@ by now, inside the `my-project` directory you should have a `package.json` file
 a `truffle-config.js` file (created by the `zos` CLI for Truffle), and a
 `zos.json` file (created by `zos` for ZeppelinOS).
 
-Note: if you haven't installed Truffle, run the following command to add it to your project:
+Next, we need to install Truffle. To do so, run the following command:
 
 ```console
-npm install truffle --save
+npm install truffle@4.1.15 --save
 ```
+
+> Note: We are specifically installing Truffle 4.1.15, because ZeppelinOS 2.1 only supports Truffle 5 partially. Full support is expected in ZeppelinOS 2.2, which will be released soon._
+
+That's it! Our project is now fully set up for using ZeppelinOS.
 
 ## Adding a contract
 
@@ -69,7 +73,7 @@ Name it `MyContract.sol`, and put it in the `contracts` folder with the
 following Solidity code:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "zos-lib/contracts/Initializable.sol";
 
@@ -105,7 +109,7 @@ prevent the `initialize` function from be called more than once.
 Now we can add the contract to the project:
 
 ```console
-zos add MyContract
+npx zos add MyContract
 ```
 
 This command will first compile `MyContract`, and then it will add it to the
@@ -137,7 +141,7 @@ Once we have done that, let's go back to the original terminal and
 run the following command:
 
 ```console
-zos session --network local --from 0x1df62f291b2e969fb0849d99d9ce41e2f137006e --expires 3600
+npx zos session --network local --from 0x1df62f291b2e969fb0849d99d9ce41e2f137006e --expires 3600
 ```
 
 The `session` command starts a session to work with a desired network.
@@ -156,7 +160,7 @@ Now that everything has been setup, we are ready to deploy the project.
 To do so simply run:
 
 ```console
-zos push
+npx zos push
 ```
 
 This command deploys `MyContract` to the specified network and prints its

--- a/packages/docs/docs/docs/linking.md
+++ b/packages/docs/docs/docs/linking.md
@@ -19,7 +19,7 @@ let's make it import a very common
 contract from the [OpenZeppelin](https://openzeppelin.org/) EVM package:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-eth/contracts/token/ERC721/ERC721Mintable.sol";
 
@@ -42,8 +42,10 @@ For more information, see
 Now, let's link our project to the openzeppelin-eth package by running:
 
 ```console
-zos link openzeppelin-eth
+npx zos link openzeppelin-eth@2.0.2
 ```
+
+> Note: We are specifically installing openzeppelin-eth 2.0.2 because later versions of openzeppelin-eth use Solidity 0.5, and in this example we are using Solidity 0.4.
 
 This command will install the openzeppelin-eth contracts locally, which is
 needed to compile the contracts that import it; but it will also update the
@@ -55,18 +57,18 @@ The following commands will be familiar to you. Just as we did before, we have
 to add the contract to the project:
 
 ```console
-zos add MyLinkedContract
+npx zos add MyLinkedContract
 ```
 
 > If any of the following commands fail with an `A network name must be provided 
 to execute the requested action` error, it means our session has expired. 
-In that case, renew it by running the command `zos session --network local 
+In that case, renew it by running the command `npx zos session --network local 
 --from 0x1df62f291b2e969fb0849d99d9ce41e2f137006e --expires 3600` again.
 
 Now, let's push our changes to the blockchain:
 
 ```console
-zos push --deploy-dependencies
+npx zos push --deploy-dependencies
 ```
 
 There is one caveat here with the `--deploy-dependencies` flag. We mentioned
@@ -83,13 +85,13 @@ Repeating ourselves from before, let's make an upgradeable instance of the
 contract:
 
 ```console
-zos create MyLinkedContract
+npx zos create MyLinkedContract
 ```
 
 We also need an instance of the `ERC721` token from the EVM package:
 
 ```console
-zos create openzeppelin-eth/StandaloneERC721 --init initialize --args MyToken,TKN,[<address>],[<address>]
+npx zos create openzeppelin-eth/StandaloneERC721 --init initialize --args MyToken,TKN,[<address>],[<address>]
 ```
 
 `<address>` will be the minter and pauser of the token. For local development
@@ -109,7 +111,7 @@ and `StandaloneERC721` respectively. Both addresses were returned by the `create
 commands we ran above._
 
 ```console
-truffle(local)> MyLinkedContract.at('<my-linked-contract-address>').then(i => myLinkedContract = i)
+truffle(local)> myLinkedContract = MyLinkedContract.at('<my-linked-contract-address>')
 truffle(local)> myLinkedContract.setToken('<my-erc721-address>')
 ```
 

--- a/packages/docs/docs/docs/publish.md
+++ b/packages/docs/docs/docs/publish.md
@@ -18,20 +18,20 @@ In the directory of our project, we initialize it:
 mkdir <project-name>
 cd <project-name>
 npm init
-zos init <project-name>
+npx zos init <project-name>
 ```
 
 Then, we can add to our project all the contracts that we have in the
 `contracts` directory:
 
 ```console
-zos add <contract-name-1> <contract-name-2> ... <contract-name-n>
+npx zos add <contract-name-1> <contract-name-2> ... <contract-name-n>
 ```
 
 Next, we push the project to the network:
 
 ```console
-zos push --network <network>
+npx zos push --network <network>
 ```
 
 Note that for the EVM package to be used by others, you need to use a real
@@ -42,7 +42,7 @@ All known commands so far. Here comes what's new. If you want to share your
 package in ZeppelinOS, do it by running the `publish` command:
 
 ```console
-zos publish --network <network>
+npx zos publish --network <network>
 ```
 
 It's that simple! Now you are the developer of an EVM package that lives in
@@ -71,9 +71,9 @@ ZeppelinOS configuration files, so add the following top-level field to the
 }
 ```
 
-Remember that the `zos` configuration files are where ZeppelinOS keep track of 
+Remember that the `zos` configuration files are where ZeppelinOS keeps track of 
 your contracts, the addresses of the instances you have created, and in this
-case the address of the EVM package you have published. This is how ZeppelinOS 
+case the address of the EVM package you will have published. This is how ZeppelinOS 
 solves the link of foreign projects that depend on yours.
 
 Make sure to check that the rest of the fields describe your package
@@ -98,7 +98,7 @@ Now we are done for real. Other developers will be able to link to your
 package by using:
 
 ```console
-zos link <your-project-name>
+npx zos link <your-project-name>
 ```
 
 Spread the word! Tell others to reuse your work, and to help you improving it

--- a/packages/docs/docs/docs/upgrading.md
+++ b/packages/docs/docs/docs/upgrading.md
@@ -8,7 +8,7 @@ project with one contract. Here is the code of the contract, to keep it fresh
 on our minds:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "zos-lib/contracts/Initializable.sol";
 
@@ -37,17 +37,17 @@ automated, or any combination of both that will earn the trust of our users.
 
 > If any of the following commands fail with an `A network name must be provided 
 to execute the requested action` error, it means our session has expired. 
-In that case, renew it by running the command `zos session --network local 
+In that case, renew it by running the command `npx zos session --network local 
 --from 0x1df62f291b2e969fb0849d99d9ce41e2f137006e --expires 3600` again.
 
 Now let's create an upgradeable instance of this contract so you can 
 experiment with what this is all about:
 
 ```console
-zos create MyContract --init initialize --args 42,hitchhiker
+npx zos create MyContract --init initialize --args 42,hitchhiker
 ```
 
-The `zos create` command receives an optional `--init [function-name]`
+The `npx zos create` command receives an optional `--init [function-name]`
 parameter to call the initialization function after creating the contract,
 and the `--args` parameter allows you to pass arguments to it. This way, you
 are initializing your contract with `42` as the value of the `x` state
@@ -72,7 +72,7 @@ that our instance is working as expected:
 by the `create` command we ran above._
 
 ```console
-truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
+truffle(local)> myContract = MyContract.at('<your-contract-address>')
 truffle(local)> myContract.x().then(x => x.toString())
 '42'
 
@@ -94,7 +94,7 @@ extend its functionalities.
 Open `contracts/MyContract.sol`, and add a new function:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "zos-lib/contracts/Initializable.sol";
 
@@ -123,13 +123,13 @@ contract MyContract is Initializable {
 Once you have saved these changes, push the new code to the network:
 
 ```console
-zos push
+npx zos push
 ```
 
 Finally, let's update the already deployed contract with the new code:
 
 ```console
-zos update MyContract
+npx zos update MyContract
 ```
 
 You will see that this command prints the same contract address as before, 
@@ -154,7 +154,7 @@ returned by the `create` command we ran in the previous section, which
 is the same as the one returned by the `update` command we ran above._
 
 ```console
-truffle(local)> MyContract.at('<your-contract-address>').then(i => myContract = i)
+truffle(local)> myContract = MyContract.at('<your-contract-address>')
 truffle(local)> myContract.increment()
 truffle(local)> myContract.x().then(x => x.toString())
 43

--- a/packages/docs/docs/docs/zos_lib.md
+++ b/packages/docs/docs/docs/zos_lib.md
@@ -34,7 +34,7 @@ Now, let's write two simple contracts. The first in `contracts/MyContractV0`
 with the following contents:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "zos-lib/contracts/Initializable.sol";
 
@@ -51,7 +51,7 @@ The second in `contracts/MyContractV1`, and it will be almost the same as the
 first one but with one extra function:
 
 ```solidity
-pragma solidity ^0.5.0;
+pragma solidity ^0.4.24;
 
 import "zos-lib/contracts/Initializable.sol";
 


### PR DESCRIPTION
Fix #639 
Part of #635 

This PR updates the guides in the quickstart section of the docs to use `npx zos` so that we make sure that the user is using ZeppelinOS 2.1, pins Truffle to 4.1.15, rollsback all example contracts to Solidity 0.4.24, and pins openzeppelin-eth to 2.0.2 (which is the last version that had Solidity 0.4.24 contracts). 