### PR TITLE
Fix Contract#at to create a clone of the current instance

### DIFF
--- a/examples/creating-instances-from-solidity/index.js
+++ b/examples/creating-instances-from-solidity/index.js
@@ -90,8 +90,7 @@ async function main() {
   console.log(`Factory proxy created at ${factoryProxy.address}`);
 
   // Use the Factory proxy address to create a javascript Factory contract object.
-  const factoryContract = Contracts.getFromLocal('Factory');
-  factoryContract.at(factoryProxy.address);
+  const factoryContract = Contracts.getFromLocal('Factory').at(factoryProxy.address);
 
   // Construct the call data for the initialize method of Instance.sol.
   // This call data consists of the contract's `initialize` method with the value of `42`.
@@ -115,8 +114,7 @@ async function main() {
   console.log(`Instance proxy created at ${instanceAddress}`);
 
   // Use the Instance proxy address to create a javascript Instance contract object.
-  const instanceContract = Contracts.getFromLocal('Instance');
-  instanceContract.at(instanceAddress);
+  const instanceContract = Contracts.getFromLocal('Instance').at(instanceAddress);
 
   // Retrieve the value stored in the instance contract.
   // Note that we cannot make the call using the same address that created the proxy

--- a/packages/cli/test/models/TestHelper.test.js
+++ b/packages/cli/test/models/TestHelper.test.js
@@ -77,6 +77,13 @@ contract('TestHelper', function ([_, owner]) {
       const say = await proxy.methods.say().call()
       say.should.eq('V1')
     })
+
+    it("creates two different proxies", async function() {
+      const proxy1 = await this.project.createProxy(ImplV1, { contractName: 'Impl' })
+      const proxy2 = await this.project.createProxy(ImplV1, { contractName: 'Impl' })  
+      proxy1.address.should.not.be.eq(proxy2.address);
+    });
+  
   })
 
 })

--- a/packages/lib/src/artifacts/Contract.ts
+++ b/packages/lib/src/artifacts/Contract.ts
@@ -82,8 +82,10 @@ function _wrapContractInstance(schema: any, instance: Web3Contract): Contract {
 
   instance.at = function(address: string): Contract | never {
     if(!ZWeb3.isAddress(address)) throw new Error('Given address is not valid: ' + address);
-    instance.options.address = instance._address = address;
-    return instance;
+    const newWeb3Instance = instance.clone();
+    newWeb3Instance._address = address;
+    newWeb3Instance.options.address = address;
+    return _wrapContractInstance(instance.schema, newWeb3Instance);
   };
 
   instance.link = function(libraries: { [libAlias: string]: string }): void {

--- a/packages/lib/test/src/artifacts/Contract.test.js
+++ b/packages/lib/test/src/artifacts/Contract.test.js
@@ -2,12 +2,12 @@
 require('../../setup')
 
 import utils from 'web3-utils';
-import sinon from 'sinon';
 
 import Contracts from '../../../src/artifacts/Contracts'
-import Contract from '../../../src/artifacts/ZosContract';
 
 const ContractWithStructInConstructor = Contracts.getFromLocal('WithStructInConstructor');
+const ContractWithConstructorImplementation = Contracts.getFromLocal('WithConstructorImplementation');
+
 
 contract('Contract', function(accounts) {
   const [_, account] = accounts.map(utils.toChecksumAddress)
@@ -44,6 +44,22 @@ contract('Contract', function(accounts) {
             (await instance.methods.sender().call()).should.eq(account);
           });
         });
+      });
+    });
+
+    describe('#at', function () {
+      beforeEach('deploying contracts', async function () {
+        this.instance1 = await ContractWithConstructorImplementation.new(10, "foo", txParams);
+        this.instance2 = await ContractWithConstructorImplementation.new(20, "bar", txParams);
+      });
+
+      it('creates a copy of the instance', async function () {
+        const instance1 = ContractWithConstructorImplementation.at(this.instance1.address);
+        const instance2 = ContractWithConstructorImplementation.at(this.instance2.address);
+        instance1.address.should.not.eq(instance2.address);
+        instance1.options.address.should.not.eq(instance2.options.address);
+        (await instance1.methods.text().call()).should.eq('foo');
+        (await instance2.methods.text().call()).should.eq('bar');
       });
     });
   });


### PR DESCRIPTION
Function `Contract#at` was modifying the current instance instead of creating a new one. This caused two invocations to `at` on the same contract with different addresses to end up yielding the same instance.

Fixes #784