### PR TITLE
zos add --all should only add non-library project contracts

### DIFF
--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -21,7 +21,7 @@ contract ChildImplV1 is ImplV1 {
   }
 }
 
-contract WithExternalPackageImplV1 is ImplV1, GreeterImpl {
+contract WithExternalContractImplV1 is ImplV1, GreeterImpl {
   function say(string memory phrase) public pure returns(string memory) {
     return phrase.wrap();
   }

--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.0;
 
 import "./Libraries.sol";
+import "mock-stdlib/contracts/GreeterImpl.sol";
 
 contract ImplV1 {
   uint256 public value;
@@ -17,6 +18,12 @@ contract ImplV1 {
 contract ChildImplV1 is ImplV1 {
   function say() public pure returns (string memory) {
     return "ChildV1";
+  }
+}
+
+contract WithExternalPackageImplV1 is ImplV1, GreeterImpl {
+  function say(string phrase) public pure returns(string) {
+    return phrase.wrap();
   }
 }
 

--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -22,7 +22,7 @@ contract ChildImplV1 is ImplV1 {
 }
 
 contract WithExternalPackageImplV1 is ImplV1, GreeterImpl {
-  function say(string phrase) public pure returns(string) {
+  function say(string memory phrase) public pure returns(string memory) {
     return phrase.wrap();
   }
 }

--- a/packages/cli/contracts/mocks/ImplV2.sol
+++ b/packages/cli/contracts/mocks/ImplV2.sol
@@ -18,7 +18,7 @@ contract ChildImplV2 is ImplV2 {
   }
 }
 
-contract WithExternalPackageImplV2 is ImplV2, GreeterImpl {
+contract WithExternalContractImplV2 is ImplV2, GreeterImpl {
   function say(string memory phrase) public pure returns(string memory) {
     return phrase.wrap();
   }

--- a/packages/cli/contracts/mocks/ImplV2.sol
+++ b/packages/cli/contracts/mocks/ImplV2.sol
@@ -18,6 +18,12 @@ contract ChildImplV2 is ImplV2 {
   }
 }
 
+contract WithExternalPackageImplV2 is ImplV2, GreeterImpl {
+  function say(string phrase) public pure returns(string) {
+    return phrase.wrap();
+  }
+}
+
 contract WithLibraryImplV2 is ImplV2 {
   using UintLib for uint256;
 

--- a/packages/cli/contracts/mocks/ImplV2.sol
+++ b/packages/cli/contracts/mocks/ImplV2.sol
@@ -19,7 +19,7 @@ contract ChildImplV2 is ImplV2 {
 }
 
 contract WithExternalPackageImplV2 is ImplV2, GreeterImpl {
-  function say(string phrase) public pure returns(string) {
+  function say(string memory phrase) public pure returns(string memory) {
     return phrase.wrap();
   }
 }

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -72,8 +72,11 @@ const Truffle = {
         .filter((name) => {
           const contract = FileSystem.parseJsonIfExists(`${buildDir}/${name}`);
           if (contract) {
+            let isLibrary = contract.ast ? contract.ast.nodes[1].contractKind === "library" : false;
             const projectDir = buildDir.replace('build/contracts', '');
-            return contract.bytecode.length > 2 && contract.sourcePath.indexOf(projectDir) === 0;
+            return (contract.bytecode.length > 2 &&
+                    contract.sourcePath.indexOf(projectDir) === 0) &&
+                    !isLibrary
           } else return false;
         })
         .map((name) => name.replace('.json', ''));

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -71,12 +71,13 @@ const Truffle = {
         .filter((name) => {
           const contract = FileSystem.parseJsonIfExists(`${buildDir}/${name}`);
           if (contract) {
-            const isLibrary = contract.ast && contract.ast.nodes.find((node) => node.name === contract.contractName && node.contractKind === 'library');
+            const isLibrary = contract.ast && contract.ast.nodes
+              .find((node) => node.name === contract.contractName && node.contractKind === 'library');
             const projectDir = buildDir.replace('build/contracts', '');
 
-            return (contract.bytecode.length > 2 &&
-                    contract.sourcePath.indexOf(projectDir) === 0 &&
-                    !isLibrary);
+            return !isLibrary
+                    && contract.sourcePath.indexOf(projectDir) === 0
+                    && contract.bytecode.length > 2;
           } else return false;
         })
         .map((name) => name.replace('.json', ''));

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -75,8 +75,8 @@ const Truffle = {
             let isLibrary = contract.ast ? contract.ast.nodes[1].contractKind === "library" : false;
             const projectDir = buildDir.replace('build/contracts', '');
             return (contract.bytecode.length > 2 &&
-                    contract.sourcePath.indexOf(projectDir) === 0) &&
-                    !isLibrary
+                    contract.sourcePath.indexOf(projectDir) === 0 &&
+                    !isLibrary);
           } else return false;
         })
         .map((name) => name.replace('.json', ''));

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -1,6 +1,5 @@
 import pickBy from 'lodash.pickby';
 import pick from 'lodash.pick';
-import { promisify } from 'util';
 import { FileSystem } from 'zos-lib';
 
 const Truffle = {
@@ -72,7 +71,7 @@ const Truffle = {
         .filter((name) => {
           const contract = FileSystem.parseJsonIfExists(`${buildDir}/${name}`);
           if (contract) {
-            const isLibrary = contract.ast ? contract.ast.nodes[1].contractKind === "library" : false;
+            const isLibrary = contract.ast && contract.ast.nodes.find((node) => node.name === contract.contractName && node.contractKind === 'library');
             const projectDir = buildDir.replace('build/contracts', '');
 
             return (contract.bytecode.length > 2 &&

--- a/packages/cli/src/models/initializer/truffle/Truffle.ts
+++ b/packages/cli/src/models/initializer/truffle/Truffle.ts
@@ -72,8 +72,9 @@ const Truffle = {
         .filter((name) => {
           const contract = FileSystem.parseJsonIfExists(`${buildDir}/${name}`);
           if (contract) {
-            let isLibrary = contract.ast ? contract.ast.nodes[1].contractKind === "library" : false;
+            const isLibrary = contract.ast ? contract.ast.nodes[1].contractKind === "library" : false;
             const projectDir = buildDir.replace('build/contracts', '');
+
             return (contract.bytecode.length > 2 &&
                     contract.sourcePath.indexOf(projectDir) === 0 &&
                     !isLibrary);

--- a/packages/cli/src/models/local/LocalController.ts
+++ b/packages/cli/src/models/local/LocalController.ts
@@ -64,10 +64,10 @@ export default class LocalController {
       const path = `${buildFolder}/${file}`;
       if(this.hasBytecode(path)) {
         const contractData = fs.parseJson(path);
-        const isLibrary = contractData.ast.nodes[1].contractKind === "library";
         const isProjectContract = contractData.sourcePath.indexOf(sourceFolder) === 0;
+        const isLibrary = contractData.ast && contractData.ast.nodes.find((node) => node.name === contractData.contractName && node.contractKind === 'library');
 
-        if (!isLibrary && isProjectContract) {
+        if (isProjectContract && !isLibrary) {
           const contractName = contractData.contractName;
           this.add(contractName, contractName);
         }

--- a/packages/cli/src/models/local/LocalController.ts
+++ b/packages/cli/src/models/local/LocalController.ts
@@ -65,7 +65,8 @@ export default class LocalController {
       if(this.hasBytecode(path)) {
         const contractData = fs.parseJson(path);
         const isProjectContract = contractData.sourcePath.indexOf(sourceFolder) === 0;
-        const isLibrary = contractData.ast && contractData.ast.nodes.find((node) => node.name === contractData.contractName && node.contractKind === 'library');
+        const isLibrary = contractData.ast && contractData.ast.nodes
+          .find((node) => node.name === contractData.contractName && node.contractKind === 'library');
 
         if (isProjectContract && !isLibrary) {
           const contractName = contractData.contractName;

--- a/packages/cli/test/scripts/add.test.js
+++ b/packages/cli/test/scripts/add.test.js
@@ -79,7 +79,7 @@ contract('add script', function() {
     this.packageFile.contract('ImplV2').should.eq('ImplV2')
   })
 
-  it('should not add solidity libraries or external packages when adding all', function() {
+  it('should not add solidity libraries or contracts from external packages when adding all', function() {
     addAll({ packageFile: this.packageFile })
 
     expect(this.packageFile.contract('Initializable')).to.be.undefined

--- a/packages/cli/test/scripts/add.test.js
+++ b/packages/cli/test/scripts/add.test.js
@@ -11,10 +11,11 @@ import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 contract('add script', function() {
   const contractName = 'ImplV1';
   const contractAlias = 'Impl';
+
   const contractsData = [{ name: contractName, alias: contractAlias }]
 
   beforeEach('setup', async function() {
-    this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+    this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-stdlib.zos.json')
   });
 
   it('should add a logic contract an alias and a filename', function() {
@@ -74,11 +75,20 @@ contract('add script', function() {
   it('should add all contracts in build contracts dir', function() {
     addAll({ packageFile: this.packageFile })
 
-    expect(this.packageFile.contract('Initializable')).to.be.undefined
-    expect(this.packageFile.contract('UintLib')).to.be.undefined
     this.packageFile.contract('ImplV1').should.eq('ImplV1')
     this.packageFile.contract('ImplV2').should.eq('ImplV2')
   })
+
+  it('should not add solidity libraries or external packages when adding all', function() {
+    addAll({ packageFile: this.packageFile })
+
+    expect(this.packageFile.contract('Initializable')).to.be.undefined
+    expect(this.packageFile.contract('GreeterImpl')).to.be.undefined
+    expect(this.packageFile.contract('GreeterLib')).to.be.undefined
+    expect(this.packageFile.contract('UintLib')).to.be.undefined
+    this.packageFile.contract('WithExternalPackageImplV1').should.eq('WithExternalPackageImplV1')
+    this.packageFile.contract('WithExternalPackageImplV2').should.eq('WithExternalPackageImplV2')
+  });
 
   describe('failures', function () {
     it('should fail to add a contract that does not exist', function() {

--- a/packages/cli/test/scripts/add.test.js
+++ b/packages/cli/test/scripts/add.test.js
@@ -74,6 +74,8 @@ contract('add script', function() {
   it('should add all contracts in build contracts dir', function() {
     addAll({ packageFile: this.packageFile })
 
+    expect(this.packageFile.contract('Initializable')).to.be.undefined
+    expect(this.packageFile.contract('UintLib')).to.be.undefined
     this.packageFile.contract('ImplV1').should.eq('ImplV1')
     this.packageFile.contract('ImplV2').should.eq('ImplV2')
   })

--- a/packages/cli/test/scripts/add.test.js
+++ b/packages/cli/test/scripts/add.test.js
@@ -11,7 +11,6 @@ import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 contract('add script', function() {
   const contractName = 'ImplV1';
   const contractAlias = 'Impl';
-
   const contractsData = [{ name: contractName, alias: contractAlias }]
 
   beforeEach('setup', async function() {
@@ -86,8 +85,8 @@ contract('add script', function() {
     expect(this.packageFile.contract('GreeterImpl')).to.be.undefined
     expect(this.packageFile.contract('GreeterLib')).to.be.undefined
     expect(this.packageFile.contract('UintLib')).to.be.undefined
-    this.packageFile.contract('WithExternalPackageImplV1').should.eq('WithExternalPackageImplV1')
-    this.packageFile.contract('WithExternalPackageImplV2').should.eq('WithExternalPackageImplV2')
+    this.packageFile.contracts.should.have.property('WithExternalContractImplV1');
+    this.packageFile.contracts.should.have.property('WithExternalContractImplV2');
   });
 
   describe('failures', function () {


### PR DESCRIPTION
Addresses #754

This fixes the issue where `zos add --all` adds non-project and library contracts. I identified project contracts by recursing through the contracts directory and aggregating an array of contract names stripped of file extensions. We then check against that array of project contracts while going through the built contracts to add and only add those that are found in the project. 

Libraries are excluded by checking the through the contracts' compiled JSON interface, this may be fragile as it appeared on first glance that the `contractKind` always appears on the second element of the `contractData.ast.nodes` array - if that's not the case it would be simple to refactor this to iteratively check for that value.