### PR TITLE
Allow bump script to receive a branch as argument

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -46,6 +46,28 @@ and [`solidity-docgen`](https://github.com/OpenZeppelin/solidity-docgen)
 respectively, and then merge the outcome manually by substituting the
 corresponding `.md` files in the `docs/docs/` directory.
 
+## Bump version
+
+The `bump-version` script is provided in order to bump to a particular version.
+
+### Usage:
+
+Specifying an already released version:
+
+```sh
+
+foo@bar:~$: npm run bump-docs 1.2.0
+
+```
+
+Specifying a version and a branch:
+
+```sh
+
+foo@bar:~$: npm run bump-docs 1.2.0 a_remote_branch
+
+```
+
 ## Maintainers
 
 * [@jcarpanelli](https://github.com/jcarpanelli/)

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -1083,8 +1083,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1105,14 +1104,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1127,20 +1124,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1257,8 +1251,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1270,7 +1263,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1285,7 +1277,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1293,14 +1284,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1319,7 +1308,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1400,8 +1388,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1413,7 +1400,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1499,8 +1485,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1536,7 +1521,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1556,7 +1540,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1600,14 +1583,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2307,10 +2288,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "set-immediate-shim": {
       "version": "1.0.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,6 +21,7 @@
     "soldoc"
   ],
   "dependencies": {
+    "semver": "^5.6.0",
     "shelljs": "^0.8.2",
     "solidity-docgen": "^0.1.0",
     "tmp": "0.0.33"

--- a/packages/docs/scripts/generators.js
+++ b/packages/docs/scripts/generators.js
@@ -1,6 +1,5 @@
 'use strict'
 
-
 import { readFileSync } from 'fs'
 import path from 'path'
 
@@ -22,7 +21,6 @@ export function cleanupSidebar(packagesDir) {
   const sidebar = path.resolve(packagesDir, 'docs', 'docs', 'website', 'sidebars.json')
   exec(`echo "{}" > ${sidebar}`)
 }
-
 
 export function genCliDocs(packagesDir) {
   const cliDir = path.resolve(packagesDir, 'cli')


### PR DESCRIPTION
Fixes #670.

I've implemented some minor changes to the `bump-script.js` file so it can receive a particular branch as an argument.

#### Usage:

Specifying an already released version:

```sh

foo@bar:~$: npm run bump-docs 1.2.0

```

Specifying a version and a branch:

```sh

foo@bar:~$: npm run bump-docs 1.2.0 a_remote_branch

```
