### PR TITLE
Balance command

### DIFF
--- a/packages/cli/contracts/mocks/ERC20Fake.sol
+++ b/packages/cli/contracts/mocks/ERC20Fake.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.5.0;
+
+contract ERC20Fake {
+  mapping (address => uint256) private _balances;
+
+  function giveAway(address account, uint256 amount) public {
+    _balances[account] = amount;
+  }
+
+  function balanceOf(address owner) public view returns (uint256) {
+    return _balances[owner];
+  }
+}
+
+contract ERC20FakeDetailed is ERC20Fake {
+  string private _name;
+  string private _symbol;
+  uint8 private _decimals;
+
+  constructor (string memory name, string memory symbol, uint8 decimals) public {
+    _name = name;
+    _symbol = symbol;
+    _decimals = decimals;
+  }
+
+  function name() public view returns (string memory) {
+    return _name;
+  }
+
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
+
+  function decimals() public view returns (uint8) {
+    return _decimals;
+  }
+}

--- a/packages/cli/src/commands/balance.ts
+++ b/packages/cli/src/commands/balance.ts
@@ -1,0 +1,40 @@
+import balance from '../scripts/balance';
+import { promptIfNeeded, networksList, InquirerQuestions } from '../prompts/prompt';
+import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
+
+const name: string = 'balance';
+const signature: string = `${name} [address]`;
+const description: string = 'query the balance of the specified account';
+
+const register: (program: any) => any = (program) => program
+  .command(signature, undefined, { noHelp: true })
+  .usage('[options]')
+  .description(description)
+  .option('--erc20 <contractAddress>', 'specify an ERC20 token address')
+  .withNetworkOptions()
+  .withNonInteractiveOption()
+  .action(action);
+
+async function action(accountAddress: string, options: any): Promise<void> {
+  const { network: networkInOpts, erc20: contractAddress, interactive } = options;
+  const args = { accountAddress };
+  const opts = { network: networkInOpts };
+  const props = getCommandProps();
+  const promptedConfig = await promptIfNeeded({ args, opts, props }, interactive);
+
+  await ConfigVariablesInitializer.initNetworkConfiguration(promptedConfig);
+  await balance({ accountAddress: promptedConfig.accountAddress, contractAddress });
+
+  if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
+}
+
+function getCommandProps(): InquirerQuestions {
+  return {
+    ...networksList('network', 'list'),
+    accountAddress: {
+      type: 'input',
+      message: 'Enter an account address',
+    },
+  };
+}
+export default { name, signature, description, register, action };

--- a/packages/cli/src/commands/balance.ts
+++ b/packages/cli/src/commands/balance.ts
@@ -11,7 +11,7 @@ const register: (program: any) => any = (program) => program
   .command(signature, undefined, { noHelp: true })
   .usage('[options]')
   .description(description)
-  .option('--erc20 <contractAddress>', 'specify an ERC20 token address')
+  .option('--erc20 <contractAddress>', 'specify an ERC20 token address or leave empty to query ETH balance')
   .withNetworkOptions()
   .withNonInteractiveOption()
   .action(action);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -17,6 +17,7 @@ import update from './update';
 import verify from './verify';
 import unpack from './unpack';
 import transfer from './transfer';
