### PR TITLE
Remove openzeppelin-solidity as a dependency

### DIFF
--- a/packages/lib/contracts/application/App.sol
+++ b/packages/lib/contracts/application/App.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 import "./ImplementationProvider.sol";
 import "./Package.sol";
 import "../upgradeability/AdminUpgradeabilityProxy.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../openzeppelin-solidity/ownership/Ownable.sol";
 
 /**
  * @title App

--- a/packages/lib/contracts/application/ImplementationDirectory.sol
+++ b/packages/lib/contracts/application/ImplementationDirectory.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.24;
 
 import "./ImplementationProvider.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import 'openzeppelin-solidity/contracts/AddressUtils.sol';
+import "../openzeppelin-solidity/ownership/Ownable.sol";
+import '../openzeppelin-solidity/utils/Address.sol';
 
 /**
  * @title ImplementationDirectory
@@ -59,7 +59,7 @@ contract ImplementationDirectory is ImplementationProvider, Ownable {
    * @param implementation Address of the implementation.
    */
   function setImplementation(string contractName, address implementation) public onlyOwner whenNotFrozen {
-    require(AddressUtils.isContract(implementation), "Cannot set implementation in directory with a non-contract address");
+    require(Address.isContract(implementation), "Cannot set implementation in directory with a non-contract address");
     implementations[contractName] = implementation;
     emit ImplementationChanged(contractName, implementation);
   }

--- a/packages/lib/contracts/application/Package.sol
+++ b/packages/lib/contracts/application/Package.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../openzeppelin-solidity/ownership/Ownable.sol";
 
 /**
  * @title Package

--- a/packages/lib/contracts/mocks/DeprecatedApp.sol
+++ b/packages/lib/contracts/mocks/DeprecatedApp.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 import "../application/ImplementationProvider.sol";
 import "../application/Package.sol";
 import { DeprecatedAdminUpgradeabilityProxy as AdminUpgradeabilityProxy } from "../mocks/DeprecatedAdminUpgradeabilityProxy.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../openzeppelin-solidity/ownership/Ownable.sol";
 
 /**
  * @title App

--- a/packages/lib/contracts/openzeppelin-solidity/ownership/Ownable.sol
+++ b/packages/lib/contracts/openzeppelin-solidity/ownership/Ownable.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.4.24;
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ * Source: https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-solidity/v2.0.0/contracts/ownership/Ownable.sol
+ */
+contract Ownable {
+  address private _owner;
+
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  constructor() internal {
+    _owner = msg.sender;
+    emit OwnershipTransferred(address(0), _owner);
+  }
+
+  /**
+   * @return the address of the owner.
+   */
+  function owner() public view returns(address) {
+    return _owner;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(isOwner());
+    _;
+  }
+
+  /**
+   * @return true if `msg.sender` is the owner of the contract.
+   */
+  function isOwner() public view returns(bool) {
+    return msg.sender == _owner;
+  }
+
+  /**
+   * @dev Allows the current owner to relinquish control of the contract.
+   * @notice Renouncing to ownership will leave the contract without an owner.
+   * It will not be possible to call the functions with the `onlyOwner`
+   * modifier anymore.
+   */
+  function renounceOwnership() public onlyOwner {
+    emit OwnershipTransferred(_owner, address(0));
+    _owner = address(0);
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    _transferOwnership(newOwner);
+  }
+
+  /**
+   * @dev Transfers control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function _transferOwnership(address newOwner) internal {
+    require(newOwner != address(0));
+    emit OwnershipTransferred(_owner, newOwner);
+    _owner = newOwner;
+  }
+}

--- a/packages/lib/contracts/openzeppelin-solidity/utils/Address.sol
+++ b/packages/lib/contracts/openzeppelin-solidity/utils/Address.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.24;
+
+/**
+ * Utility library of inline functions on addresses
+ * Source https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-solidity/v2.0.0/contracts/utils/Address.sol
+ */
+library Address {
+
+  /**
+   * Returns whether the target address is a contract
+   * @dev This function will return false if invoked during the constructor of a contract,
+   * as the code is not actually created until after the constructor finishes.
+   * @param account address of the account to check
+   * @return whether the target address is a contract
+   */
+  function isContract(address account) internal view returns (bool) {
+    uint256 size;
+    // XXX Currently there is no better way to check if there is a contract in an address
+    // than to check the size of the code at that address.
+    // See https://ethereum.stackexchange.com/a/14016/36603
+    // for more details about how this works.
+    // TODO Check this again before the Serenity release, because all addresses will be
+    // contracts then.
+    // solium-disable-next-line security/no-inline-assembly
+    assembly { size := extcodesize(account) }
+    return size > 0;
+  }
+
+}

--- a/packages/lib/contracts/upgradeability/ProxyAdmin.sol
+++ b/packages/lib/contracts/upgradeability/ProxyAdmin.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../openzeppelin-solidity/ownership/Ownable.sol";
 import "./AdminUpgradeabilityProxy.sol";
 
 /**

--- a/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/packages/lib/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
 import './Proxy.sol';
-import 'openzeppelin-solidity/contracts/AddressUtils.sol';
+import '../openzeppelin-solidity/utils/Address.sol';
 
 /**
  * @title UpgradeabilityProxy
@@ -64,7 +64,7 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation Address of the new implementation.
    */
   function _setImplementation(address newImplementation) private {
-    require(AddressUtils.isContract(newImplementation), "Cannot set a proxy implementation to a non-contract address");
+    require(Address.isContract(newImplementation), "Cannot set a proxy implementation to a non-contract address");
 
     bytes32 slot = IMPLEMENTATION_SLOT;
 

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -5947,11 +5947,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -66,7 +66,6 @@
     "lodash.uniq": "^4.5.0",
     "lodash.values": "^4.3.0",
     "lodash.without": "^4.4.0",
-    "openzeppelin-solidity": "~1.10.0",
     "semver": "^5.5.1",
     "truffle-flattener": "^1.3.0",
     "web3": "1.0.0-beta.37"

--- a/packages/lib/test/src/application/App.test.js
+++ b/packages/lib/test/src/application/App.test.js
@@ -7,7 +7,6 @@ import ZWeb3 from '../../../src/artifacts/ZWeb3'
 import Package from '../../../src/application/Package'
 import Contracts from '../../../src/artifacts/Contracts'
 import ProxyAdmin from '../../../src/proxy/ProxyAdmin'
-import expectEvent from 'openzeppelin-solidity/test/helpers/expectEvent'
 import { ZERO_ADDRESS } from '../../../src/utils/Addresses';
 import { ImplementationDirectory, Proxy } from '../../../src';
 import Transactions from '../../../src/utils/Transactions';


### PR DESCRIPTION
This PR removes openzeppelin as a dependency from `zos-lib`, to allow for client projects to use whichever version of OpenZeppelin they prefer. Given that we were using only 2 contracts, we are currently manually copying them into the project. See [this thread](https://forum.zeppelin.solutions/t/zeppelinos-and-openzeppelin-compatible-versions/311) for more info.