### PR TITLE
Initialize ZWeb3 without a provider

### DIFF
--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -29,7 +29,7 @@ export default class ZWeb3 {
 
   // TODO: this.web3 could be cached and initialized lazily?
   public static web3(): any {
-    if (!ZWeb3.provider) throw new Error('ZWeb3 must be initialized with a web3 provider');
+    if (!ZWeb3.provider) return new Web3();
 
     // TODO: improve provider validation for HttpProvider scenarios
     return (typeof ZWeb3.provider === 'string')

--- a/packages/lib/test/src/artifacts/ZWeb3.test.js
+++ b/packages/lib/test/src/artifacts/ZWeb3.test.js
@@ -8,15 +8,27 @@ import utils from 'web3-utils';
 import BN from 'bignumber.js';
 
 contract('ZWeb3', accounts => {
-  accounts = accounts.map(utils.toChecksumAddress); // Required by Web3 v1.x.
+  accounts = accounts.map(utils.toChecksumAddress);
   
   before('deploy dummy instance', async function () {
     this.DummyImplementation = Contracts.getFromLocal('DummyImplementation')
     this.impl = await this.DummyImplementation.new()
   })
 
+  describe('when initializing without a provider', function () {
+    it('initializes web3 without a provider', async function () {
+      ZWeb3.initialize();
+      ZWeb3.web3().should.not.be.null;
+      expect(ZWeb3.web3().currentProvider).to.be.null;
+    })
+  })
+
   describe('when initialized', function () {
     beforeEach('initialize ZWeb3', () => ZWeb3.initialize(web3.currentProvider))
+
+    it('initializes web3 with a provider', function () {
+      ZWeb3.web3().currentProvider.should.not.be.null;
+    })
 
     it('knows a web3 instance', function () {
       ZWeb3.web3().should.not.be.null

--- a/packages/lib/test/src/artifacts/ZWeb3.test.js
+++ b/packages/lib/test/src/artifacts/ZWeb3.test.js
@@ -15,15 +15,6 @@ contract('ZWeb3', accounts => {
     this.impl = await this.DummyImplementation.new()
   })
 
-  describe('when it is not initialized', function () {
-    beforeEach('undo ZWeb3 initialization', () => ZWeb3.initialize())
-    afterEach('initialize ZWeb3', () => ZWeb3.initialize(web3.currentProvider))
-
-    it('cannot be called', async function () {
-      expect(() => ZWeb3.web3()).to.throw(/ZWeb3 must be initialized with a web3 provider/)
-    })
-  })
-
   describe('when initialized', function () {
     beforeEach('initialize ZWeb3', () => ZWeb3.initialize(web3.currentProvider))
 


### PR DESCRIPTION
Fixes #735.

As discussed offline with @spalladino, we are now initializing `ZWeb3#web3` without a provider instead of throwing an error.