+import balance from './balance';
 
 export default {
   add,
@@ -38,4 +39,5 @@ export default {
   verify,
   unpack,
   transfer,
+  balance,
 };

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -1,13 +1,14 @@
-import { Transactions, Logger, ZWeb3 } from 'zos-lib';
+import { Transactions, Logger, ZWeb3, encodeCall } from 'zos-lib';
 import { isValidUnit } from '../../utils/units';
+import { ERC20_PARTIAL_ABI } from '../../utils/constants';
 
 const log = new Logger('TransactionController');
 
 export default class TransactionController {
   public txParams: any;
 
-  constructor(txParams) {
-    this.txParams = txParams;
+  constructor(txParams?: any) {
+    if (txParams) this.txParams = txParams;
   }
 
   public async transfer(to: string, amount: string, unit: string): Promise<void> {
@@ -19,5 +20,22 @@ export default class TransactionController {
     log.info(`Sending ${amount} ${validUnit} to ${to}...`);
     const { transactionHash } = await Transactions.sendRawTransaction(to, { value }, this.txParams);
     log.info(`Funds successfully sent!. Transaction hash: ${transactionHash}`);
+  }
+
+  public async getBalanceOf(accountAddress: string, contractAddress?: string): Promise<void> {
+    if (contractAddress) {
+      try {
+        const contract = ZWeb3.contract(ERC20_PARTIAL_ABI, contractAddress);
+        const balance = await contract.methods.balanceOf(accountAddress).call();
+        const tokenSymbol = await contract.methods.symbol().call();
+        log.info(`Balance: ${ZWeb3.fromWei(balance, 'ether')} ${tokenSymbol}`);
+      } catch(error) {
+        error.message = `Could not get balance of ${accountAddress} in ${contractAddress}. Error: ${error.message}`;
+        throw error;
+      }
+    } else {
+      const balance = await ZWeb3.getBalance(accountAddress);
+      log.info(`Balance: ${ZWeb3.fromWei(balance, 'ether')} ether`);
+    }
   }
 }

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -1,6 +1,7 @@
 import { Transactions, Logger, ZWeb3 } from 'zos-lib';
 import { isValidUnit, prettifyTokenAmount, toWei, fromWei } from '../../utils/units';
 import { ERC20_PARTIAL_ABI } from '../../utils/constants';
+import { allPromisesOrError } from '../../utils/async';
 
 const log = new Logger('TransactionController');
 
@@ -43,8 +44,10 @@ export default class TransactionController {
     try {
       const contract = ZWeb3.contract(ERC20_PARTIAL_ABI, contractAddress);
       balance = await contract.methods.balanceOf(accountAddress).call();
-      tokenSymbol = await contract.methods.symbol().call();
-      tokenDecimals = await contract.methods.decimals().call();
+      [tokenSymbol, tokenDecimals] = await allPromisesOrError([
+        contract.methods.symbol().call(),
+        contract.methods.decimals().call()
+      ]);
     } catch(error) {
       if (!balance) {
         error.message = `Could not get balance of ${accountAddress} in ${contractAddress}. Error: ${error.message}`;

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -1,5 +1,5 @@
 import { Transactions, Logger, ZWeb3 } from 'zos-lib';
-import { isValidUnit, prettifyTokenAmount } from '../../utils/units';
+import { isValidUnit, prettifyTokenAmount, toWei, fromWei } from '../../utils/units';
 import { ERC20_PARTIAL_ABI } from '../../utils/constants';
 
 const log = new Logger('TransactionController');
@@ -22,7 +22,7 @@ export default class TransactionController {
       throw Error(`Invalid unit ${unit}. Please try with: wei, kwei, gwei, milli, ether or any other valid unit.`);
     }
     const validUnit = unit.toLowerCase();
-    const value = ZWeb3.toWei(amount, validUnit);
+    const value = toWei(amount, validUnit);
     log.info(`Sending ${amount} ${validUnit} to ${to}...`);
     const { transactionHash } = await Transactions.sendRawTransaction(to, { value }, this.txParams);
     log.info(`Funds successfully sent!. Transaction hash: ${transactionHash}`);
@@ -34,7 +34,7 @@ export default class TransactionController {
       log.info(`Balance: ${prettifyTokenAmount(balance, tokenDecimals, tokenSymbol)}`);
     } else {
       const balance = await ZWeb3.getBalance(accountAddress);
-      log.info(`Balance: ${ZWeb3.fromWei(balance, 'ether')} ETH`);
+      log.info(`Balance: ${fromWei(balance, 'ether')} ETH`);
     }
   }
 

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -1,4 +1,4 @@
-import { Transactions, Logger, ZWeb3, encodeCall } from 'zos-lib';
+import { Transactions, Logger, ZWeb3 } from 'zos-lib';
 import { isValidUnit } from '../../utils/units';
 import { ERC20_PARTIAL_ABI } from '../../utils/constants';
 

--- a/packages/cli/src/scripts/balance.ts
+++ b/packages/cli/src/scripts/balance.ts
@@ -1,0 +1,8 @@
+import TransactionController from '../models/network/TransactionController';
+import { BalanceParams } from './interfaces';
+
+export default async function transfer({ accountAddress, contractAddress }: BalanceParams): Promise<any> {
+  if (!accountAddress) throw Error('An account address must be specified.');
+  const controller = new TransactionController();
+  await controller.getBalanceOf(accountAddress, contractAddress);
+}

--- a/packages/cli/src/scripts/balance.ts
+++ b/packages/cli/src/scripts/balance.ts
@@ -1,7 +1,7 @@
 import TransactionController from '../models/network/TransactionController';
 import { BalanceParams } from './interfaces';
 
-export default async function transfer({ accountAddress, contractAddress }: BalanceParams): Promise<any> {
+export default async function balance({ accountAddress, contractAddress }: BalanceParams): Promise<void | never> {
   if (!accountAddress) throw Error('An account address must be specified.');
   const controller = new TransactionController();
   await controller.getBalanceOf(accountAddress, contractAddress);

--- a/packages/cli/src/scripts/index.ts
+++ b/packages/cli/src/scripts/index.ts
@@ -19,6 +19,7 @@ import unlink from './unlink';
 import update from './update';
 import verify from './verify';
 import transfer from './transfer';
+import balance from './balance';
 
 export default {
   add,
@@ -41,5 +42,6 @@ export default {
   unlink,
   update,
   verify,
-  transfer
+  transfer,
+  balance,
 };

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -122,3 +122,8 @@ export interface QueryDeploymentParams extends Network {
   salt: string;
   sender?: string;
 }
+
+export interface BalanceParams {
+  accountAddress: string;
+  contractAddress?: string;
+}

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -123,6 +123,14 @@ export interface QueryDeploymentParams extends Network {
   sender?: string;
 }
 
+export interface TransferParams {
+  to: string;
+  value: string;
+  txParams: any;
+  unit?: string;
+  from?: string;
+}
+
 export interface BalanceParams {
   accountAddress: string;
   contractAddress?: string;

--- a/packages/cli/src/scripts/transfer.ts
+++ b/packages/cli/src/scripts/transfer.ts
@@ -1,8 +1,8 @@
 import TransactionController from '../models/network/TransactionController';
 import ScriptError from '../models/errors/ScriptError';
-import { CreateParams } from './interfaces';
+import { TransferParams } from './interfaces';
 
-export default async function transfer({ to, value, unit = 'ether', from, txParams = {} }: any): Promise<any> {
+export default async function transfer({ to, value, unit = 'ether', from, txParams = {} }: TransferParams): Promise<void | never> {
   if (!to) throw Error('A recipient address must be specified');
   if (!value) throw Error('An amount to be transferred must be specified');
 

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,0 +1,28 @@
+// export const ERC20_PARTIAL_ABI = [{ constant: true, inputs: [{ name: '_owner', type: 'address' }], name : 'balanceOf', outputs: [{ name: 'balance', type:'uint256' }], payable: false, stateMutability: 'view', type: 'function' }, { constant: true, inputs: [], name: 'symbol', outputs: [{ name: '', type: 'string' }], payable: false, stateMutability: 'view', type: 'function' }];
+
+export const ERC20_PARTIAL_ABI = [{
+  constant: true,
+  inputs: [{
+    name: '_owner',
+    type: 'address'
+  }],
+  name: 'balanceOf',
+  outputs: [{
+    name: 'balance',
+    type: 'uint256'
+  }],
+  payable: false,
+  stateMutability: 'view',
+  type: 'function'
+}, {
+  constant: true,
+  inputs: [],
+  name: 'symbol',
+  outputs: [{
+    name: '',
+    type: 'string'
+  }],
+  payable: false,
+  stateMutability: 'view',
+  type: 'function'
+}];

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,5 +1,3 @@
-// export const ERC20_PARTIAL_ABI = [{ constant: true, inputs: [{ name: '_owner', type: 'address' }], name : 'balanceOf', outputs: [{ name: 'balance', type:'uint256' }], payable: false, stateMutability: 'view', type: 'function' }, { constant: true, inputs: [], name: 'symbol', outputs: [{ name: '', type: 'string' }], payable: false, stateMutability: 'view', type: 'function' }];
-
 export const ERC20_PARTIAL_ABI = [{
   constant: true,
   inputs: [{

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -23,4 +23,17 @@ export const ERC20_PARTIAL_ABI = [{
   payable: false,
   stateMutability: 'view',
   type: 'function'
+}, {
+  constant: true,
+  inputs: [],
+  name: 'decimals',
+  outputs: [
+    {
+      name: '',
+      type: 'uint8'
+    }
+  ],
+  payable: false,
+  stateMutability: 'view',
+  type: 'function'
 }];

--- a/packages/cli/src/utils/units.ts
+++ b/packages/cli/src/utils/units.ts
@@ -1,5 +1,14 @@
 import { ZWeb3 } from 'zos-lib';
+import BN from 'bignumber.js';
 
 export function isValidUnit(unit: string): boolean {
   return ZWeb3.getUnits().includes(unit.toLowerCase());
+}
+
+export function prettifyTokenAmount(amount: string, decimals?: string, symbol?: string): string {
+  const prettifiedAmount = decimals
+    ? new BN(amount).dividedBy(new BN(10).exponentiatedBy(decimals)).toFormat()
+    : amount;
+
+  return symbol ? `${prettifiedAmount} ${symbol}` : prettifiedAmount;
 }

--- a/packages/cli/src/utils/units.ts
+++ b/packages/cli/src/utils/units.ts
@@ -1,8 +1,8 @@
-import { ZWeb3 } from 'zos-lib';
 import BN from 'bignumber.js';
+import web3Utils from 'web3-utils';
 
 export function isValidUnit(unit: string): boolean {
-  return ZWeb3.getUnits().includes(unit.toLowerCase());
+  return Object.keys(web3Utils.unitMap).includes(unit.toLowerCase());
 }
 
 export function prettifyTokenAmount(amount: string, decimals?: string, symbol?: string): string {
@@ -11,4 +11,12 @@ export function prettifyTokenAmount(amount: string, decimals?: string, symbol?: 
     : amount;
 
   return symbol ? `${prettifiedAmount} ${symbol}` : prettifiedAmount;
+}
+
+export function toWei(value: string, unit: any): string {
+  return web3Utils.toWei(value, unit);
+}
+
+export function fromWei(value: string, unit: any): string {
+  return web3Utils.fromWei(value, unit);
 }

--- a/packages/cli/test/commands/balance.test.js
+++ b/packages/cli/test/commands/balance.test.js
@@ -1,0 +1,16 @@
+'use strict'
+require('../setup')
+
+import { stubCommands, itShouldParse } from './share';
+
+describe('balance command', function() {
+  stubCommands()
+
+  itShouldParse('should call balance script with account address', 'balance', 'zos balance 0x42 --network test', function(transfer) {
+    transfer.should.have.been.calledWithExactly({ accountAddress: '0x42', contractAddress: undefined })
+  });
+
+  itShouldParse('should call balance script with account and contract address', 'balance', 'zos balance 0x42 --erc20 0x10 --network test', function(transfer) {
+    transfer.should.have.been.calledWithExactly({ accountAddress: '0x42', contractAddress: '0x10' })
+  });
+})

--- a/packages/cli/test/commands/share.js
+++ b/packages/cli/test/commands/share.js
@@ -23,6 +23,7 @@ import * as verify from '../../src/scripts/verify';
 import * as setAdmin from '../../src/scripts/set-admin';
 import * as unpack from '../../src/scripts/unpack';
 import * as transfer from '../../src/scripts/transfer';
+import * as balance from '../../src/scripts/balance';
 
 import program from '../../src/bin/program';
 import Session from '../../src/models/network/Session';
@@ -73,7 +74,8 @@ exports.stubCommands = function () {
     this.verify = sinon.stub(verify, 'default')
     this.setAdmin = sinon.stub(setAdmin, 'default')
     this.unpack = sinon.stub(unpack, 'default')
-    this.transfer= sinon.stub(transfer, 'default')
+    this.transfer = sinon.stub(transfer, 'default')
+    this.balance = sinon.stub(balance, 'default')
     this.compiler = sinon.stub(Compiler, 'call').callsFake(() => null)
     this.errorHandler = sinon.stub(ErrorHandler.prototype, 'call').callsFake(() => null)
     this.initializer = sinon.stub(ConfigVariablesInitializer, 'initNetworkConfiguration').callsFake(function (options) {

--- a/packages/cli/test/scripts/balance.test.js
+++ b/packages/cli/test/scripts/balance.test.js
@@ -1,0 +1,67 @@
+'use strict'
+require('../setup');
+
+import utils from 'web3-utils';
+import { ZWeb3, Contracts } from 'zos-lib';
+import CaptureLogs from '../helpers/captureLogs';
+
+import balance from '../../src/scripts/balance';
+
+const ERC20 = Contracts.getFromLocal('ERC20Fake');
+const ERC20Detailed = Contracts.getFromLocal('ERC20FakeDetailed');
+
+contract('balance script', function(accounts) {
+  const [_, account] = accounts.map(utils.toChecksumAddress);
+
+  beforeEach('set logger captures', function() {
+    this.logs = new CaptureLogs();
+  });
+
+  afterEach('restore captures', function() {
+    this.logs.restore();
+  });
+
+  describe('get balance', function() {
+    context('when not specifying an ERC20 token address', function() {
+      it('logs balance in ETH', async function() {
+        await balance({ accountAddress: account });
+        this.logs.infos.should.have.lengthOf(1);
+        this.logs.infos[0].should.eq('Balance: 100 ETH');
+      });
+    });
+
+    context('when specifying an invalid ERC20 token address', function() {
+      it('throws an error', async function() {
+        await balance({ accountAddress: account, contractAddress: '0x42' }).should.be.rejectedWith(/Could not get balance of/);
+      });
+    });
+
+    context('when specifying a valid ERC20 token address', function() {
+      context('when token does not have a symbol and decimals', function() {
+        beforeEach('setup', async function() {
+          this.erc20 = await ERC20.new();
+          await this.erc20.methods.giveAway(account, 15e10).send();
+        });
+
+        it('logs the balance without formatting decimals or showing symbol', async function() {
+          await balance({ accountAddress: account, contractAddress: this.erc20.address });
+          this.logs.infos.should.have.lengthOf(1);
+          this.logs.infos[0].should.eq(`Balance: ${15e10.toString()}`);
+        });
+      });
+
+      context('when it is an ERC20Detailed', function() {
+        beforeEach('setup', async function() {
+          this.erc20Detailed = await ERC20Detailed.new('MyToken', 'TKN', 10);
+          await this.erc20Detailed.methods.giveAway(account, 15e10).send();
+        });
+
+        it('logs the balance formatting the output with decimals and shows symbol', async function() {
+          await balance({ accountAddress: account, contractAddress: this.erc20Detailed.address });
+          this.logs.infos.should.have.lengthOf(1);
+          this.logs.infos[0].should.eq(`Balance: 15 TKN`);
+        });
+      });
+    });
+  });
+});

--- a/packages/cli/test/scripts/balance.test.js
+++ b/packages/cli/test/scripts/balance.test.js
@@ -22,6 +22,12 @@ contract('balance script', function(accounts) {
   });
 
   describe('get balance', function() {
+    context('when not specifying an account address', function() {
+      it('throws an error', async function() {
+        await balance({ accountAddress: undefined }).should.be.rejectedWith('An account address must be specified.');
+      });
+    });
+
     context('when not specifying an ERC20 token address', function() {
       it('logs balance in ETH', async function() {
         await balance({ accountAddress: account });

--- a/packages/cli/test/scripts/balance.test.js
+++ b/packages/cli/test/scripts/balance.test.js
@@ -11,7 +11,7 @@ const ERC20 = Contracts.getFromLocal('ERC20Fake');
 const ERC20Detailed = Contracts.getFromLocal('ERC20FakeDetailed');
 
 contract('balance script', function(accounts) {
-  const [_, account] = accounts.map(utils.toChecksumAddress);
+  const [_, accountAddress] = accounts.map(utils.toChecksumAddress);
 
   beforeEach('set logger captures', function() {
     this.logs = new CaptureLogs();
@@ -24,13 +24,13 @@ contract('balance script', function(accounts) {
   describe('get balance', function() {
     context('when not specifying an account address', function() {
       it('throws an error', async function() {
-        await balance({ accountAddress: undefined }).should.be.rejectedWith('An account address must be specified.');
+        await balance({}).should.be.rejectedWith('An account address must be specified.');
       });
     });
 
     context('when not specifying an ERC20 token address', function() {
       it('logs balance in ETH', async function() {
-        await balance({ accountAddress: account });
+        await balance({ accountAddress });
         this.logs.infos.should.have.lengthOf(1);
         this.logs.infos[0].should.eq('Balance: 100 ETH');
       });
@@ -38,7 +38,7 @@ contract('balance script', function(accounts) {
 
     context('when specifying an invalid ERC20 token address', function() {
       it('throws an error', async function() {
-        await balance({ accountAddress: account, contractAddress: '0x42' }).should.be.rejectedWith(/Could not get balance of/);
+        await balance({ accountAddress, contractAddress: '0x42' }).should.be.rejectedWith(/Could not get balance of/);
       });
     });
 
@@ -46,11 +46,11 @@ contract('balance script', function(accounts) {
       context('when token does not have a symbol and decimals', function() {
         beforeEach('setup', async function() {
           this.erc20 = await ERC20.new();
-          await this.erc20.methods.giveAway(account, 15e10).send();
+          await this.erc20.methods.giveAway(accountAddress, 15e10).send();
         });
 
         it('logs the balance without formatting decimals or showing symbol', async function() {
-          await balance({ accountAddress: account, contractAddress: this.erc20.address });
+          await balance({ accountAddress, contractAddress: this.erc20.address });
           this.logs.infos.should.have.lengthOf(1);
           this.logs.infos[0].should.eq(`Balance: ${15e10.toString()}`);
         });
@@ -59,11 +59,11 @@ contract('balance script', function(accounts) {
       context('when it is an ERC20Detailed', function() {
         beforeEach('setup', async function() {
           this.erc20Detailed = await ERC20Detailed.new('MyToken', 'TKN', 10);
-          await this.erc20Detailed.methods.giveAway(account, 15e10).send();
+          await this.erc20Detailed.methods.giveAway(accountAddress, 15e10).send();
         });
 
         it('logs the balance formatting the output with decimals and shows symbol', async function() {
-          await balance({ accountAddress: account, contractAddress: this.erc20Detailed.address });
+          await balance({ accountAddress, contractAddress: this.erc20Detailed.address });
           this.logs.infos.should.have.lengthOf(1);
           this.logs.infos[0].should.eq(`Balance: 15 TKN`);
         });

--- a/packages/cli/test/utils/units.test.js
+++ b/packages/cli/test/utils/units.test.js
@@ -1,0 +1,68 @@
+'use strict'
+require('../setup');
+
+import { isValidUnit, prettifyTokenAmount, toWei, fromWei } from '../../src/utils/units';
+
+describe('units', function() {
+  describe('functions', function() {
+    describe('#prettifyTokenAmount', function () {
+      context('when specifying decimals and symbol', function() {
+        it('returns value and symbol', function() {
+          prettifyTokenAmount(15e10.toString(), '10', 'TKN').should.eq('15 TKN');
+        });
+      });
+
+      context('when not specifying decimals and symbol', function() {
+        it('returns value and symbol', function() {
+          prettifyTokenAmount(15e10.toString()).should.eq(15e10.toString());
+        });
+      });
+    });
+
+    describe('#isValidUnit', function () {
+      context('when providing an invalid unit', function() {
+        it('returns false', function() {
+          isValidUnit('foo').should.be.false;
+          isValidUnit('foobar').should.be.false;
+        });
+      });
+
+      context('when providing a valid unit', function() {
+        it('returns false', function() {
+          isValidUnit('wei').should.be.true;
+          isValidUnit('gwei').should.be.true;
+          isValidUnit('ether').should.be.true;
+          isValidUnit('tether').should.be.true;
+        });
+      });
+    });
+
+    describe('#toWei', function () {
+      context('when specifying ether as convertion unit', function () {
+        it('transforms ethers to wei', function () {
+          toWei('1', 'ether').should.eq(1e18.toString());
+        });
+      });
+
+      context('when specifying gwei as convertion unit', function () {
+        it('transforms ethers to wei', function () {
+          toWei('1', 'gwei').should.eq(1e9.toString());
+        });
+      });
+    });
+
+    describe('#fromWei', function () {
+      context('when specifying wei to convert to gwei', function () {
+        it('transforms wei to gwei', function () {
+          fromWei(1e18.toString(), 'gwei').should.eq(1e9.toString());
+        });
+      });
+
+      context('when specifying gwei as convertion unit', function () {
+        it('transforms wei to ether', function () {
+          fromWei(1e18.toString(), 'ether').should.eq('1');
+        });
+      });
+    });
+  });
+});

--- a/packages/cli/test/utils/units.test.js
+++ b/packages/cli/test/utils/units.test.js
@@ -13,7 +13,7 @@ describe('units', function() {
       });
 
       context('when not specifying decimals and symbol', function() {
-        it('returns value and symbol', function() {
+        it('returns the raw amount value', function() {
           prettifyTokenAmount(15e10.toString()).should.eq(15e10.toString());
         });
       });
@@ -28,7 +28,7 @@ describe('units', function() {
       });
 
       context('when providing a valid unit', function() {
-        it('returns false', function() {
+        it('returns true', function() {
           isValidUnit('wei').should.be.true;
           isValidUnit('gwei').should.be.true;
           isValidUnit('ether').should.be.true;
@@ -45,7 +45,7 @@ describe('units', function() {
       });
 
       context('when specifying gwei as convertion unit', function () {
-        it('transforms ethers to wei', function () {
+        it('transforms gwei to wei', function () {
           toWei('1', 'gwei').should.eq(1e9.toString());
         });
       });

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -60,6 +60,10 @@ export default class ZWeb3 {
     return Web3.utils.toWei(value, unit);
   }
 
+  public static fromWei(value: string, unit: any): string {
+    return Web3.utils.fromWei(value, unit);
+  }
+
   public static getUnits(): string[] {
     return Object.keys(Web3.utils.unitMap);
   }

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -45,7 +45,7 @@ export default class ZWeb3 {
       ? new Web3(new Web3.providers.HttpProvider(ZWeb3.provider))
       : new Web3(ZWeb3.provider);
 
-    return ZWeb3.web3instance
+    return ZWeb3.web3instance;
   }
 
   public static sha3(value: string): string {
@@ -54,18 +54,6 @@ export default class ZWeb3 {
 
   public static isAddress(address: string): boolean {
     return Web3.utils.isAddress(address);
-  }
-
-  public static toWei(value: string, unit: any): string {
-    return Web3.utils.toWei(value, unit);
-  }
-
-  public static fromWei(value: string, unit: any): string {
-    return Web3.utils.fromWei(value, unit);
-  }
-
-  public static getUnits(): string[] {
-    return Object.keys(Web3.utils.unitMap);
   }
 
   public static eth(): Eth {

--- a/packages/lib/test/src/artifacts/ZWeb3.test.js
+++ b/packages/lib/test/src/artifacts/ZWeb3.test.js
@@ -97,6 +97,20 @@ contract('ZWeb3', function(accounts) {
       })
     })
 
+    describe('fromWei', function () {
+      context('when specifying wei to convert to gwei', function () {
+        it('transforms wei to gwei', function () {
+          ZWeb3.fromWei(1e18.toString(), 'gwei').should.eq(1e9.toString());
+        })
+      })
+
+      context('when specifying gwei as convertion unit', function () {
+        it('transforms wei to ether', function () {
+          ZWeb3.fromWei(1e18.toString(), 'ether').should.eq('1');
+        })
+      })
+    })
+
     describe('getUnits', function () {
       it('returns array of valid units', function () {
         const units = ZWeb3.getUnits();

--- a/packages/lib/test/src/artifacts/ZWeb3.test.js
+++ b/packages/lib/test/src/artifacts/ZWeb3.test.js
@@ -83,42 +83,6 @@ contract('ZWeb3', function(accounts) {
       block.number.should.not.be.null
     })
 
-    describe('toWei', function () {
-      context('when specifying ether as convertion unit', function () {
-        it('transforms ethers to wei', function () {
-          ZWeb3.toWei('1', 'ether').should.eq(1e18.toString());
-        })
-      })
-
-      context('when specifying gwei as convertion unit', function () {
-        it('transforms ethers to wei', function () {
-          ZWeb3.toWei('1', 'gwei').should.eq(1e9.toString());
-        })
-      })
-    })
-
-    describe('fromWei', function () {
-      context('when specifying wei to convert to gwei', function () {
-        it('transforms wei to gwei', function () {
-          ZWeb3.fromWei(1e18.toString(), 'gwei').should.eq(1e9.toString());
-        })
-      })
-
-      context('when specifying gwei as convertion unit', function () {
-        it('transforms wei to ether', function () {
-          ZWeb3.fromWei(1e18.toString(), 'ether').should.eq('1');
-        })
-      })
-    })
-
-    describe('getUnits', function () {
-      it('returns array of valid units', function () {
-        const units = ZWeb3.getUnits();
-        units.should.be.an('array').that.includes('wei', 'gwei', 'ether');
-        units.should.be.an('array').that.not.includes('foo', 'bar', 'buz');
-      })
-    })
-
     describe('get code', function () {
       it('can tell the deployed bytecode of a certain address', async function () {
         const bytecode = await ZWeb3.getCode(this.impl.address)

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -329,7 +329,7 @@ contract('Transactions', function(accounts) {
       context('when function is payable', function() {
         it('sends funds', async function () {
           const encodedCall = encodeCall('initializePayable', [], []);
-          const transactionParams = { data: encodedCall, value: ZWeb3.toWei('1', 'ether') };
+          const transactionParams = { data: encodedCall, value: utils.toWei('1', 'ether') };
           await Transactions.sendRawTransaction(this.instance.address, transactionParams, { from: account2 });
           (await ZWeb3.getBalance(this.instance.address)).should.eq(1e18.toString());
         });
@@ -337,7 +337,7 @@ contract('Transactions', function(accounts) {
 
       context('when function is not payable', function() {
         it('reverts', async function () {
-          const transactionParams = { data: this.encodedCall, value: ZWeb3.toWei('1', 'ether') };
+          const transactionParams = { data: this.encodedCall, value: utils.toWei('1', 'ether') };
           await assertRevert(Transactions.sendRawTransaction(this.instance.address, transactionParams, { from: account2 }));
           (await ZWeb3.getBalance(this.instance.address)).should.eq('0');
         });


### PR DESCRIPTION
Fixes #828, fixes #829.

Started implementing both interactive command and script to get the balance of an account on a specified network, or to get the balance in tokens if an ERC20 address is specified.

Example usage:
![balance-gif](https://i.ibb.co/gv0Nq88/balance.gif)

Still have to add some tests, and also decide what to do with the ERC20 `abi` that I included in a new `utils/constants.ts`, which I believe it's mandatory to have in the project to query both token balance and symbol.

~_Message for the reviewer: I branched from `feature/transfer-command` and squashed all the commits implemented on it for making the review easier. You should review all commits after `f3f0b76` (included). After merging https://github.com/zeppelinos/zos/pull/823, we can remove that squashed commit_.~
