### PR TITLE
Fix circleci caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,33 @@ defaults: &defaults
     - image: circleci/node:10.13
   working_directory: ~/zos
 
+aliases:
+  - restore_cache: &restore-build-cache-lib
+      keys: ['dependency-cache-v1-build-lib-{{ .Revision }}']
+  - restore_cache: &restore-build-cache-cli
+      keys: ['dependency-cache-v1-build-cli-{{ .Revision }}']
+  - restore_cache: &restore-cache-root
+      keys: ['dependency-cache-v1-root-{{ checksum "package.json" }}', 'dependency-cache-v1-root-']
+  - restore_cache: &restore-cache-lib
+      keys: ['dependency-cache-v1-lib-{{ checksum "packages/lib/package.json" }}', 'dependency-cache-v1-lib-']
+  - restore_cache: &restore-cache-cli
+      keys: ['dependency-cache-v1-cli-{{ checksum "packages/cli/package.json" }}', 'dependency-cache-v1-cli-']
+
 commands:
+
+  restore-lib-caches:
+    steps:
+      - restore_cache: *restore-cache-root
+      - restore_cache: *restore-cache-lib
+      - restore_cache: *restore-build-cache-lib
+
+  restore-all-caches:
+    steps:
+      - restore_cache: *restore-cache-root
+      - restore_cache: *restore-cache-lib
+      - restore_cache: *restore-cache-cli
+      - restore_cache: *restore-build-cache-lib
+      - restore_cache: *restore-build-cache-cli
 
   npm-install-with-cache:
     parameters:
@@ -68,18 +94,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: &restore-cache-root
-          keys: 
-            - dependency-cache-v1-root-{{ checksum "package.json" }}
-            - dependency-cache-v1-root-
-      - restore_cache: &restore-cache-lib
-          keys: 
-            - dependency-cache-v1-lib-{{ checksum "packages/lib/package.json" }}
-            - dependency-cache-v1-lib-
-      - restore_cache: &restore-cache-cli
-          keys: 
-            - dependency-cache-v1-cli-{{ checksum "packages/cli/package.json" }}
-            - dependency-cache-v1-cli-
+      - restore-lib-caches
       - run:
           name: Install dependencies at root
           command: npm install
@@ -92,23 +107,22 @@ jobs:
           paths: [node_modules]
       - save_cache:
           key: dependency-cache-v1-cli-{{ checksum "packages/cli/package.json" }}
-          paths:
-            - packages/cli/node_modules
-            - packages/cli/lib
-            - packages/cli/build
+          paths: [packages/cli/node_modules]
       - save_cache:
           key: dependency-cache-v1-lib-{{ checksum "packages/lib/package.json" }}
-          paths:
-            - packages/lib/node_modules
-            - packages/lib/lib
-            - packages/lib/build
+          paths: [packages/lib/node_modules]
+      - save_cache:
+          key: dependency-cache-v1-build-cli-{{ .Revision }}
+          paths: [packages/cli/lib, packages/cli/build]
+      - save_cache:
+          key: dependency-cache-v1-build-lib-{{ .Revision }}
+          paths: [packages/lib/lib, packages/lib/build]
 
   test-lib:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
+      - restore-lib-caches
       - run:
           name: Test lib
           command: 'npm run test'
@@ -118,9 +132,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
-      - restore_cache: *restore-cache-cli
+      - restore-all-caches
       - run:
           name: Test CLI
           command: 'npm run test'
@@ -130,8 +142,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
+      - restore-lib-caches
       - npm-install-and-test:
           dir: "~/zos/examples/lib-simple"
           install-cmd: '~/zos/node_modules/.bin/lerna bootstrap --scope=example-zos-lib-simple --scope="zos-lib"'
@@ -140,8 +151,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
+      - restore-lib-caches
       - npm-install-and-test:
           dir: "~/zos/examples/lib-complex"
           install-cmd: '~/zos/node_modules/.bin/lerna bootstrap --scope=example-zos-lib-complex --scope="zos-lib"'
@@ -150,9 +160,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
-      - restore_cache: *restore-cache-cli
+      - restore-all-caches
       - npm-install-and-test:
           dir: "~/zos/examples/creating-instances-from-solidity"
           install-cmd: '~/zos/node_modules/.bin/lerna bootstrap --scope=example-creating-instances-from-solidity --scope="zos*"'
@@ -166,9 +174,7 @@ jobs:
         command: "--dev --dev.period=1 --rpc --rpcport=8545 --rpcaddr=localhost --networkid=9955"
     steps:
       - checkout
-      - restore_cache: *restore-cache-root
-      - restore_cache: *restore-cache-lib
-      - restore_cache: *restore-cache-cli
+      - restore-all-caches
       - npm-install-with-cache: 
           dir: "~/zos/tests/cli/workdir"
           cache-version: 'v3'


### PR DESCRIPTION
Lib and CLI caches were calculated based on the checksum of the package json,
yet they included the result of the build process. This caused changes on the
package code to be lost if the package.json did not change.

This fix adds a new cache to host the result of the build process, that
depends exclusively on the revision being built.