### PR TITLE
Adds ability to change owner of a proxy admin to set-admin command

### DIFF
--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -1,4 +1,5 @@
 import pickBy from 'lodash.pickby';
+import inquirer from 'inquirer';
 
 import setAdmin from '../scripts/set-admin';
 import { fromContractFullName } from '../utils/naming';
@@ -7,13 +8,16 @@ import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesIni
 
 const name: string = 'set-admin';
 const signature: string = `${name} [alias-or-address] [new-admin-address]`;
-const description: string = 'change upgradeability admin of a contract instance. Provide the [alias] or [package]/[alias] of the contract to change the ownership of all its instances, or its [address] to change a single one. Note that if you transfer to an incorrect address, you may irreversibly lose control over upgrading your contract.';
+const description: string = `change upgradeability admin of a contract instance, all instances or proxy admin.
+Provide the [alias] or [package]/[alias] of the contract to change the ownership of all its instances,
+or its [address] to change a single one, or none to change all contract instances to a new admin. 
+Note that if you transfer to an incorrect address, you may irreversibly lose control over upgrading your contract.`;
 
 const register: (program: any) => any = (program) => program
   .command(signature, undefined, { noHelp: true })
   .usage('[alias-or-address] [new-admin-address] --network <network> [options]')
   .description(description)
-  .option('-y, --yes', 'accept transferring admin rights (required)')
+  .option('-f, --force', 'bypass a manual check')
   .withNetworkOptions()
   .action(action);
 
