### PR TITLE
Handle spaces in project path

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile, ExecException } from 'child_process';
 import { FileSystem, Contracts, Logger } from 'zos-lib';
 
 const log = new Logger('Compiler');
@@ -10,7 +10,7 @@ const Compiler = {
     if (!FileSystem.exists(truffleBin)) truffleBin = 'truffle'; // Attempt to load global truffle if local was not found
 
     return new Promise((resolve, reject) => {
-      exec(`${truffleBin} compile --all`, (error, stdout, stderr) => {
+      execFile(truffleBin, ['compile', '--all'], (error: ExecException, stdout, stderr) => {
         if (error) {
           if (error.code === 127) console.error('Could not find truffle executable. Please install it by running: npm install truffle');
           reject(error);


### PR DESCRIPTION
Use execFile to provide path to file and options separately, instead of using plain exec with a manually built command string.

Fixes #708