### PR TITLE
Get accounts from `web3.eth` in ZWeb3 instead of getting them from `web3.eth.personal`.

### DIFF
--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -54,7 +54,7 @@ export default class ZWeb3 {
   }
 
   public static async accounts(): Promise<string[]> {
-    return await ZWeb3.eth().personal.getAccounts();
+    return await ZWeb3.eth().getAccounts();
   }
 
   public static async defaultAccount(): Promise<string> {


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/645.