### PR TITLE
interactive push (first part)

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -46,9 +46,9 @@ async function action(options: any): Promise<void> {
   Session.setDefaultNetworkIfNeeded(promptedOpts.network);
 
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(promptedOpts);
-  const promptDepenencyDeploy = await promptForDependencyDeploy(deployDependencies, network);
+  const promptDeployDependencies = await promptForDeployDependencies(deployDependencies, network);
 
-  await push({ force, reupload, network, txParams, ...promptDepenencyDeploy });
+  await push({ force, reupload, network, txParams, ...promptDeployDependencies });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }
 
@@ -60,7 +60,7 @@ async function tryAction(externalOptions: any): Promise<void> {
   return action(options);
 }
 
-async function promptForDependencyDeploy(deployDependencies, network) {
+async function promptForDeployDependencies(deployDependencies, network): Promise<{ deployDependencies: boolean }> {
   if (await ZWeb3.isGanacheNode()) return { deployDependencies: true };
   if (Dependency.hasDependenciesForDeploy(network)) {
     return promptIfNeeded({ opts: { deployDependencies }, props: props(network) });

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -38,10 +38,11 @@ const register: (program: any) => any = (program) => program
 async function action(options: any): Promise<void> {
   const { force, deployDependencies, reset: reupload, network: networkInArgs } = options;
   const { network: networkInSession } = Session.getOptions();
+  const defaultArgs = { network: Session.getDefaultNetwork() };
   const defaultOpts = { network: networkInSession || networkInArgs };
   if (!options.skipCompile) await Compiler.call();
 
-  const promptedOpts = await promptIfNeeded({ opts: defaultOpts, props: props() });
+  const promptedOpts = await promptIfNeeded({ opts: defaultOpts, defaults: defaultArgs, props: props() });
   Session.setDefaultNetworkIfNeeded(promptedOpts.network);
 
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(promptedOpts);

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -77,6 +77,11 @@ export default class ZosNetworkFile {
     return file ? file.zosversion : null;
   }
 
+  public static getDependencies(fileName: string): { [key: string]: any } | undefined {
+    const file = fs.parseJsonIfExists(fileName);
+    return file ? file.dependencies : undefined;
+  }
+
   // TS-TODO: type for network parameter (and class member too).
   constructor(packageFile: ZosPackageFile, network: any, fileName: string) {
     this.packageFile = packageFile;

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -16,12 +16,12 @@ interface GenericObject {
 // TS-TODO: Define a more accurate return type as soon as we know the final structure of it
 export async function promptIfNeeded({ args = {}, opts = {}, defaults, props }: Args, interactive: boolean = true): Promise<any> {
   const argsQuestions = Object.keys(args)
-    .filter((argName) => args[argName] === undefined || isEmpty(args[argName]))
-    .map((argName) => promptFor(argName, defaults, props));
+    .filter(argName => args[argName] === undefined || isEmpty(args[argName]))
+    .map(argName => promptFor(argName, defaults, props));
 
   const optsQuestions = Object.keys(opts)
-    .filter((optName) => opts[optName] === undefined)
-    .map((optName) => promptFor(optName, defaults, props));
+    .filter(optName => opts[optName] === undefined)
+    .map(optName => promptFor(optName, defaults, props));
 
   return interactive
     ? { ...args, ...opts, ...await answersFor(argsQuestions), ...await answersFor(optsQuestions) }

--- a/packages/cli/test/commands/add.test.js
+++ b/packages/cli/test/commands/add.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('add command', function() {
-
+describe('add command', function() {
   stubCommands()
 
   itShouldParse('should call add script with an alias and a filename', 'add', 'zos add ImplV1:Impl --skip-compile', function(add) {
@@ -16,7 +15,6 @@ contract('add command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos add --all --push test --skip-compile', function(push) {
-    push.should.have.been.calledWithExactly({  deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/bump.test.js
+++ b/packages/cli/test/commands/bump.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('bump command', function() {
-
+describe('bump command', function() {
   stubCommands()
 
   itShouldParse('should call bump script with version', 'bump', 'zos bump 0.2.0 ', function(bump) {
@@ -12,7 +11,7 @@ contract('bump command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos bump 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({  deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
 })

--- a/packages/cli/test/commands/check.test.js
+++ b/packages/cli/test/commands/check.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('check command', function() {
-
+describe('check command', function() {
   stubCommands()
 
   itShouldParse('should call check script with an alias', 'check', 'zos check Impl --skip-compile', function(check) {
@@ -14,5 +13,4 @@ contract('check command', function() {
   itShouldParse('should call check script for all contracts', 'check', 'zos check --skip-compile', function(check) {
     check.should.have.been.calledWithExactly({ contractAlias: undefined })
   })
-  
 })

--- a/packages/cli/test/commands/create.test.js
+++ b/packages/cli/test/commands/create.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('create command', function() {
-
+describe('create command', function() {
   stubCommands()
 
   itShouldParse('should call create script with options', 'create', 'zos create Impl --network test --init setup --args 42 --force --from 0x40', function(create) {
@@ -30,5 +29,4 @@ contract('create command', function() {
   itShouldParse('should call create script with contract from package with slashes', 'create', 'zos create Zeppelin/OpenZeppelin/Impl --network test', function(create) {
     create.should.have.been.calledWithExactly( { packageName: 'Zeppelin/OpenZeppelin', contractAlias: 'Impl', network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/freeze.test.js
+++ b/packages/cli/test/commands/freeze.test.js
@@ -1,14 +1,12 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('freeze command', function() {
-
+describe('freeze command', function() {
   stubCommands()
 
   itShouldParse('should call freeze script with network option', 'freeze', 'zos freeze --network test', function(freeze) {
     freeze.should.have.been.calledWithExactly({ network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('init command', function() {
-
+describe('init command', function() {
   stubCommands()
 
   itShouldParse('should call init script with name, version and dependencies', 'init', 'zos init MyApp 0.2.0 --force --no-install --link mock-stdlib@1.1.0,mock-stdlib2@1.2.0', function(init) {
@@ -13,11 +12,10 @@ contract('init command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos init MyApp 0.2.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({  deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
 
   itShouldParse('should call init script with light flag', 'init', 'zos init MyApp 0.2.0 --publish', function(init) {
     init.should.have.been.calledWithExactly({ name: 'MyApp', version: '0.2.0', publish: true, force: undefined, installDependencies: undefined, dependencies: [] })
   })
-
 })

--- a/packages/cli/test/commands/link.test.js
+++ b/packages/cli/test/commands/link.test.js
@@ -3,8 +3,7 @@ require('../setup')
 
 import { stubCommands, itShouldParse } from './share';
 
-contract('link command', function() {
-
+describe('link command', function() {
   stubCommands()
 
   itShouldParse('should call link script with a list of dependencies and no install', 'link', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --no-install --no-interactive', function(link) {
@@ -13,7 +12,6 @@ contract('link command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos link mock-stdlib@1.1.0 mock-stdlib2@1.2.0 --push test --no-interactive', function(push) {
-    push.should.have.been.calledWithExactly({ deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/publish.test.js
+++ b/packages/cli/test/commands/publish.test.js
@@ -1,14 +1,12 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('publish command', function() {
-
+describe('publish command', function() {
   stubCommands()
 
   itShouldParse('should call publish script with network', 'publish', 'zos publish --network test', function(publish) {
     publish.should.have.been.calledWithExactly({ network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -1,14 +1,30 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { ZWeb3 } from 'zos-lib';
+import sinon from 'sinon';
+import { stubCommands, itShouldParse } from './share';
 
-contract('push command', function() {
-
+describe('push command', function() {
   stubCommands()
 
-  itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f', function(push) {
-    push.should.have.been.calledWithExactly({ force: true, deployDependencies: true, reupload: true, network: 'test', txParams: {} })
-  })
+  context('when network uses ganache', function() {
+    itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f', function(push) {
+      push.should.have.been.calledWithExactly({ force: true, deployDependencies: true, reupload: true, network: 'test', txParams: {} })
+    })
+  });
 
+  context('when network does not use ganache', function () {
+    before('stub ZWeb3#isGanacheNode', function() {
+      sinon.stub(ZWeb3, 'isGanacheNode').returns(false);
+    })
+
+    after('restore stub', function() {
+      sinon.restore();
+    })
+
+    itShouldParse('should call push script with options', 'push', 'zos push --network test --skip-compile -d --reset -f', function(push) {
+      push.should.have.been.calledWithExactly({ force: true, deployDependencies: undefined, reupload: true, network: 'test', txParams: {} })
+    })
+  })
 })

--- a/packages/cli/test/commands/remove.test.js
+++ b/packages/cli/test/commands/remove.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('remove command', function() {
-
+describe('remove command', function() {
   stubCommands()
 
   itShouldParse('should call remove script', 'remove', 'zos remove Impl', function(remove) {
@@ -12,7 +11,6 @@ contract('remove command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos remove Impl --push test', function(push) {
-    push.should.have.been.calledWithExactly({  deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({  deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/session.test.js
+++ b/packages/cli/test/commands/session.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('session command', function() {
-
+describe('session command', function() {
   stubCommands()
 
   itShouldParse('should call session script with --expires option', 'session', 'zos session --network test --expires 3600', function(session) {

--- a/packages/cli/test/commands/setAdmin.test.js
+++ b/packages/cli/test/commands/setAdmin.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('set-admin command', function() {
-
+describe('set-admin command', function() {
   stubCommands()
 
   itShouldParse('should call set-admin script with proxy address', 'setAdmin', 'zos set-admin 0x20 0x30 -y --network test', function(update) {
@@ -22,5 +21,4 @@ contract('set-admin command', function() {
   itShouldParse('should call set-admin script with package name and contract name', 'setAdmin', 'zos set-admin OpenZeppelin/Impl 0x30 -y --network test ', function(update) {
     update.should.have.been.calledWith( { packageName: "OpenZeppelin", contractAlias: "Impl", newAdmin: "0x30", network: 'test', txParams: { } } )
   })
-
 })

--- a/packages/cli/test/commands/status.test.js
+++ b/packages/cli/test/commands/status.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('status command', function() {
-
+describe('status command', function() {
   stubCommands()
 
   itShouldParse('should call status script', 'status', 'zos status --network test', function(status) {
@@ -18,5 +17,4 @@ contract('status command', function() {
   itShouldParse('should call compare script when passing --fetch option', 'compare', 'zos status --network test --fetch', function(compare) {
     compare.should.have.been.calledWithExactly({ network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/unlink.test.js
+++ b/packages/cli/test/commands/unlink.test.js
@@ -3,7 +3,7 @@ require('../setup')
 
 import { stubCommands, itShouldParse } from './share'
 
-contract('unlink command', function() {
+describe('unlink command', function() {
   stubCommands()
 
   itShouldParse('calls unlink script with a dependency name as parameter', 'unlink', 'zos unlink mock-stdlib@1.1.0 mock-stdlib2@1.1.0', function(unlink) {
@@ -12,7 +12,6 @@ contract('unlink command', function() {
   })
 
   itShouldParse('should call push script when passing --push option', 'push', 'zos unlink mock-stdlib@1.1.0 --push test', function(push) {
-    push.should.have.been.calledWithExactly({ deployDependencies: undefined, force: undefined, reupload: undefined, network: 'test', txParams: {} })
+    push.should.have.been.calledWithExactly({ deployDependencies: true, force: undefined, reupload: undefined, network: 'test', txParams: {} })
   })
-
 })

--- a/packages/cli/test/commands/update.test.js
+++ b/packages/cli/test/commands/update.test.js
@@ -1,10 +1,9 @@
 'use strict'
 require('../setup')
 
-import {stubCommands, itShouldParse} from './share';
+import { stubCommands, itShouldParse } from './share';
 
-contract('update command', function() {
-
+describe('update command', function() {
   stubCommands()
 
   itShouldParse('should call update script with options', 'update', 'zos update --network test --all --init initialize --args 42 --force --from 0x40', function(update) {
@@ -26,5 +25,4 @@ contract('update command', function() {
   itShouldParse('should call update script with address', 'update', 'zos update 0x80 --network test', function(update) {
     update.should.have.been.calledWith( { proxyAddress: '0x80', network: 'test', txParams: {} } )
   })
-
 })

--- a/packages/cli/test/commands/verify.test.js
+++ b/packages/cli/test/commands/verify.test.js
@@ -3,12 +3,11 @@ require('../setup')
 
 import { stubCommands, itShouldParse } from './share'
 
-contract('verify command', function() {
+describe('verify command', function() {
   stubCommands()
 
   itShouldParse('calls verify with options', 'verify', 'zos verify Impl --network rinkeby --remote etherscan --optimizer --optimizer-runs 150 --api-key AP1-K3Y', function(verify) {
     const args = { optimizer: true, optimizerRuns: '150', apiKey: 'AP1-K3Y', remote: 'etherscan', network: 'rinkeby', txParams: {} }
     verify.should.have.been.calledWithMatch('Impl', args)
   })
-
 })

--- a/packages/cli/test/mocks/networks/network-with-stdlibs.zos.test.json
+++ b/packages/cli/test/mocks/networks/network-with-stdlibs.zos.test.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.1.0",
+  "zosversion": "2.2",
+  "contracts": {},
+  "dependencies": {
+    "mock-stdlib": {
+      "version": "^1.1.0",
+      "package": "0x0000000000000000000000000000000000000210"
+    },
+    "mock-stdlib-2": {
+      "version": "^1.2.0",
+      "package": "0x0000000000000000000000000000000000000210"
+    }
+  }
+}

--- a/packages/cli/test/models/Dependency.test.js
+++ b/packages/cli/test/models/Dependency.test.js
@@ -4,6 +4,7 @@ require('../setup')
 
 import sinon from 'sinon'
 import npm from 'npm-programmatic'
+import { FileSystem as fs } from 'zos-lib'
 import Dependency from '../../src/models/dependency/Dependency'
 
 contract('Dependency', function([_, from]) {
@@ -48,6 +49,36 @@ contract('Dependency', function([_, from]) {
       })
     })
 
+
+    describe('#hasDependenciesForDeploy', function() {
+      afterEach('restore sinon', function() {
+        sinon.restore()
+      })
+
+      context('when there are dependencies to deploy', function() {
+        it('returns true', function () {
+          const projectPackageFile = fs.parseJsonIfExists('test/mocks/packages/package-with-multiple-stdlibs.zos.json')
+          const projectNetworkFile = fs.parseJsonIfExists('test/mocks/networks/network-with-stdlibs.zos.test.json')
+          const stubbedParseJsonIfExists = sinon.stub(fs, 'parseJsonIfExists')
+          stubbedParseJsonIfExists.withArgs('zos.json').returns(projectPackageFile)
+          stubbedParseJsonIfExists.withArgs('zos.test.json').returns(projectNetworkFile)
+
+          Dependency.hasDependenciesForDeploy('test').should.be.true
+        })
+      })
+
+      context('when all dependencies are already deployed', function() {
+        it('returns false', function() {
+          const projectPackageFile = fs.parseJsonIfExists('test/mocks/packages/package-with-stdlib.zos.json')
+          const projectNetworkFile = fs.parseJsonIfExists('test/mocks/networks/network-with-stdlibs.zos.test.json')
+          const stubbedParseJsonIfExists = sinon.stub(fs, 'parseJsonIfExists')
+          stubbedParseJsonIfExists.withArgs('zos.json').returns(projectPackageFile)
+          stubbedParseJsonIfExists.withArgs('zos.test.json').returns(projectNetworkFile)
+
+          Dependency.hasDependenciesForDeploy('test').should.be.false
+        })
+      })
+    })
   })
 
   describe('#constructor', function() {

--- a/packages/cli/test/models/ZosNetworkFile.test.js
+++ b/packages/cli/test/models/ZosNetworkFile.test.js
@@ -12,6 +12,25 @@ contract('ZosNetworkFile', function() {
     this.appPackageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
   })
   
+  describe('class methods', function () {
+    describe('#getDependencies', function () {
+      context('on network file with dependencies', function () {
+        it('returns an object with dependencies', function () {
+          const dependencies = ZosNetworkFile.getDependencies('test/mocks/networks/network-with-stdlibs.zos.test.json')
+          dependencies.should.not.be.empty
+          dependencies.should.have.all.keys('mock-stdlib', 'mock-stdlib-2')
+        })
+      })
+
+      context('on network file without dependencies', function () {
+        it('returns an empty object', function () {
+          const dependencies = ZosNetworkFile.getDependencies('test/mocks/networks/network-app-with-contract.zos.test.json')
+          expect(dependencies).to.be.undefined
+        })
+      })
+    })
+  })
+
   describe('constructor', function () {
     it('creates empty file', function () {
       const file = new ZosNetworkFile(this.appPackageFile, 'test', 'test/mocks/networks/new.test.json')

--- a/packages/cli/test/scripts/session.test.js
+++ b/packages/cli/test/scripts/session.test.js
@@ -11,22 +11,22 @@ describe('session script', function () {
   const opts = { network: 'foo', from: '0x1', timeout: 10 }
 
   describe('opening a new session', function () {
-    describe('when there was no session opened before', function () {
-      describe('when the time out does not expire', function () {
+    context('when there was no session opened before', function () {
+      context('when the time out does not expire', function () {
         beforeEach(function () {
           session(opts)
         })
 
         it('sets the new options', function () {
-          Session.getOptions().should.be.deep.equal(opts)
+          Session.getOptions().should.include(opts)
         })
 
         it('merges given options with session defaults', function () {
-          Session.getOptions({ from: '0x2' }).should.be.deep.equal({ network: 'foo', timeout: 10, from: '0x2' })
+          Session.getOptions({ from: '0x2' }).should.include({ network: 'foo', timeout: 10, from: '0x2' })
         })
       })
 
-      describe('when the time out expires', function () {
+      context('when the time out expires', function () {
         it('clears all options', function () {
           session({ ... opts, expires: 0 })
           Session.getOptions().should.be.deep.equal({ timeout: DEFAULT_TX_TIMEOUT })
@@ -38,17 +38,17 @@ describe('session script', function () {
       })
     })
 
-    describe('when there was a session opened before', function () {
+    context('when there was a session opened before', function () {
       beforeEach(() => session(opts))
 
-      describe('when the time out does not expire', function () {
+      context('when the time out does not expire', function () {
         it('replaces all options', function () {
           session({ network: 'bar' })
-          Session.getOptions().should.be.deep.equal({ network: 'bar', timeout: DEFAULT_TX_TIMEOUT })
+          Session.getOptions().should.include({ network: 'bar', timeout: DEFAULT_TX_TIMEOUT })
         })
       })
 
-      describe('when the time out expires', function () {
+      context('when the time out expires', function () {
         it('clears all options', function () {
           session({ network: 'bar', expires: 0 })
           Session.getOptions().should.be.deep.equal({ timeout: DEFAULT_TX_TIMEOUT })
@@ -58,14 +58,14 @@ describe('session script', function () {
   })
 
   describe('closing a session', function () {
-    describe('when there was no session opened before', function () {
+    context('when there was no session opened before', function () {
       it('sets the new network', function () {
         session({ close: true })
         Session.getOptions().should.be.deep.equal({ timeout: DEFAULT_TX_TIMEOUT })
       })
     })
 
-    describe('when there was a session opened before', function () {
+    context('when there was a session opened before', function () {
       beforeEach(() => session(opts))
 
       it('replaces the previous network', function () {
@@ -76,13 +76,13 @@ describe('session script', function () {
   })
 
   describe('arguments', function () {
-    describe('when no arguments are given', function () {
+    context('when no arguments are given', function () {
       it('throws an error', function () {
         expect(() => session({})).to.throw('Please provide either a network option (--network, --timeout, --from) or --close.')
       })
     })
 
-    describe('when both arguments are given', function () {
+    context('when both arguments are given', function () {
       it('throws an error', function () {
         expect(() => session({ network: 'boo', close: true })).to.throw('Please provide either a network option (--network, --timeout, --from) or --close.')
       })

--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,8 @@
       "adjacent-overload-signatures": [false],
       "no-string-literal": [false],
       "max-classes-per-file": [false],
-      "one-variable-per-declaration": [false]
+      "one-variable-per-declaration": [false],
+      "arrow-parens": [false]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Fixes #707, fixes #716.

This PR includes:
- Automatic deployment of dependencies if working with `ganache`
- Prompt to deploy dependencies if necessary
- Save last network used for using it as default for next time

![interactive-push](https://i.ibb.co/ccmGcCX/interactive-push.gif)

EDIT: I also refactored a bit the commands tests. Sorry for doing  this here PR :eyes: 