@@ -21,14 +25,30 @@ async function action(contractFullNameOrAddress: string, newAdmin: string, optio
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(options);
   if (!await hasToMigrateProject(network)) process.exit(0);
 
-  const { yes } = options;
-  if (!yes) {
-    throw Error('This is a potentially irreversible operation: if you specify an incorrect admin address, you may lose the ability to upgrade your contract forever.\nPlease double check all parameters, and run the same command with --yes.');
-  }
-
   let proxyAddress;
   let contractAlias;
   let packageName;
+
+  if (!contractFullNameOrAddress) throw Error('You have to specify at least a new admin address.');
+
+  // we assume if newAdmin is empty it was specified as first argument
+  if (!newAdmin) {
+    newAdmin = contractFullNameOrAddress;
+    contractFullNameOrAddress = '';
+  }
+
+  if (!options.force) {
+    const answers = await inquirer.prompt([
+      {
+        name: 'address',
+        type: 'string',
+        message: 'Please double check your address and type the last 4 characters of the new admin address. If you provide a wrong address, you will lose control over your contracts.',
+      }
+    ]);
+    if (answers.address !== newAdmin.slice(-4)) {
+      throw Error('Last 4 characters of the admin address do not match');
+    }
+  }
 
   if (contractFullNameOrAddress && contractFullNameOrAddress.startsWith('0x')) {
     proxyAddress = contractFullNameOrAddress;

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -598,6 +598,13 @@ export default class NetworkController {
   }
 
   // Proxy model
+  public async setProxyAdminOwner(newAdminOwner: string): Promise<void> {
+    await this._migrateZosversionIfNeeded();
+    await this.fetchOrDeploy(this.currentVersion);
+    await this.project.transferAdminOwnership(newAdminOwner);
+  }
+
+  // Proxy model
   private async _changeProxiesAdmin(proxies: ProxyInterface[], newAdmin: string, project: Project = null): Promise<void> {
     if (!project) project = this.project;
     await allPromisesOrError(map(proxies, async (aProxy) => {

--- a/packages/cli/src/scripts/set-admin.ts
+++ b/packages/cli/src/scripts/set-admin.ts
@@ -4,15 +4,23 @@ import ScriptError from '../models/errors/ScriptError';
 import { SetAdminParams } from './interfaces';
 
 export default async function setAdmin({ newAdmin, packageName, contractAlias, proxyAddress, network, txParams = {}, networkFile }: SetAdminParams): Promise<void | never> {
-  if (!contractAlias && !proxyAddress) {
+  if (!contractAlias && !proxyAddress && packageName) {
     throw Error('The address or name of the contract to transfer upgradeability admin rights must be provided.');
+  }
+
+  if (!newAdmin) {
+    throw Error('The address of the new admin must be provided.');
   }
 
   const controller = new NetworkController(network, txParams, networkFile);
 
   try {
-    const proxies = await controller.setProxiesAdmin(packageName, contractAlias, proxyAddress, newAdmin);
-    proxies.forEach((proxy) => stdout(proxy.address));
+    if (contractAlias || proxyAddress) {
+      const proxies = await controller.setProxiesAdmin(packageName, contractAlias, proxyAddress, newAdmin);
+      proxies.forEach((proxy) => stdout(proxy.address));
+    } else {
+      await controller.setProxyAdminOwner(newAdmin);
+    }
     controller.writeNetworkPackageIfNeeded();
   } catch(error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();

--- a/packages/cli/test/commands/setAdmin.test.js
+++ b/packages/cli/test/commands/setAdmin.test.js
@@ -6,19 +6,23 @@ import { stubCommands, itShouldParse } from './share';
 describe('set-admin command', function() {
   stubCommands()
 
-  itShouldParse('should call set-admin script with proxy address', 'setAdmin', 'zos set-admin 0x20 0x30 -y --network test', function(update) {
+  itShouldParse('should call set-admin script with proxy address', 'setAdmin', 'zos set-admin 0x20 0x30 -f --network test', function(update) {
     update.should.have.been.calledWith( { proxyAddress: "0x20", newAdmin: "0x30", network: 'test', txParams: { } } )
   })
 
-  itShouldParse('should call set-admin script with network options', 'setAdmin', 'zos set-admin 0x20 0x30 --network test --from 0x40 -y', function(update) {
+  itShouldParse('should call set-admin script with network options', 'setAdmin', 'zos set-admin 0x20 0x30 -f --network test --from 0x40', function(update) {
     update.should.have.been.calledWith( { proxyAddress: "0x20", newAdmin: "0x30", network: 'test', txParams: { from: '0x40' } } )
   })
 
-  itShouldParse('should call set-admin script with contract name', 'setAdmin', 'zos set-admin Impl 0x30 --network test -y', function(update) {
+  itShouldParse('should call set-admin script with contract name', 'setAdmin', 'zos set-admin Impl 0x30 -f --network test', function(update) {
     update.should.have.been.calledWith( { contractAlias: "Impl", newAdmin: "0x30", network: 'test', txParams: { } } )
   })
 
-  itShouldParse('should call set-admin script with package name and contract name', 'setAdmin', 'zos set-admin OpenZeppelin/Impl 0x30 -y --network test ', function(update) {
+  itShouldParse('should call set-admin script with package name and contract name', 'setAdmin', 'zos set-admin OpenZeppelin/Impl 0x30 -f --network test ', function(update) {
     update.should.have.been.calledWith( { packageName: "OpenZeppelin", contractAlias: "Impl", newAdmin: "0x30", network: 'test', txParams: { } } )
+  })
+
+  itShouldParse('should call set-admin with new proxy admin owner address', 'setAdmin', 'zos set-admin 0x30 -f --network test ', function(update) {
+    update.should.have.been.calledWith( { newAdmin: "0x30", network: 'test', txParams: { } } )
   })
 })

--- a/packages/cli/test/scripts/set-admin.test.js
+++ b/packages/cli/test/scripts/set-admin.test.js
@@ -1,7 +1,7 @@
 'use strict'
 require('../setup')
 
-import { Proxy } from "zos-lib";
+import { Proxy, ProxyAdmin } from "zos-lib";
 
 import push from '../../src/scripts/push';
 import createProxy from '../../src/scripts/create';
@@ -45,6 +45,12 @@ contract('set-admin script', function(accounts) {
       await assertAdmin(this.withLibraryImpl.address, this.networkFile.proxyAdminAddress, this.networkFile)
     });
 
+    it('changes owner of a proxy admin', async function() {
+      await setAdmin({ newAdmin, network, txParams, networkFile: this.networkFile });
+      const newOwner = await ProxyAdmin.fetch(this.networkFile.proxyAdmin.address).getOwner();
+      newOwner.should.be.eq(newAdmin);
+    });
+
     it('changes admin of several proxies given name', async function() {
       await setAdmin({ contractAlias: 'Impl', newAdmin, network, txParams, networkFile: this.networkFile });
       
@@ -60,10 +66,6 @@ contract('set-admin script', function(accounts) {
       await assertAdmin(this.impl2.address, anotherNewAdmin, this.networkFile)
       await assertAdmin(this.withLibraryImpl.address, this.networkFile.proxyAdminAddress, this.networkFile)
     });
-
-    it('refuses to update all proxies', async function () {
-      await setAdmin({ newAdmin, network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/address or name of the contract/);
-    })
 
     it('refuses to update all proxies given package name', async function () {
       await setAdmin({ packageName: "Herbs", newAdmin, network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/address or name of the contract/);

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -130,6 +130,10 @@ export default class AppProject extends BasePackageProject {
     return new Promise((resolve) => resolve(this.proxyAdmin.address));
   }
 
+  public async transferAdminOwnership(newAdminOwner: string): Promise<void> {
+    await this.proxyAdmin.transferOwnership(newAdminOwner);
+  }
+
   public getApp(): App {
     return this.app;
   }

--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -48,4 +48,9 @@ export default class ProxyAdminProject extends BaseSimpleProject {
   public getAdminAddress(): Promise<string> {
     return new Promise((resolve) => resolve(this.proxyAdmin.address));
   }
+
+  public async transferAdminOwnership(newAdminOwner: string): Promise<void> {
+    await this.proxyAdmin.transferOwnership(newAdminOwner);
+  }
+
 }

--- a/packages/lib/src/proxy/ProxyAdmin.ts
+++ b/packages/lib/src/proxy/ProxyAdmin.ts
@@ -49,6 +49,16 @@ export default class ProxyAdmin {
     return contract.at(proxyAddress);
   }
 
+  public async transferOwnership(newAdminOwner: string): Promise<void> {
+    log.info(`Changing ownership for proxy admin to ${newAdminOwner}...`);
+    await Transactions.sendTransaction(this.contract.methods.transferOwnership, [newAdminOwner], { ...this.txParams });
+    log.info(`Owner for proxy admin set to ${newAdminOwner}`);
+  }
+
+  public async getOwner(): Promise<string> {
+    return await this.contract.methods.owner().call({ ...this.txParams });
+  }
+
   private async _upgradeProxy(proxyAddress: string, implementation: string): Promise<any> {
     log.info(`Upgrading proxy at ${proxyAddress} without running migrations...`);
     return Transactions.sendTransaction(this.contract.methods.upgrade, [proxyAddress, implementation], { ...this.txParams });
@@ -59,4 +69,5 @@ export default class ProxyAdmin {
     log.info(`Upgrading proxy at ${proxyAddress} and calling ${callDescription(initMethod, initArgs)}...`);
     return Transactions.sendTransaction(this.contract.methods.upgradeAndCall, [proxyAddress, implementationAddress, callData], { ...this.txParams });
   }
+
 }

--- a/packages/lib/test/src/ProxyAdmin.test.js
+++ b/packages/lib/test/src/ProxyAdmin.test.js
@@ -12,7 +12,7 @@ const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
 const ProxyAdminContract = Contracts.getFromLocal('ProxyAdmin');
 
 contract('ProxyAdmin class', function(accounts) {
-  const [_, proxyAdminOwner, newAdmin, otherAccount] = accounts.map(utils.toChecksumAddress);
+  const [_, proxyAdminOwner, newAdmin, newAdminOwner, otherAccount] = accounts.map(utils.toChecksumAddress);
   const version = '0.0.1';
   const contentURI = '0x10';
 
@@ -79,6 +79,14 @@ contract('ProxyAdmin class', function(accounts) {
           const implementationAddress = await this.proxyAdmin.getProxyImplementation(this.proxy.address);
           implementationAddress.should.be.equal(this.implementationV2.address)
         });
+      });
+    });
+
+    describe('#transferOwnership', function() {
+      it('transfers ownership to a new address', async function() {
+        await this.proxyAdmin.transferOwnership(newAdminOwner);
+        const owner = await this.proxyAdmin.getOwner();
+        owner.should.be.equal(newAdminOwner);
       });
     });
   });

--- a/packages/lib/test/src/project/AdminProxy.behaviour.js
+++ b/packages/lib/test/src/project/AdminProxy.behaviour.js
@@ -1,0 +1,33 @@
+'use strict'
+require('../../setup')
+
+import Proxy from '../../../src/proxy/Proxy';
+import Contracts from '../../../src/artifacts/Contracts';
+import { toAddress } from '../../../src/utils/Addresses';
+import random from 'lodash.random';
+
+const Impl = Contracts.getFromLocal('Impl');
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation');
+const DummyImplementationV2 = Contracts.getFromLocal('DummyImplementationV2');
+
+export default function shouldManageAdminProxy({ otherAdmin, setImplementations }) {
+
+  describe('proxyAdmin', function () {
+
+    describe('transferAdminOwnership', function () {
+      beforeEach('setting implementations', setImplementations);
+      beforeEach('create proxy', createProxy);
+
+      it('transfers owneship of a proxy admin to a new owner', async function () {
+        await this.project.transferAdminOwnership(otherAdmin);
+        const owner = await this.project.proxyAdmin.getOwner();
+        owner.should.be.equal(otherAdmin);
+      })
+    });
+  });
+
+  async function createProxy () {
+    this.instance = await this.project.createProxy(DummyImplementation);
+  };
+
+}

--- a/packages/lib/test/src/project/AppProject.test.js
+++ b/packages/lib/test/src/project/AppProject.test.js
@@ -8,6 +8,7 @@ import SimpleProject from '../../../src/project/SimpleProject';
 import shouldManageProxies from './ProxyProject.behaviour';
 import shouldManageDependencies from './DependenciesProject.behaviour';
 import shouldBehaveLikePackageProject from './PackageProject.behavior';
+import shouldManageAdminProxy from './AdminProxy.behaviour';
 import assertRevert from '../../../src/test/helpers/assertRevert'
 import { toAddress } from '../../../src/utils/Addresses';
 import { Package } from '../../../src';
@@ -16,6 +17,11 @@ import ProxyFactory from '../../../src/proxy/ProxyFactory';
 
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
+
+async function setImplementations() {
+  await this.project.setImplementation(ImplV1, "DummyImplementation");
+  await this.project.setImplementation(ImplV2, "DummyImplementationV2");
+}
 
 contract('AppProject', function (accounts) {
   accounts = accounts.map(utils.toChecksumAddress);
@@ -88,13 +94,14 @@ contract('AppProject', function (accounts) {
     shouldManageProxies({
       supportsNames: true,
       otherAdmin: another,
-      setImplementations: async function () {
-        await this.project.setImplementation(ImplV1, "DummyImplementation")
-        await this.project.setImplementation(ImplV2, "DummyImplementationV2")
-      }
+      setImplementations,
     })
 
     shouldManageDependencies();
+    shouldManageAdminProxy({
+      otherAdmin: another,
+      setImplementations,
+    });
   });
 
   describe('fromSimpleProject', function () {

--- a/packages/lib/test/src/project/ProxyAdminProject.test.js
+++ b/packages/lib/test/src/project/ProxyAdminProject.test.js
@@ -7,11 +7,17 @@ import ProxyAdminProject from '../../../src/project/ProxyAdminProject';
 import shouldManageProxies from './ProxyProject.behaviour';
 import shouldManageDependencies from './DependenciesProject.behaviour';
 import shouldManageImplementations from './Implementations.behaviour';
+import shouldManageAdminProxy from './AdminProxy.behaviour';
 import Contracts from '../../../src/artifacts/Contracts';
 import { noop } from 'lodash';
 
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
+
+async function setImplementations() {
+  await this.project.setImplementation(ImplV1, "DummyImplementation");
+  await this.project.setImplementation(ImplV2, "DummyImplementationV2");
+}
 
 contract('ProxyAdminProject', function(accounts) {
   const [_, proxyAdminOwner, another] = accounts.map(utils.toChecksumAddress);
@@ -46,10 +52,7 @@ contract('ProxyAdminProject', function(accounts) {
     shouldManageProxies({
       supportsNames: true,
       otherAdmin: another,
-      setImplementations: async function () {
-        await this.project.setImplementation(ImplV1, "DummyImplementation")
-        await this.project.setImplementation(ImplV2, "DummyImplementationV2")
-      }
+      setImplementations,
     })
 
     it('unsets an implementation', async function () {
@@ -61,4 +64,8 @@ contract('ProxyAdminProject', function(accounts) {
 
   shouldManageDependencies();
   shouldManageImplementations();
+  shouldManageAdminProxy({
+    otherAdmin: another,
+    setImplementations,
+  });
 });

--- a/packages/lib/test/src/project/ProxyProject.behaviour.js
+++ b/packages/lib/test/src/project/ProxyProject.behaviour.js
@@ -100,9 +100,10 @@ export default function shouldManageProxies({ otherAdmin, setImplementations, su
 
       it('changes admin of a proxy', async function () {
         await this.project.changeProxyAdmin(this.instance.address, otherAdmin);
-        await assertIsProxy(this.instance, otherAdmin)
+        await assertIsProxy(this.instance, otherAdmin);
       })
     });
+
   });
 
   async function assertIsProxy(address, adminAddress) {


### PR DESCRIPTION
* Adds required functionality to a `set-admin` command in the following way:
`zos set-admin <new-proxy-admin-address>`
* Use interactive check to prevent admin address input errors.
* Adds tests to support required changes.