### PR TITLE
Eliminates ProxyAdmin code duplication in ProxyAdminProject and AppProject using TypeScript Mixins

### DIFF
--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -5,16 +5,17 @@ import BaseSimpleProject from './BaseSimpleProject';
 import { ContractInterface } from './AppProject';
 import Contract from '../artifacts/Contract';
 import ProxyFactory from '../proxy/ProxyFactory';
+import ProxyAdminProjectMixin from './mixin/ProxyAdminProjectMixin';
 
 const log: Logger = new Logger('ProxyAdminProject');
 
-export default class ProxyAdminProject extends BaseSimpleProject {
+class BaseProxyAdminProject extends BaseSimpleProject {
   public proxyAdmin: ProxyAdmin;
 
-  public static async fetch(name: string = 'main', txParams: any = {}, proxyAdminAddress?: string, proxyFactoryAddress?: string) {
+  public static async fetch(name: string = 'main', txParams: any = {}, proxyAdminAddress?: string, proxyFactoryAddress?: string): Promise<ProxyAdminProject> {
     const proxyAdmin = proxyAdminAddress ? await ProxyAdmin.fetch(proxyAdminAddress, txParams) : null;
     const proxyFactory = proxyFactoryAddress ? await ProxyFactory.fetch(proxyFactoryAddress, txParams) : null;
-    return new this(name, proxyAdmin, proxyFactory, txParams);
+    return new ProxyAdminProject(name, proxyAdmin, proxyFactory, txParams);
   }
 
   constructor(name: string = 'main', proxyAdmin: ProxyAdmin, proxyFactory?: ProxyFactory, txParams: any = {}) {
@@ -40,17 +41,8 @@ export default class ProxyAdminProject extends BaseSimpleProject {
     return contract.at(pAddress);
   }
 
-  public async changeProxyAdmin(proxyAddress: string, newAdmin: string): Promise<void> {
-    await this.proxyAdmin.changeProxyAdmin(proxyAddress, newAdmin);
-    log.info(`Proxy ${proxyAddress} admin changed to ${newAdmin}`);
-  }
-
   public getAdminAddress(): Promise<string> {
     return new Promise((resolve) => resolve(this.proxyAdmin ? this.proxyAdmin.address : null));
-  }
-
-  public async transferAdminOwnership(newAdminOwner: string): Promise<void> {
-    await this.proxyAdmin.transferOwnership(newAdminOwner);
   }
 
   public async ensureProxyAdmin(): Promise<ProxyAdmin> {
@@ -60,3 +52,7 @@ export default class ProxyAdminProject extends BaseSimpleProject {
     return this.proxyAdmin;
   }
 }
+
+// Mixings produce value but not type
+// We have to export full class with type & callable
+export default class ProxyAdminProject extends ProxyAdminProjectMixin(BaseProxyAdminProject) {};

--- a/packages/lib/src/project/mixin/ProxyAdminProjectMixin.ts
+++ b/packages/lib/src/project/mixin/ProxyAdminProjectMixin.ts
@@ -1,0 +1,21 @@
+import Constructable, { AbstractType, GetMixinType } from '../../utils/Mixin';
+import ProxyAdmin from '../../proxy/ProxyAdmin';
+
+// A mixin that adds ProxyAdmin field and related ProxyAdminProject methods
+// Intented to as a building block for Project class
+// Can't extend contructor at that moment due to TypeScript limitations https://github.com/Microsoft/TypeScript/issues/14126
+function ProxyAdminProjectMixin<T extends Constructable>(Base: T) {
+  return class extends Base {
+    public proxyAdmin: ProxyAdmin;
+
+    public async transferAdminOwnership(newAdminOwner: string): Promise<void> {
+      await this.proxyAdmin.transferOwnership(newAdminOwner);
+    }
+
+    public async changeProxyAdmin(proxyAddress: string, newAdmin: string): Promise<void> {
+      return this.proxyAdmin.changeProxyAdmin(proxyAddress, newAdmin);
+    }
+  };
+}
+
+export default ProxyAdminProjectMixin;

--- a/packages/lib/src/utils/Mixin.ts
+++ b/packages/lib/src/utils/Mixin.ts
@@ -1,0 +1,7 @@
+type Constructable<T = {}> = new (...args: any[]) => T;
+export type Callable<T = any> = (...args: any[]) => T;
+export type AbstractType<T = {}> = Function & { prototype: T };
+
+export type GetMixinType<T extends Callable> = InstanceType<ReturnType<T>>;
+
+export default Constructable;


### PR DESCRIPTION
The goal of the PR is to eliminate code duplication at ProxyAdminProject and AppProject classes as well as introduce and showcase TypeScript Mixins usage in the project.

Notes on TypeScript Mixins

TypeScripts Mixins is a relatively new feature with no official or community consensus on usage or established library. It is under development and presents certain challenges. Mixins are great for development but should be used with caution. [Official documentation](https://www.typescriptlang.org/docs/handbook/mixins.html) is outdated but there is [PR](https://github.com/Microsoft/TypeScript/pull/13743) introducing a new approach.

Regarding ZOS I struggled with mixin abstract classes. Generally speaking [it is not possible](https://github.com/Microsoft/TypeScript/issues/25606) to mixin abstract classes in TypeScript at that moment. There are some workarounds but will probably cause a loss of compile type checks which defeats the entire purpose of using TypeScript. I believe in the long term we should replace abstract classes & inheritance with mixins.

Another issue is mixins [constrain for constructor signature](https://github.com/Microsoft/TypeScript/issues/14126) `constructor(...args: any[])`. That doesn't allow mixins to type their constructor parameters and forced to use a workaround in order for mixins to access their constructor arguments.

Despite all current struggles I believe using Mixins in a typed way clearly outweighs limitations of inheritance and abstract classes. As TypeScript language support for Mixins will improve over the time we should rely more on them at ZOS.