### PR TITLE
Fix in ZWeb3#ganacheNode return statement

### DIFF
--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -88,7 +88,7 @@ export default class ZWeb3 {
 
   public static async isGanacheNode(): Promise<boolean> {
     const nodeVersion = await ZWeb3.getNode();
-    return nodeVersion.match(/TestRPC/).length > 0;
+    return nodeVersion.match(/TestRPC/) !== null;
   }
 
   public static async getBlock(filter: string | number): Promise<Block> {


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/647. The problem was that while working with mainnet/any testnet, `ZWeb3#isGanacheNode` was trying to access to the `length` attribute of a `null` value, which made the cli crash, for example, when calling `ZWeb3#awaitConfirmations` in `zosversion` migration.