### PR TITLE
Fix blueprint.truffle.js not being available in cli/lib output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,8 +6,9 @@
   "private": false,
   "license": "MIT",
   "scripts": {
+    "copy-files": "./scripts/copy-files.sh",
     "compile-ts": "rm -rf lib && tsc",
-    "prepare": "npm run compile-ts && chmod 755 ./lib/bin/zos-cli.js",
+    "prepare": "npm run compile-ts && npm run copy-files && chmod 755 ./lib/bin/zos-cli.js",
     "test": "./scripts/test.sh",
     "gen-docs": "babel-node docs/bin/docs.js",
     "watch": "tsc -w",

--- a/packages/cli/scripts/copy-files.sh
+++ b/packages/cli/scripts/copy-files.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# blueprint.truffle.js
+cp src/models/initializer/truffle/blueprint.truffle.js lib/models/initializer/truffle/blueprint.truffle.js


### PR DESCRIPTION
#### Problem
When running `zos init myProject` in a directory that has not yet been initialized by truffle, the following error is thrown:

```
ENOENT: no such file or directory, copyfile '/home/user/myProject/node_modules/zos/lib/models/initializer/truffle/blueprint.truffle.js' -> '/home/user/myProject/truffle-config.js'
```

The truffle.js blueprint does not make it to lib, because the Typescript compiler simply ignores it.

#### Suggested solution
This PR adds a copy-files.sh script that simply copies the file into the lib folder.