### PR TITLE
Log `truffle compile` output outside if/else

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -15,10 +15,10 @@ const Compiler = {
           if (error.code === 127) console.error('Could not find truffle executable. Please install it by running: npm install truffle');
           reject(error);
         } else {
-          if (stdout) console.log(stdout);
-          if (stderr) console.error(stderr);
           resolve({ stdout, stderr });
         }
+        if (stdout) console.log(stdout);
+        if (stderr) console.error(stderr);
       });
     });
   }


### PR DESCRIPTION
Fixes #644, fixes #641. I moved both `console.log` and `console.error` outside the if/else clauses.