### PR TITLE
feature/check address prior running create2 #774

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -505,6 +505,12 @@ export default class NetworkController {
     this.checkInitialization(contract, initMethod, initArgs);
 
     const createArgs = { packageName, contractName: contractAlias, initMethod, initArgs };
+
+    if (salt) {
+      const deploymentAddress = await this.getProxyDeploymentAddress(salt);
+      if (await ZWeb3.getCode(deploymentAddress) != '0x') throw new Error("deployment address already in use");
+    }
+
     const proxyInstance = salt
       ? await this.project.createProxyWithSalt(contract, salt, createArgs)
       : await this.project.createProxy(contract, createArgs);

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -506,10 +506,7 @@ export default class NetworkController {
 
     const createArgs = { packageName, contractName: contractAlias, initMethod, initArgs };
 
-    if (salt) {
-      const deploymentAddress = await this.getProxyDeploymentAddress(salt);
-      if (await ZWeb3.getCode(deploymentAddress) != '0x') throw new Error("deployment address already in use");
-    }
+    if (salt) await this._checkDeploymentAddress(salt);
 
     const proxyInstance = salt
       ? await this.project.createProxyWithSalt(contract, salt, createArgs)
@@ -535,6 +532,12 @@ export default class NetworkController {
     this._tryRegisterProxyFactory();
 
     return address;
+  }
+
+  // Proxy model
+  private async _checkDeploymentAddress(salt: string) {
+    const deploymentAddress = await this.getProxyDeploymentAddress(salt);
+    if (await ZWeb3.getCode(deploymentAddress) != '0x') throw new Error(`Deployment address for salt ${salt} is already in use`);
   }
 
   // Proxy model
@@ -777,6 +780,6 @@ export default class NetworkController {
 
   private _updateZosVersionsIfNeeded(version) {
     if(this.networkFile.zosversion !== ZOS_VERSION) this.networkFile.zosversion = version;
-    if(this.packageFile.zosversion !== ZOS_VERSION)this.packageFile.zosversion = version;
+    if(this.packageFile.zosversion !== ZOS_VERSION) this.packageFile.zosversion = version;
   }
 }

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -167,6 +167,13 @@ contract('create script', function([_, owner]) {
       predictedAddress.should.equalIgnoreCase(proxyInfo.address, "Predicted address does not match actualy deployment address");
     });
 
+    it('should fail if an address is already in use when creating a proxy with create2', async function () {
+      const salt = random(0, 2**32);
+      await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt });
+      await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt })
+        .should.be.rejectedWith(/deployment address already in use/);
+    });
+
     describe('warnings', function () {
       beforeEach('capturing log output', function () {
         this.logs = new CaptureLogs();

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -167,7 +167,7 @@ contract('create script', function([_, owner]) {
       predictedAddress.should.equalIgnoreCase(proxyInfo.address, "Predicted address does not match actualy deployment address");
     });
 
-    it('should fail if an address is already in use when creating a proxy with create2', async function () {
+    it('should fail if an address is already in use when creating a proxy with a salt', async function () {
       const salt = random(0, 2**32);
       await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt });
       await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt })

--- a/packages/cli/test/scripts/create.test.js
+++ b/packages/cli/test/scripts/create.test.js
@@ -171,7 +171,7 @@ contract('create script', function([_, owner]) {
       const salt = random(0, 2**32);
       await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt });
       await create({ contractAlias, network, txParams, networkFile: this.networkFile, salt })
-        .should.be.rejectedWith(/deployment address already in use/);
+        .should.be.rejectedWith(/Deployment address for salt \d+ is already in use/);
     });
 
     describe('warnings', function () {


### PR DESCRIPTION
I wanted to look at the `create2` stuff a bit more and this seemed like a good issue(#774) to dive into it with. Added a check in `NetworkController.createProxy` to ensure the deployment address isn't occupied prior to calling `createProxyWithSalt`. Added a case to `create.test.js` covering this change.

