### PR TITLE
Prompt migration question for each network independently

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -23,7 +23,7 @@ const register: (program: any) => any = (program) => program
 
 async function action(contractFullName: string, options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
-  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
+  const zosversion = await ZosNetworkFile.getZosversion(network);
   if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { force } = options;

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -24,7 +24,7 @@ const register: (program: any) => any = (program) => program
 async function action(contractFullName: string, options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
-  if (!await hasToMigrateProject(zosversion)) return;
+  if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { force } = options;
   const { initMethod, initArgs } = parseInit(options, 'initialize');

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -5,7 +5,7 @@ import { parseInit } from '../utils/input';
 import { fromContractFullName } from '../utils/naming';
 import { hasToMigrateProject } from '../utils/prompt-migration';
 import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
-import ZosPackageFile from '../models/files/ZosPackageFile';
+import ZosNetworkFile from '../models/files/ZosNetworkFile';
 
 const name: string = 'create';
 const signature: string = `${name} <alias>`;
@@ -22,12 +22,13 @@ const register: (program: any) => any = (program) => program
   .action(action);
 
 async function action(contractFullName: string, options: any): Promise<void> {
-  const zosversion = await ZosPackageFile.getZosversion();
+  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
+  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
   if (!await hasToMigrateProject(zosversion)) return;
+
   const { force } = options;
   const { initMethod, initArgs } = parseInit(options, 'initialize');
   const { contract: contractAlias, package: packageName } = fromContractFullName(contractFullName);
-  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   const args = pickBy({ packageName, contractAlias, initMethod, initArgs, force });
 
   await create({ ...args, network, txParams });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,7 +1,7 @@
 import publish from '../scripts/publish';
 import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
 import { hasToMigrateProject } from '../utils/prompt-migration';
-import ZosPackageFile from '../models/files/ZosPackageFile';
+import ZosNetworkFile from '../models/files/ZosNetworkFile';
 
 const name: string = 'publish';
 const signature: string = `${name}`;
@@ -15,9 +15,10 @@ const register: (program: any) => any = (program) => program
   .action(action);
 
 async function action(options: any): Promise<void> {
-  const zosversion = await ZosPackageFile.getZosversion();
-  if (!await hasToMigrateProject(zosversion)) return;
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
+  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
+  if (!await hasToMigrateProject(zosversion)) return;
+
   await publish({ network, txParams });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -17,7 +17,7 @@ const register: (program: any) => any = (program) => program
 async function action(options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
-  if (!await hasToMigrateProject(zosversion)) return;
+  if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   await publish({ network, txParams });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -16,7 +16,7 @@ const register: (program: any) => any = (program) => program
 
 async function action(options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
-  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
+  const zosversion = await ZosNetworkFile.getZosversion(network);
   if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   await publish({ network, txParams });

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -20,7 +20,7 @@ const register: (program: any) => any = (program) => program
 
 async function action(contractFullNameOrAddress: string, newAdmin: string, options: any): Promise<void | never> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
-  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
+  const zosversion = await ZosNetworkFile.getZosversion(network);
   if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { yes } = options;

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -4,7 +4,7 @@ import setAdmin from '../scripts/set-admin';
 import { fromContractFullName } from '../utils/naming';
 import { hasToMigrateProject } from '../utils/prompt-migration';
 import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
-import ZosPackageFile from '../models/files/ZosPackageFile';
+import ZosNetworkFile from '../models/files/ZosNetworkFile';
 
 const name: string = 'set-admin';
 const signature: string = `${name} [alias-or-address] [new-admin-address]`;
@@ -19,7 +19,8 @@ const register: (program: any) => any = (program) => program
   .action(action);
 
 async function action(contractFullNameOrAddress: string, newAdmin: string, options: any): Promise<void | never> {
-  const zosversion = await ZosPackageFile.getZosversion();
+  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
+  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
   if (!await hasToMigrateProject(zosversion)) return;
 
   const { yes } = options;
@@ -38,7 +39,6 @@ async function action(contractFullNameOrAddress: string, newAdmin: string, optio
   }
 
   const args = pickBy({ contractAlias, packageName, proxyAddress, newAdmin });
-  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   await setAdmin({ ...args, network, txParams });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -21,7 +21,7 @@ const register: (program: any) => any = (program) => program
 async function action(contractFullNameOrAddress: string, newAdmin: string, options: any): Promise<void | never> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
-  if (!await hasToMigrateProject(zosversion)) return;
+  if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { yes } = options;
   if (!yes) {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -24,7 +24,7 @@ const register: (program: any) => any = (program) => program
 
 async function action(contractFullNameOrAddress: string, options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
-  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
+  const zosversion = await ZosNetworkFile.getZosversion(network);
   if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { initMethod, initArgs } = parseInit(options, 'initialize');

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -5,7 +5,7 @@ import { parseInit } from '../utils/input';
 import { fromContractFullName } from '../utils/naming';
 import { hasToMigrateProject } from '../utils/prompt-migration';
 import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
-import ZosPackageFile from '../models/files/ZosPackageFile';
+import ZosNetworkFile from '../models/files/ZosNetworkFile';
 
 const name: string = 'update';
 const signature: string = `${name} [alias-or-address]`;
@@ -23,7 +23,8 @@ const register: (program: any) => any = (program) => program
   .action(action);
 
 async function action(contractFullNameOrAddress: string, options: any): Promise<void> {
-  const zosversion = await ZosPackageFile.getZosversion();
+  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
+  const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
   if (!await hasToMigrateProject(zosversion)) return;
 
   const { initMethod, initArgs } = parseInit(options, 'initialize');
@@ -40,7 +41,6 @@ async function action(contractFullNameOrAddress: string, options: any): Promise<
   }
 
   const args = pickBy({ contractAlias, packageName, proxyAddress, initMethod, initArgs, all, force });
-  const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   await update({ ...args, network, txParams });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -25,7 +25,7 @@ const register: (program: any) => any = (program) => program
 async function action(contractFullNameOrAddress: string, options: any): Promise<void> {
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   const zosversion = await ZosNetworkFile.getZosversion(`zos.${network}.json`);
-  if (!await hasToMigrateProject(zosversion)) return;
+  if (!await hasToMigrateProject(zosversion)) process.exit(0);
 
   const { initMethod, initArgs } = parseInit(options, 'initialize');
   const { all, force } = options;

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -72,8 +72,8 @@ export default class ZosNetworkFile {
     dependencies: { [dependencyName: string]: DependencyInterface };
   };
 
-  public static getZosversion(fileName: string): string | null {
-    const file = fs.parseJsonIfExists(fileName);
+  public static getZosversion(network: string): string | null {
+    const file = fs.parseJsonIfExists(`zos.${network}.json`);
     return file.zosversion || null;
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -72,6 +72,11 @@ export default class ZosNetworkFile {
     dependencies: { [dependencyName: string]: DependencyInterface };
   };
 
+  public static getZosversion(fileName: string): string | null {
+    const file = fs.parseJsonIfExists(fileName);
+    return file.zosversion || null;
+  }
+
   // TS-TODO: type for network parameter (and class member too).
   constructor(packageFile: ZosPackageFile, network: any, fileName: string) {
     this.packageFile = packageFile;

--- a/packages/cli/src/models/files/ZosPackageFile.ts
+++ b/packages/cli/src/models/files/ZosPackageFile.ts
@@ -18,11 +18,6 @@ export default class ZosPackageFile {
     publish: boolean;
   };
 
-  public static getZosversion(fileName: string = 'zos.json'): string | null {
-    const file = fs.parseJsonIfExists(fileName);
-    return file.zosversion || null;
-  }
-
   constructor(fileName: string = 'zos.json') {
     this.fileName = fileName;
     this.data = fs.parseJsonIfExists(this.fileName) || { zosversion: ZOS_VERSION };

--- a/packages/cli/test/commands/share.js
+++ b/packages/cli/test/commands/share.js
@@ -22,7 +22,7 @@ import * as setAdmin from '../../src/scripts/set-admin';
 
 import program from '../../src/bin/program';
 import Session from '../../src/models/network/Session';
-import ZosPackageFile from '../../src/models/files/ZosPackageFile';
+import ZosNetworkFile from '../../src/models/files/ZosNetworkFile';
 import Compiler from '../../src/models/compiler/Compiler';
 import ErrorHandler from '../../src/models/errors/ErrorHandler';
 import ConfigVariablesInitializer from '../../src/models/initializer/ConfigVariablesInitializer';
@@ -72,7 +72,7 @@ exports.stubCommands = function () {
       const txParams = from ? { from } : {}
       return { network, txParams }
     })
-    this.getZosversion = sinon.stub(ZosPackageFile, 'getZosversion').returns('2.2');
+    this.getZosversion = sinon.stub(ZosNetworkFile, 'getZosversion').returns('2.2');
   })
 
   afterEach('restore', function () {


### PR DESCRIPTION
The `zosversion` check has been changed in order to check it in the `zos.network.json` file rather than in the `zos.json` file. This means that we are going to prompt the migration question for each network independently instead of checking it once and then migrate without asking on the remaining networks.