### PR TITLE
Fix set-admin owner check

### DIFF
--- a/packages/cli/src/commands/create2.ts
+++ b/packages/cli/src/commands/create2.ts
@@ -1,5 +1,7 @@
 import pickBy from 'lodash.pickby';
 
+import { TxParams } from 'zos-lib';
+
 import create from '../scripts/create';
 import queryDeployment from '../scripts/query-deployment';
 import querySignedDeployment from '../scripts/query-signed-deployment';
@@ -44,12 +46,12 @@ async function action(contractFullName: string, options: any): Promise<void> {
 
 export default { name, signature, description, register, action };
 
-async function runQuery(options: any, network: string, txParams: any) {
+async function runQuery(options: any, network: string, txParams: TxParams) {
   const sender = (typeof options.query === 'boolean') ? null : options.query;
   await queryDeployment({ salt: options.salt, sender, network, txParams });
 }
 
-async function runSignatureQuery(options: any, network: string, txParams: any) {
+async function runSignatureQuery(options: any, network: string, txParams: TxParams) {
   const { query, initMethod, initArgs, contractAlias, packageName, force, salt, signature: signatureOption, admin } = options;
   if (!contractAlias) throw new Error('missing required argument: alias');
   if (typeof query === 'string') throw new Error('cannot specify argument `sender\' as it is inferred from `signature\'');
@@ -57,7 +59,7 @@ async function runSignatureQuery(options: any, network: string, txParams: any) {
   await querySignedDeployment({ ...args, network, txParams });
 }
 
-async function runCreate(options: any, network: string, txParams: any) {
+async function runCreate(options: any, network: string, txParams: TxParams) {
   const { initMethod, initArgs, contractAlias, packageName, force, salt, signature: signatureOption, admin } = options;
   if (!contractAlias) throw new Error('missing required argument: alias');
   const args = pickBy({ packageName, contractAlias, initMethod, initArgs, force, salt, signature: signatureOption, admin });

--- a/packages/cli/src/models/TestHelper.ts
+++ b/packages/cli/src/models/TestHelper.ts
@@ -1,6 +1,6 @@
 import NetworkController from '../models/network/NetworkController';
 import ZosNetworkFile from '../models/files/ZosNetworkFile';
-import { ProxyAdminProject, AppProject } from 'zos-lib';
+import { ProxyAdminProject, AppProject, TxParams } from 'zos-lib';
 
 /**
  * Initializes a zOS application testing and deploying it to the test network,
@@ -8,7 +8,7 @@ import { ProxyAdminProject, AppProject } from 'zos-lib';
  * @param txParams optional txParams (from, gas, gasPrice) to use on every transaction
  * @param networkFile optional `ZosNetworkFile` object to use, instead of zos.test.json
  */
-export default async function(txParams: any = {}, networkFile?: ZosNetworkFile): Promise<ProxyAdminProject | AppProject> {
+export default async function(txParams: TxParams = {}, networkFile?: ZosNetworkFile): Promise<ProxyAdminProject | AppProject> {
   const controller = new NetworkController('test', txParams, networkFile);
   await controller.deployDependencies();
   await controller.push(false, true);

--- a/packages/cli/src/models/dependency/Dependency.ts
+++ b/packages/cli/src/models/dependency/Dependency.ts
@@ -7,7 +7,7 @@ import npm from 'npm-programmatic';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
-import { FileSystem as fs, PackageProject, Contracts, Contract, getSolidityLibNames, Logger } from 'zos-lib';
+import { TxParams, FileSystem as fs, PackageProject, Contracts, Contract, getSolidityLibNames, Logger } from 'zos-lib';
 import ZosPackageFile from '../files/ZosPackageFile';
 import ZosNetworkFile from '../files/ZosNetworkFile';
 
@@ -74,7 +74,7 @@ export default class Dependency {
     this.requirement = requirement || tryWithCaret(packageVersion);
   }
 
-  public async deploy(txParams: any): Promise<PackageProject> {
+  public async deploy(txParams: TxParams): Promise<PackageProject> {
     const version = semver.coerce(this.version).toString();
     const project = await PackageProject.fetchOrDeploy(version, txParams, {});
 

--- a/packages/cli/src/models/initializer/ConfigVariablesInitializer.ts
+++ b/packages/cli/src/models/initializer/ConfigVariablesInitializer.ts
@@ -1,15 +1,20 @@
-import { ZWeb3, Contracts } from 'zos-lib';
+import { ZWeb3, Contracts, TxParams } from 'zos-lib';
 import Truffle from './truffle/Truffle';
 import Session from '../network/Session';
 
-const ConfigVariablesInitializer = {
+export interface NetworkConfig {
+  network: string;
+  txParams: TxParams;
+}
 
-  initStaticConfiguration(): void {
+export default class ConfigVariablesInitializer {
+
+  public static initStaticConfiguration(): void {
     const buildDir = Truffle.getBuildDir();
     Contracts.setLocalBuildDir(buildDir);
-  },
+  }
 
-  async initNetworkConfiguration(options: any, silent?: boolean): Promise<any> {
+  public static async initNetworkConfiguration(options: any, silent?: boolean): Promise<NetworkConfig> {
     this.initStaticConfiguration();
     const { network, from, timeout } = Session.getOptions(options, silent);
     Session.setDefaultNetworkIfNeeded(options.network);
@@ -26,6 +31,4 @@ const ConfigVariablesInitializer = {
     const txParams = { from: ZWeb3.toChecksumAddress(from || artifactDefaults.from || await ZWeb3.defaultAccount()) };
     return { network: await ZWeb3.getNetworkName(), txParams };
   }
-};
-
-export default ConfigVariablesInitializer;
+}

--- a/packages/cli/src/models/local/LocalController.ts
+++ b/packages/cli/src/models/local/LocalController.ts
@@ -2,7 +2,17 @@
 
 import every from 'lodash.every';
 import map from 'lodash.map';
-import { Contracts, Contract, Logger, FileSystem as fs, getBuildArtifacts, BuildArtifacts, validate as validateContract, validationPasses} from 'zos-lib';
+import {
+  Contracts,
+  Contract,
+  Logger,
+  FileSystem as fs,
+  getBuildArtifacts,
+  BuildArtifacts,
+  validate as validateContract,
+  validationPasses,
+  TxParams,
+} from 'zos-lib';
 
 import Session from '../network/Session';
 import Dependency from '../dependency/Dependency';
@@ -186,7 +196,7 @@ export default class LocalController {
     }
   }
 
-  public onNetwork(network: string, txParams: any, networkFile?: ZosNetworkFile): NetworkController {
+  public onNetwork(network: string, txParams: TxParams, networkFile?: ZosNetworkFile): NetworkController {
     return new NetworkController(network, txParams, networkFile);
   }
 }

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -14,9 +14,32 @@ import isEqual from 'lodash.isequal';
 import concat from 'lodash.concat';
 import toPairs from 'lodash.topairs';
 
-import { Contracts, Contract, Logger, FileSystem as fs, Proxy, Transactions, semanticVersionToString, contractMethodsFromAst } from 'zos-lib';
-import { ProxyAdminProject, AppProject, flattenSourceCode, getStorageLayout, BuildArtifacts, getBuildArtifacts, getSolidityLibNames } from 'zos-lib';
-import { validate, newValidationErrors, validationPasses, App, ZWeb3, ProxyAdmin, SimpleProject, AppProxyMigrator } from 'zos-lib';
+import {
+  Contracts,
+  Contract,
+  Logger,
+  FileSystem as fs,
+  Proxy,
+  Transactions,
+  semanticVersionToString,
+  contractMethodsFromAst,
+  ProxyAdminProject,
+  AppProject,
+  flattenSourceCode,
+  getStorageLayout,
+  BuildArtifacts,
+  getBuildArtifacts,
+  getSolidityLibNames,
+  validate,
+  newValidationErrors,
+  validationPasses,
+  App,
+  ZWeb3,
+  TxParams,
+  ProxyAdmin,
+  SimpleProject,
+  AppProxyMigrator
+} from 'zos-lib';
 import { isMigratableZosversion } from '../files/ZosVersion';
 import { allPromisesOrError } from '../../utils/async';
 import { toContractFullName } from '../../utils/naming';
@@ -37,12 +60,12 @@ type ProjectDeployer = ProxyAdminProjectDeployer | AppProjectDeployer;
 export default class NetworkController {
 
   public localController: LocalController;
-  public txParams: any;
+  public txParams: TxParams;
   public network: string;
   public networkFile: ZosNetworkFile;
   public project: Project;
 
-  constructor(network: string, txParams: any, networkFile?: ZosNetworkFile) {
+  constructor(network: string, txParams: TxParams, networkFile?: ZosNetworkFile) {
     if(!networkFile) {
       const packageFile = new ZosPackageFile();
       this.networkFile = packageFile.networkFile(network);

--- a/packages/cli/src/models/network/ProjectDeployer.ts
+++ b/packages/cli/src/models/network/ProjectDeployer.ts
@@ -1,5 +1,13 @@
 import forEach from 'lodash.foreach';
-import { AppProject, PackageProject, ProxyAdminProject, App, Package, ImplementationDirectory } from 'zos-lib';
+import {
+  AppProject,
+  PackageProject,
+  ProxyAdminProject,
+  App,
+  Package,
+  ImplementationDirectory,
+  TxParams,
+} from 'zos-lib';
 
 import NetworkController from './NetworkController';
 import ZosPackageFile from '../files/ZosPackageFile';
@@ -24,7 +32,7 @@ class BaseProjectDeployer {
   protected controller: NetworkController;
   protected packageFile: ZosPackageFile;
   protected networkFile: ZosNetworkFile;
-  protected txParams: any;
+  protected txParams: TxParams;
   protected requestedVersion: string;
 
   constructor(controller: NetworkController, requestedVersion: string) {

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -1,4 +1,4 @@
-import { Transactions, Logger, ZWeb3 } from 'zos-lib';
+import { Transactions, Logger, ZWeb3, TxParams } from 'zos-lib';
 import { isValidUnit, prettifyTokenAmount, toWei, fromWei } from '../../utils/units';
 import { ERC20_PARTIAL_ABI } from '../../utils/constants';
 import { allPromisesOrError } from '../../utils/async';
@@ -12,7 +12,7 @@ interface ERC20TokenInfo {
 }
 
 export default class TransactionController {
-  public txParams: any;
+  public txParams: TxParams;
 
   constructor(txParams?: any) {
     if (txParams) this.txParams = txParams;

--- a/packages/cli/src/models/status/StatusChecker.ts
+++ b/packages/cli/src/models/status/StatusChecker.ts
@@ -1,11 +1,18 @@
-import { promisify } from 'util';
-
 import EventsFilter from './EventsFilter';
 import StatusFetcher from './StatusFetcher';
 import StatusComparator from './StatusComparator';
-import { ZWeb3, Logger, AppProject, bytecodeDigest, semanticVersionToString, semanticVersionEqual, replaceSolidityLibAddress, isSolidityLib } from 'zos-lib';
+import {
+  ZWeb3,
+  TxParams,
+  Logger,
+  AppProject,
+  bytecodeDigest,
+  semanticVersionToString,
+  semanticVersionEqual,
+  replaceSolidityLibAddress,
+  isSolidityLib
+} from 'zos-lib';
 import ZosNetworkFile, {
-  ProxyInterface,
   DependencyInterface
 } from '../files/ZosNetworkFile';
 import { ComparedObject } from './StatusComparator';
@@ -16,23 +23,23 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export default class StatusChecker {
 
   public visitor: any;
-  public txParams: any;
+  public txParams: TxParams;
   public networkFile: any;
   public packageName: any;
 
   private project: AppProject;
 
-  public static fetch(networkFile: ZosNetworkFile, txParams: any = {}): StatusChecker {
+  public static fetch(networkFile: ZosNetworkFile, txParams: TxParams = {}): StatusChecker {
     const fetcher = new StatusFetcher(networkFile);
     return new this(fetcher, networkFile, txParams);
   }
 
-  public static compare(networkFile: ZosNetworkFile, txParams: any = {}): StatusChecker {
+  public static compare(networkFile: ZosNetworkFile, txParams: TxParams = {}): StatusChecker {
     const comparator = new StatusComparator();
     return new this(comparator, networkFile, txParams);
   }
 
-  constructor(visitor: any, networkFile: ZosNetworkFile, txParams: any = {}) {
+  constructor(visitor: any, networkFile: ZosNetworkFile, txParams: TxParams = {}) {
     this.visitor = visitor;
     this.txParams = txParams;
     this.networkFile = networkFile;

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -1,3 +1,5 @@
+import { TxParams } from 'zos-lib';
+
 import ZosPackageFile from '../models/files/ZosPackageFile';
 import ZosNetworkFile from '../models/files/ZosNetworkFile';
 
@@ -18,7 +20,7 @@ interface PackageArgs {
 
 interface Network {
   network: string;
-  txParams?: any;
+  txParams?: TxParams;
   networkFile?: ZosNetworkFile;
 }
 

--- a/packages/lib/src/application/App.ts
+++ b/packages/lib/src/application/App.ts
@@ -11,19 +11,20 @@ import { buildCallData, callDescription, CalldataInfo } from '../utils/ABIs';
 import Contract from '../artifacts/Contract';
 import { toSemanticVersion, semanticVersionEqual } from '../utils/Semver';
 import Transactions from '../utils/Transactions';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('App');
 
 export default class App {
   public appContract: any;
-  private txParams: any;
+  private txParams: TxParams;
 
-  public static async fetch(address: string, txParams: any = {}): Promise<App> {
+  public static async fetch(address: string, txParams: TxParams = {}): Promise<App> {
     const appContract = (await this.getContractClass()).at(address);
     return new this(appContract, txParams);
   }
 
-  public static async deploy(txParams: any = {}): Promise<App> {
+  public static async deploy(txParams: TxParams = {}): Promise<App> {
     log.info('Deploying new App...');
     const appContract = await Transactions.deployContract(this.getContractClass(), [], txParams);
     log.info(`Deployed App at ${appContract.address}`);
@@ -34,7 +35,7 @@ export default class App {
     return Contracts.getFromLib('App');
   }
 
-  constructor(appContract: Contract, txParams: any = {}) {
+  constructor(appContract: Contract, txParams: TxParams = {}) {
     this.appContract = appContract;
     this.txParams = txParams;
   }

--- a/packages/lib/src/application/ImplementationDirectory.ts
+++ b/packages/lib/src/application/ImplementationDirectory.ts
@@ -2,6 +2,7 @@ import Logger from '../utils/Logger';
 import Transactions from '../utils/Transactions';
 import Contracts from '../artifacts/Contracts';
 import Contract from '../artifacts/Contract';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log = new Logger('ImplementationDirectory');
 
@@ -9,9 +10,9 @@ const log = new Logger('ImplementationDirectory');
 export default class ImplementationDirectory {
 
   public directoryContract: Contract;
-  public txParams: any;
+  public txParams: TxParams;
 
-  public static async deploy(txParams: any = {}): Promise<ImplementationDirectory> {
+  public static async deploy(txParams: TxParams = {}): Promise<ImplementationDirectory> {
     const contract = this.getContract();
     log.info(`Deploying new ${contract.schema.contractName}...`);
     const directory = await Transactions.deployContract(contract, [], txParams);
@@ -20,7 +21,7 @@ export default class ImplementationDirectory {
     return new this(directory, txParams);
   }
 
-  public static fetch(address: string, txParams: any = {}): ImplementationDirectory {
+  public static fetch(address: string, txParams: TxParams = {}): ImplementationDirectory {
     const contract = this.getContract();
     const directory = contract.at(address);
     return new this(directory, txParams);
@@ -30,7 +31,7 @@ export default class ImplementationDirectory {
     return Contracts.getFromLib('ImplementationDirectory');
   }
 
-  constructor(directory: Contract, txParams: any = {}) {
+  constructor(directory: Contract, txParams: TxParams = {}) {
     this.directoryContract = directory;
     this.txParams = txParams;
   }

--- a/packages/lib/src/application/Package.ts
+++ b/packages/lib/src/application/Package.ts
@@ -4,22 +4,23 @@ import ImplementationDirectory from '../application/ImplementationDirectory';
 import { toSemanticVersion, SemanticVersion } from '../utils/Semver';
 import { toAddress, isZeroAddress } from '../utils/Addresses';
 import Contract from '../artifacts/Contract';
+import { TxParams } from '../artifacts/ZWeb3';
 import Transactions from '../utils/Transactions';
 
 const log: Logger = new Logger('Package');
 
 export default class Package {
   private packageContract: Contract;
-  private txParams: any;
+  private txParams: TxParams;
 
-  public static fetch(address: string, txParams: any = {}): Package | null {
+  public static fetch(address: string, txParams: TxParams = {}): Package | null {
     if (isZeroAddress(address)) return null;
     const PackageContact = Contracts.getFromLib('Package');
     const packageContract = PackageContact.at(address);
     return new this(packageContract, txParams);
   }
 
-  public static async deploy(txParams: any = {}): Promise<Package> {
+  public static async deploy(txParams: TxParams = {}): Promise<Package> {
     log.info('Deploying new Package...');
     const PackageContract: Contract = Contracts.getFromLib('Package');
     const packageContract = await Transactions.deployContract(PackageContract, [], txParams);
@@ -27,7 +28,7 @@ export default class Package {
     return new this(packageContract, txParams);
   }
 
-  constructor(packageContract: Contract, txParams: any = {}) {
+  constructor(packageContract: Contract, txParams: TxParams = {}) {
     this.packageContract = packageContract;
     this.txParams = txParams;
   }

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -18,6 +18,11 @@ const NETWORKS = {
   42: 'kovan'
 };
 
+export interface TxParams {
+  from?: string;
+  gas?: number;
+}
+
 // TS-TODO: Type Web3.
 // TS-TODO: Review what could be private in this class.
 export default class ZWeb3 {
@@ -144,11 +149,11 @@ export default class ZWeb3 {
     return NETWORKS[networkId] || `dev-${networkId}`;
   }
 
-  public static async sendTransaction(params: any): Promise<TransactionReceipt> {
+  public static async sendTransaction(params: TxParams): Promise<TransactionReceipt> {
     return ZWeb3.eth().sendTransaction({ ...params });
   }
 
-  public static sendTransactionWithoutReceipt(params: any): Promise<string> {
+  public static sendTransactionWithoutReceipt(params: TxParams): Promise<string> {
     return new Promise((resolve, reject) => {
       ZWeb3.eth().sendTransaction({ ...params }, (error, txHash) => {
         if (error) reject(error.message);

--- a/packages/lib/src/helpers/copyContract.ts
+++ b/packages/lib/src/helpers/copyContract.ts
@@ -4,13 +4,14 @@ import ZWeb3 from '../artifacts/ZWeb3';
 import Contracts from '../artifacts/Contracts';
 import Contract from '../artifacts/Contract';
 import Transactions from '../utils/Transactions';
+import { TxParams } from '../artifacts/ZWeb3';
 
 async function sendTransaction(params: any): Promise<any> {
   if (!params.gas) params.gas = await Transactions.estimateGas(params);
   return ZWeb3.sendTransactionWithoutReceipt(params);
 }
 
-export default async function copyContract(contract: Contract, address: string, txParams: any = {}): Promise<Contract> {
+export default async function copyContract(contract: Contract, address: string, txParams: TxParams = {}): Promise<Contract> {
   const trimmedAddress: string = address.replace('0x', '');
 
   // This is EVM assembly will return of the code of a foreign address.

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -13,7 +13,7 @@ import Logger from './utils/Logger';
 import FileSystem from './utils/FileSystem';
 import Contracts from './artifacts/Contracts';
 import Contract, { contractMethodsFromAst } from './artifacts/Contract';
-import ZWeb3 from './artifacts/ZWeb3';
+import ZWeb3, { TxParams } from './artifacts/ZWeb3';
 import { bodyCode, constructorCode, bytecodeDigest, replaceSolidityLibAddress, isSolidityLib, getSolidityLibNames } from './utils/Bytecode';
 import Transactions from './utils/Transactions';
 import { flattenSourceCode } from './utils/Solidity';
@@ -82,6 +82,7 @@ export {
   Semver,
   FileSystem,
   ZWeb3,
+  TxParams,
   Transactions,
   Contracts,
   App,

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -15,6 +15,7 @@ import { DeployError } from '../utils/errors/DeployError';
 import { semanticVersionToString } from '../utils/Semver';
 import ProxyFactory from '../proxy/ProxyFactory';
 import { CalldataInfo, buildCallData, callDescription } from '../utils/ABIs';
+import { TxParams } from '../artifacts/ZWeb3';
 import Logger from '../utils/Logger';
 
 const DEFAULT_NAME: string = 'main';
@@ -48,7 +49,7 @@ class BaseAppProject extends BasePackageProject {
   public static async fetchOrDeploy(
     name: string = DEFAULT_NAME,
     version: string = DEFAULT_VERSION,
-    txParams: any = {},
+    txParams: TxParams = {},
     { appAddress, packageAddress, proxyAdminAddress, proxyFactoryAddress }: ExistingAddresses = {}
   ): Promise<AppProject | never> {
     let thepackage: Package;
@@ -110,7 +111,7 @@ class BaseAppProject extends BasePackageProject {
     return appProject;
   }
 
-  constructor(app: App, name: string = DEFAULT_NAME, version: string = DEFAULT_VERSION, proxyAdmin: ProxyAdmin, proxyFactory: ProxyFactory, txParams: any = {}) {
+  constructor(app: App, name: string = DEFAULT_NAME, version: string = DEFAULT_VERSION, proxyAdmin: ProxyAdmin, proxyFactory: ProxyFactory, txParams: TxParams = {}) {
     super(txParams);
     this.app = app;
     this.name = name;

--- a/packages/lib/src/project/BasePackageProject.ts
+++ b/packages/lib/src/project/BasePackageProject.ts
@@ -4,12 +4,13 @@ import { semanticVersionToString } from '../utils/Semver';
 import Contract from '../artifacts/Contract';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import Package from '../application/Package';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('PackageProject');
 
 export default abstract class BasePackageProject {
 
-  protected txParams: any;
+  protected txParams: TxParams;
   public version: string;
   public package: Package;
   protected directory: ImplementationDirectory;

--- a/packages/lib/src/project/BaseSimpleProject.ts
+++ b/packages/lib/src/project/BaseSimpleProject.ts
@@ -11,6 +11,7 @@ import { buildCallData, callDescription, CalldataInfo } from '../utils/ABIs';
 import { ContractInterface } from './AppProject';
 import Contract from '../artifacts/Contract';
 import ProxyFactory from '../proxy/ProxyFactory';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('BaseSimpleProject');
 
@@ -35,11 +36,11 @@ interface Dependency {
 export default abstract class BaseSimpleProject {
   public implementations: Implementations;
   public dependencies: Dependencies;
-  public txParams: any;
+  public txParams: TxParams;
   public name: string;
   public proxyFactory?: ProxyFactory;
 
-  constructor(name: string, proxyFactory?: ProxyFactory, txParams = {}) {
+  constructor(name: string, proxyFactory?: ProxyFactory, txParams: TxParams = {}) {
     this.txParams = txParams;
     this.name = name;
     this.implementations = {};

--- a/packages/lib/src/project/PackageProject.ts
+++ b/packages/lib/src/project/PackageProject.ts
@@ -3,16 +3,17 @@ import Package from '../application/Package';
 import ImplementationDirectory from '../application/ImplementationDirectory';
 import { DeployError } from '../utils/errors/DeployError';
 import { semanticVersionToString } from '../utils/Semver';
+import { TxParams } from '../artifacts/ZWeb3';
 
 export default class PackageProject extends BasePackageProject {
 
-  public static async fetch(packageAddress: string, version: string = '0.1.0', txParams: any): Promise<PackageProject> {
+  public static async fetch(packageAddress: string, version: string = '0.1.0', txParams: TxParams): Promise<PackageProject> {
     const thepackage: Package = Package.fetch(packageAddress, txParams);
     return new this(thepackage, version, txParams);
   }
 
   // REFACTOR: Evaluate merging this logic with CLI's ProjectDeployer classes
-  public static async fetchOrDeploy(version: string = '0.1.0', txParams: any = {}, { packageAddress }: { packageAddress?: string } = {}): Promise<PackageProject | never> {
+  public static async fetchOrDeploy(version: string = '0.1.0', txParams: TxParams = {}, { packageAddress }: { packageAddress?: string } = {}): Promise<PackageProject | never> {
     let thepackage: Package;
     let directory: ImplementationDirectory;
     version = semanticVersionToString(version);
@@ -34,7 +35,7 @@ export default class PackageProject extends BasePackageProject {
     }
   }
 
-  constructor(thepackage: Package, version: string = '0.1.0', txParams: any = {}) {
+  constructor(thepackage: Package, version: string = '0.1.0', txParams: TxParams = {}) {
     super(txParams);
     this.package = thepackage;
     this.version = semanticVersionToString(version);

--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -6,13 +6,14 @@ import { ContractInterface } from './AppProject';
 import Contract from '../artifacts/Contract';
 import ProxyFactory from '../proxy/ProxyFactory';
 import ProxyAdminProjectMixin from './mixin/ProxyAdminProjectMixin';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('ProxyAdminProject');
 
 class BaseProxyAdminProject extends BaseSimpleProject {
   public proxyAdmin: ProxyAdmin;
 
-  public static async fetch(name: string = 'main', txParams: any = {}, proxyAdminAddress?: string, proxyFactoryAddress?: string): Promise<ProxyAdminProject> {
+  public static async fetch(name: string = 'main', txParams: TxParams = {}, proxyAdminAddress?: string, proxyFactoryAddress?: string): Promise<ProxyAdminProject> {
     const proxyAdmin = proxyAdminAddress ? await ProxyAdmin.fetch(proxyAdminAddress, txParams) : null;
     const proxyFactory = proxyFactoryAddress ? await ProxyFactory.fetch(proxyFactoryAddress, txParams) : null;
     return new ProxyAdminProject(name, proxyAdmin, proxyFactory, txParams);

--- a/packages/lib/src/project/SimpleProject.ts
+++ b/packages/lib/src/project/SimpleProject.ts
@@ -5,11 +5,12 @@ import Contract from '../artifacts/Contract';
 import { ContractInterface } from './AppProject';
 import BaseSimpleProject from './BaseSimpleProject';
 import ProxyFactory from '../proxy/ProxyFactory';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('SimpleProject');
 
 export default class SimpleProject  extends BaseSimpleProject {
-  constructor(name: string = 'main', proxyFactory?: ProxyFactory, txParams: any = {}) {
+  constructor(name: string = 'main', proxyFactory?: ProxyFactory, txParams: TxParams = {}) {
     super(name, proxyFactory, txParams);
   }
 

--- a/packages/lib/src/proxy/Proxy.ts
+++ b/packages/lib/src/proxy/Proxy.ts
@@ -3,13 +3,14 @@ import Contracts from '../artifacts/Contracts';
 import { toAddress, uint256ToAddress } from '../utils/Addresses';
 import Transactions from '../utils/Transactions';
 import Contract from '../artifacts/Contract';
+import { TxParams } from '../artifacts/ZWeb3';
 
 export default class Proxy {
   private contract: Contract;
-  private txParams: any;
+  private txParams: TxParams;
   public address: string;
 
-  public static at(contractOrAddress: string | Contract, txParams: any = {}): Proxy {
+  public static at(contractOrAddress: string | Contract, txParams: TxParams = {}): Proxy {
     const ProxyContract = Contracts.getFromLib('AdminUpgradeabilityProxy');
     const contract = ProxyContract.at(toAddress(contractOrAddress));
     return new this(contract, txParams);
@@ -22,7 +23,7 @@ export default class Proxy {
     return new this(contract, txParams);
   }
 
-  constructor(contract: Contract, txParams: any = {}) {
+  constructor(contract: Contract, txParams: TxParams = {}) {
     this.address = toAddress(contract);
     this.contract = contract;
     this.txParams = txParams;

--- a/packages/lib/src/proxy/ProxyFactory.ts
+++ b/packages/lib/src/proxy/ProxyFactory.ts
@@ -4,31 +4,32 @@ import { toAddress } from '../utils/Addresses';
 import Transactions from '../utils/Transactions';
 import Contract from '../artifacts/Contract';
 import Proxy from './Proxy';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('ProxyFactory');
 
 export default class ProxyFactory {
   public contract: Contract;
   public address: string;
-  public txParams: any;
+  public txParams: TxParams;
 
-  public static tryFetch(address: string, txParams: any = {}): ProxyFactory | null {
+  public static tryFetch(address: string, txParams: TxParams = {}): ProxyFactory | null {
     return address ? this.fetch(address, txParams) : null;
   }
 
-  public static fetch(address: string, txParams: any = {}): ProxyFactory {
+  public static fetch(address: string, txParams: TxParams = {}): ProxyFactory {
     const contract = Contracts.getFromLib('ProxyFactory').at(address);
     return new this(contract, txParams);
   }
 
-  public static async deploy(txParams: any = {}): Promise<ProxyFactory> {
+  public static async deploy(txParams: TxParams = {}): Promise<ProxyFactory> {
     log.info('Deploying new ProxyFactory...');
     const contract = await Transactions.deployContract(Contracts.getFromLib('ProxyFactory'), [], txParams);
     log.info(`Deployed ProxyFactory at ${contract.address}`);
     return new this(contract, txParams);
   }
 
-  constructor(contract: any, txParams: any = {}) {
+  constructor(contract: any, txParams: TxParams = {}) {
     this.contract = contract;
     this.address = toAddress(contract);
     this.txParams = txParams;

--- a/packages/lib/src/utils/Migrator.ts
+++ b/packages/lib/src/utils/Migrator.ts
@@ -1,10 +1,11 @@
 import Transactions from './Transactions';
 import encodeCall from '../helpers/encodeCall';
 import Logger from '../utils/Logger';
+import { TxParams } from '../artifacts/ZWeb3';
 
 const log: Logger = new Logger('Migrator');
 
-export default async function migrate(appAddress: string, proxyAddress: string, proxyAdminAddress: string, txParams: any = {}): Promise<void> {
+export default async function migrate(appAddress: string, proxyAddress: string, proxyAdminAddress: string, txParams: TxParams = {}): Promise<void> {
   const data = encodeCall('changeProxyAdmin', ['address', 'address'], [proxyAddress, proxyAdminAddress]);
   await Transactions.sendRawTransaction(appAddress, { data }, { ...txParams });
   log.info(`Proxy ${proxyAddress} admin changed to ${proxyAdminAddress}`);

--- a/packages/lib/src/utils/Transactions.ts
+++ b/packages/lib/src/utils/Transactions.ts
@@ -13,6 +13,7 @@ import Contracts from '../artifacts/Contracts';
 import Contract from '../artifacts/Contract';
 import { TransactionReceipt } from 'web3/types';
 import { buildDeploymentCallData } from './ABIs';
+import { TxParams } from '../artifacts/ZWeb3';
 
 // Cache, exported for testing
 export const state: any = {};
@@ -51,7 +52,7 @@ export default {
    * @param txParams other transaction parameters (from, gasPrice, etc)
    * @param retries number of transaction retries
    */
-  async sendRawTransaction(address: string, { data, value }: TransactionParams, txParams: any = {}, retries: number = RETRY_COUNT): Promise<any> {
+  async sendRawTransaction(address: string, { data, value }: TransactionParams, txParams: TxParams = {}, retries: number = RETRY_COUNT): Promise<any> {
     await this._fixGasPrice(txParams);
     try {
       const from = await ZWeb3.defaultAccount();
@@ -74,7 +75,7 @@ export default {
    * @param txParams other transaction parameters (from, gasPrice, etc)
    * @param retries number of transaction retries
    */
-  async sendTransaction(contractFn: GenericFunction, args: any[] = [], txParams: any = {}, retries: number = RETRY_COUNT): Promise<any> {
+  async sendTransaction(contractFn: GenericFunction, args: any[] = [], txParams: TxParams = {}, retries: number = RETRY_COUNT): Promise<any> {
     await this._fixGasPrice(txParams);
 
     try {
@@ -94,7 +95,7 @@ export default {
    * @param txParams other transaction parameters (from, gasPrice, etc)
    * @param retries number of deploy retries
    */
-  async deployContract(contract: Contract, args: any[] = [], txParams: any = {}, retries: number = RETRY_COUNT): Promise<any> {
+  async deployContract(contract: Contract, args: any[] = [], txParams: TxParams = {}, retries: number = RETRY_COUNT): Promise<any> {
     await this._fixGasPrice(txParams);
 
     try {
@@ -113,7 +114,7 @@ export default {
    * @param txParams all transaction parameters (data, from, gasPrice, etc)
    * @param retries number of data transaction retries
    */
-  async sendDataTransaction(contract: Contract, txParams: any, retries: number = RETRY_COUNT): Promise<TransactionReceipt> {
+  async sendDataTransaction(contract: Contract, txParams: TxParams, retries: number = RETRY_COUNT): Promise<TransactionReceipt> {
     await this._fixGasPrice(txParams);
 
     try {
@@ -144,7 +145,7 @@ export default {
     }
   },
 
-  async estimateActualGasFnCall(contractFn: GenericFunction, args: any[], txParams: any, retries: number = RETRY_COUNT): Promise<any> {
+  async estimateActualGasFnCall(contractFn: GenericFunction, args: any[], txParams: TxParams, retries: number = RETRY_COUNT): Promise<any> {
     // Retry if estimate fails. This could happen because we are depending
     // on a previous transaction being mined that still hasn't reach the node
     // we are working with, if the txs are routed to different nodes.
@@ -177,7 +178,7 @@ export default {
     }
   },
 
-  async _sendContractDataTransaction(contract: Contract, txParams: any): Promise<TransactionReceipt> {
+  async _sendContractDataTransaction(contract: Contract, txParams: TxParams): Promise<TransactionReceipt> {
     const defaults = await Contracts.getDefaultTxParams();
     const tx = { to: contract.address, ...defaults, ...txParams };
     const txHash = await ZWeb3.sendTransactionWithoutReceipt(tx);


### PR DESCRIPTION
* The PR adds `set-admin` owner check in order to provide more meaningful messaging, and prevents sending failing transactions.
* It also introduce `TxParams` interface across `lib` and `cli` project for consistent typing. 
* Refactors `ConfigVariablesInitializer` to ES6 class.