### PR TITLE
Minimal proxies

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -10,6 +10,7 @@ import { hasToMigrateProject } from '../prompts/migrations';
 import ConfigVariablesInitializer from '../models/initializer/ConfigVariablesInitializer';
 import { promptIfNeeded, networksList, contractsList, methodsList, argsList } from '../prompts/prompt';
 import promptForMethodParams from '../prompts/method-params';
+import { ProxyType } from '../scripts/interfaces';
 
 interface PropsParams {
   contractFullName?: string;
@@ -28,6 +29,7 @@ const register: (program: any) => any = (program) => program
   .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
   .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
   .option('--force', 'force creation even if contracts have local modifications')
+  .option('--minimal', 'creates a cheaper but non-upgradeable instance instead, using a minimal proxy')
   .withNetworkOptions()
   .withNonInteractiveOption()
   .action(commandActions);
@@ -50,6 +52,7 @@ async function action(contractFullName: string, options: any) {
   const { force, methodName, methodArgs, network, txParams } = options;
   const { contract: contractAlias, package: packageName } = fromContractFullName(contractFullName);
   const args = pickBy({ packageName, contractAlias, methodName, methodArgs, force });
+  if (options.minimal) args.kind = ProxyType.Minimal;
 
   if (!await hasToMigrateProject(network)) process.exit(0);
 

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -244,7 +244,7 @@ export default class ZosNetworkFile {
     return !isEmpty(this.dependencies);
   }
 
-  public getProxies({ package: packageName, contract, address }: ProxyInterface = {}): ProxyInterface[] {
+  public getProxies({ package: packageName, contract, address, kind }: ProxyInterface = {}): ProxyInterface[] {
     if (isEmpty(this.data.proxies)) return [];
     const allProxies = flatMap(this.data.proxies || {}, (proxiesList, fullname) => (
       map(proxiesList, (proxyInfo) => ({
@@ -255,7 +255,8 @@ export default class ZosNetworkFile {
     return filter(allProxies, (proxy) => (
       (!packageName || proxy.package === packageName) &&
       (!contract || proxy.contract === contract) &&
-      (!address || proxy.address === address)
+      (!address || proxy.address === address) &&
+      (!kind || proxy.kind === kind)
     ));
   }
 

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -11,6 +11,7 @@ import { Logger, FileSystem as fs, bytecodeDigest, bodyCode, constructorCode, se
 import { fromContractFullName, toContractFullName } from '../../utils/naming';
 import { ZOS_VERSION, checkVersion } from './ZosVersion';
 import ZosPackageFile from './ZosPackageFile';
+import { ProxyType } from '../../scripts/interfaces';
 
 const log = new Logger('ZosNetworkFile');
 
@@ -42,6 +43,7 @@ export interface ProxyInterface {
   version?: string;
   implementation?: string;
   admin?: string;
+  kind?: ProxyType;
 }
 
 export interface DependencyInterface {

--- a/packages/cli/src/models/files/ZosNetworkFile.ts
+++ b/packages/cli/src/models/files/ZosNetworkFile.ts
@@ -249,7 +249,8 @@ export default class ZosNetworkFile {
     const allProxies = flatMap(this.data.proxies || {}, (proxiesList, fullname) => (
       map(proxiesList, (proxyInfo) => ({
         ...fromContractFullName(fullname),
-        ...proxyInfo
+        ...proxyInfo,
+        kind: proxyInfo.kind || ProxyType.Upgradeable
       }))
     ));
     return filter(allProxies, (proxy) => (

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -38,7 +38,8 @@ import {
   TxParams,
   ProxyAdmin,
   SimpleProject,
-  AppProxyMigrator
+  AppProxyMigrator,
+  MinimalProxy
 } from 'zos-lib';
 import { isMigratableZosversion } from '../files/ZosVersion';
 import { allPromisesOrError } from '../../utils/async';
@@ -52,6 +53,7 @@ import LocalController from '../local/LocalController';
 import ZosNetworkFile, { ProxyInterface } from '../files/ZosNetworkFile';
 import ZosPackageFile from '../files/ZosPackageFile';
 import { ZOS_VERSION } from '../files/ZosVersion';
+import { ProxyType } from '../../scripts/interfaces';
 
 const log = new Logger('NetworkController');
 type Project = ProxyAdminProject | AppProject;
@@ -534,7 +536,7 @@ export default class NetworkController {
   }
 
   // Proxy model
-  public async createProxy(packageName: string, contractAlias: string, initMethod: string, initArgs: string[], admin?: string, salt?: string, signature?: string): Promise<Contract> {
+  public async createProxy(packageName: string, contractAlias: string, initMethod: string, initArgs: string[], admin?: string, salt?: string, signature?: string, kind?: ProxyType): Promise<Contract> {
     await this._migrateZosversionIfNeeded();
     await this.fetchOrDeploy(this.currentVersion);
     if (!packageName) packageName = this.packageFile.name;
@@ -544,22 +546,44 @@ export default class NetworkController {
     if (salt) await this._checkDeploymentAddress(salt);
 
     const createArgs = { packageName, contractName: contractAlias, initMethod, initArgs, admin };
-    const proxyInstance = salt
-      ? await this.project.createProxyWithSalt(contract, salt, signature, createArgs)
-      : await this.project.createProxy(contract, createArgs);
+    const { proxy, instance } = await this.createProxyInstance(kind, salt, contract, signature, createArgs);
 
-    const implementationAddress = await Proxy.at(proxyInstance).implementation();
+    const implementationAddress = await proxy.implementation();
     const packageVersion = packageName === this.packageFile.name ? this.currentVersion : (await this.project.getDependencyVersion(packageName));
     await this._tryRegisterProxyAdmin();
     await this._tryRegisterProxyFactory();
-    await this._updateTruffleDeployedInformation(contractAlias, proxyInstance);
+    await this._updateTruffleDeployedInformation(contractAlias, instance);
     this.networkFile.addProxy(packageName, contractAlias, {
-      address: proxyInstance.address,
+      address: instance.address,
       version: semanticVersionToString(packageVersion),
       implementation: implementationAddress,
-      admin: admin || this.networkFile.proxyAdminAddress
+      admin: admin || this.networkFile.proxyAdminAddress,
+      kind,
     });
-    return proxyInstance;
+    return instance;
+  }
+
+  private async createProxyInstance(kind: ProxyType, salt: string, contract: Contract, signature: string, createArgs: { packageName: string; contractName: string; initMethod: string; initArgs: string[]; admin: string; }): Promise<{ instance: Contract, proxy: Proxy | MinimalProxy }> {
+    let instance: Contract, proxy: Proxy | MinimalProxy;
+    switch (kind) {
+      case ProxyType.Upgradeable:
+        instance = salt
+          ? await this.project.createProxyWithSalt(contract, salt, signature, createArgs)
+          : await this.project.createProxy(contract, createArgs);
+        proxy = await Proxy.at(instance.address);
+        return { proxy, instance };
+
+      case ProxyType.Minimal:
+        if (salt) {
+          throw new Error(`Cannot create a minimal proxy with a precomputed address, use an Upgradeable proxy instead.`);
+        }
+        instance = await this.project.createMinimalProxy(contract, createArgs);
+        proxy = await MinimalProxy.at(instance.address);
+        return { proxy, instance };
+
+      default:
+        throw new Error(`Unknown proxy type ${kind}`);
+    }
   }
 
   public async getProxyDeploymentAddress(salt: string, sender?: string): Promise<string> {

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -744,7 +744,8 @@ export default class NetworkController {
     const proxies = this.networkFile.getProxies({
       package: packageName || (contractAlias ? this.packageFile.name : undefined),
       contract: contractAlias,
-      address: proxyAddress
+      address: proxyAddress,
+      kind: ProxyType.Upgradeable
     });
 
     if (isEmpty(proxies)) {

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -571,7 +571,7 @@ export default class NetworkController {
           ? await this.project.createProxyWithSalt(contract, salt, signature, createArgs)
           : await this.project.createProxy(contract, createArgs);
         proxy = await Proxy.at(instance.address);
-        return { proxy, instance };
+        break;
 
       case ProxyType.Minimal:
         if (salt) {
@@ -579,11 +579,13 @@ export default class NetworkController {
         }
         instance = await this.project.createMinimalProxy(contract, createArgs);
         proxy = await MinimalProxy.at(instance.address);
-        return { proxy, instance };
+        break;
 
       default:
         throw new Error(`Unknown proxy type ${kind}`);
     }
+
+    return { proxy, instance };
   }
 
   public async getProxyDeploymentAddress(salt: string, sender?: string): Promise<string> {

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -11,6 +11,7 @@ import ZosPackageFile from '../models/files/ZosPackageFile';
 import LocalController from '../models/local/LocalController';
 import Dependency from '../models/dependency/Dependency';
 import { fromContractFullName, toContractFullName } from '../utils/naming';
+import { ProxyType } from '../scripts/interfaces';
 
 type ChoicesT = string[] | ({ [key: string]: any });
 
@@ -76,7 +77,7 @@ export function networksList(name: string, type: string, message?: string): { [k
 export function proxiesList(pickProxyBy: string, network: string, packageFile?: ZosPackageFile): { [key: string]: any } {
   packageFile = packageFile || new ZosPackageFile();
   const networkFile = packageFile.networkFile(network);
-  const proxies = networkFile.getProxies();
+  const proxies = networkFile.getProxies({ kind: ProxyType.Upgradeable });
   const groupedByPackage = groupBy(proxies, 'package');
   const list = Object.keys(groupedByPackage)
     .map(packageName => {

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -1,18 +1,18 @@
 import stdout from '../utils/stdout';
 import NetworkController from '../models/network/NetworkController';
 import ScriptError from '../models/errors/ScriptError';
-import { CreateParams } from './interfaces';
+import { CreateParams, ProxyType } from './interfaces';
 import { Contract } from 'zos-lib';
 import { validateSalt } from '../utils/input';
 
-export default async function createProxy({ packageName, contractAlias, methodName, methodArgs, network, txParams = {}, force = false, salt = null, signature = null, admin = null, networkFile }: CreateParams): Promise<Contract | never> {
+export default async function createProxy({ packageName, contractAlias, methodName, methodArgs, network, txParams = {}, force = false, salt = null, signature = null, admin = null, kind = ProxyType.Upgradeable, networkFile }: CreateParams): Promise<Contract | never> {
   if (!contractAlias) throw Error('A contract alias must be provided to create a new proxy.');
   validateSalt(salt, false);
 
   const controller = new NetworkController(network, txParams, networkFile);
   try {
     await controller.checkContractDeployed(packageName, contractAlias, !force);
-    const proxy = await controller.createProxy(packageName, contractAlias, methodName, methodArgs, admin, salt, signature);
+    const proxy = await controller.createProxy(packageName, contractAlias, methodName, methodArgs, admin, salt, signature, kind);
     stdout(proxy.address);
     controller.writeNetworkPackageIfNeeded();
 

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -31,10 +31,16 @@ interface Proxy extends Network, PackageArgs {
   force?: boolean;
 }
 
+export enum ProxyType {
+  Upgradeable = 'Upgradeable',
+  Minimal = 'Minimal'
+}
+
 export interface CreateParams extends Proxy {
   salt?: string;
   signature?: string;
   admin?: string;
+  kind?: ProxyType;
 }
 
 export interface CompareParams extends Network {}

--- a/packages/cli/test/commands/create.test.js
+++ b/packages/cli/test/commands/create.test.js
@@ -2,12 +2,17 @@
 require('../setup')
 
 import { stubCommands, itShouldParse } from './share';
+import { ProxyType } from '../../src/scripts/interfaces';
 
 describe('create command', function() {
   stubCommands()
 
   itShouldParse('should call create script with options', 'create', 'zos create Impl --network test --init setup --args 42 --force --from 0x40', function(create) {
     create.should.have.been.calledWithExactly( { contractAlias: 'Impl', methodName: 'setup', methodArgs: ['42'], force: true, network: 'test', txParams: { from: '0x40'} })
+  })
+
+  itShouldParse('should call create script with kind', 'create', 'zos create Impl --network test --init setup --args 42 --force --from 0x40 --minimal', function(create) {
+    create.should.have.been.calledWithExactly( { contractAlias: 'Impl', methodName: 'setup', methodArgs: ['42'], kind: ProxyType.Minimal, force: true, network: 'test', txParams: { from: '0x40'} })
   })
 
   itShouldParse('should call create script with options', 'create', 'zos create Boolean --network test --init initialize --args false --force --from 0x40', function(create) {

--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -7,13 +7,14 @@ import CaptureLogs from '../helpers/captureLogs';
 
 import add from '../../src/scripts/add';
 import push from '../../src/scripts/push';
-import bumpVersion from '../../src/scripts/bump';
+import bump from '../../src/scripts/bump';
 import link from '../../src/scripts/link';
 import createProxy from '../../src/scripts/create';
 import update from '../../src/scripts/update';
 import setAdmin from '../../src/scripts/set-admin';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 import utils from 'web3-utils';
+import { ProxyType } from '../../src/scripts/interfaces';
 
 const ImplV1 = Contracts.getFromLocal('ImplV1')
 const ImplV2 = Contracts.getFromLocal('ImplV2')
@@ -29,15 +30,18 @@ contract('update script', function(accounts) {
   const version_2 = '0.2.0';
   const txParams = { from: owner };
 
-  const assertProxyInfo = async function(networkFile, contractAlias, proxyIndex, { version, implementation, address, value }) {
+  const assertProxyInfo = async function(networkFile, contractAlias, proxyIndex, { version, implementation, address, value, minimal }) {
     const proxyInfo = networkFile.getProxies({ contract: contractAlias })[proxyIndex]
     if (address) proxyInfo.address.should.eq(address, 'Proxy address in network file does not match expected');
     else proxyInfo.address.should.be.nonzeroAddress;
 
     if (implementation) {
+      proxyInfo.implementation.should.equalIgnoreCase(implementation, 'Implementation address in network file does not match expected');
+    }
+
+    if (!minimal && implementation) {
       const actualImplementation = await Proxy.at(proxyInfo.address).implementation()
-      actualImplementation.should.eq(implementation, 'Proxy implementation address does not match expected');
-      proxyInfo.implementation.should.eq(implementation, 'Implementation address in network file does not match expected');
+      actualImplementation.should.equalIgnoreCase(implementation, 'Proxy implementation address does not match expected');
     }
 
     if (version) {
@@ -53,209 +57,238 @@ contract('update script', function(accounts) {
     return proxyInfo;
   };
 
+  const createProxies = async function () {
+    this.networkFile = this.packageFile.networkFile(network)
+
+    const contractsData = [{ name: 'ImplV1', alias: 'Impl' }, { name: 'WithLibraryImplV1', alias: 'WithLibraryImpl' }]
+    await add({ contractsData, packageFile: this.packageFile });
+    await push({ network, txParams, networkFile: this.networkFile });
+
+    this.implV1Address = this.networkFile.contract('Impl').address;
+    this.withLibraryImplV1Address = this.networkFile.contract('WithLibraryImpl').address;
+
+    await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+    await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+    await createProxy({ contractAlias: 'WithLibraryImpl', network, txParams, networkFile: this.networkFile });
+  }
+
+  const bumpVersion = async function () {
+    await bump({ version: version_2, txParams, packageFile: this.packageFile });
+    const newContractsData = [{ name: 'ImplV2', alias: 'Impl' }, { name: 'WithLibraryImplV2', alias: 'WithLibraryImpl' }]
+    await add({ contractsData: newContractsData, packageFile: this.packageFile });
+    await push({ network, txParams, networkFile: this.networkFile });
+
+    this.implV2Address = this.networkFile.contract('Impl').address;
+    this.withLibraryImplV2Address = this.networkFile.contract('WithLibraryImpl').address;
+  }
+
   const shouldHandleUpdateScript = function () {
-    beforeEach('setup', async function() {
-      this.networkFile = this.packageFile.networkFile(network)
-
-      const contractsData = [{ name: 'ImplV1', alias: 'Impl' }, { name: 'WithLibraryImplV1', alias: 'WithLibraryImpl' }]
-      await add({ contractsData, packageFile: this.packageFile });
-      await push({ network, txParams, networkFile: this.networkFile });
-
-      this.implV1Address = this.networkFile.contract('Impl').address;
-      this.withLibraryImplV1Address = this.networkFile.contract('WithLibraryImpl').address;
-
-      await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'WithLibraryImpl', network, txParams, networkFile: this.networkFile });
-
-      await bumpVersion({ version: version_2, txParams, packageFile: this.packageFile });
-      const newContractsData = [{ name: 'ImplV2', alias: 'Impl' }, { name: 'WithLibraryImplV2', alias: 'WithLibraryImpl' }]
-      await add({ contractsData: newContractsData, packageFile: this.packageFile });
-      await push({ network, txParams, networkFile: this.networkFile });
-
-      this.implV2Address = this.networkFile.contract('Impl').address;
-      this.withLibraryImplV2Address = this.networkFile.contract('WithLibraryImpl').address;
-    });
-
-    it('should upgrade the version of a proxy given its address', async function() {
-      // Upgrade single proxy
-      const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
-      await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
-
-      // Check other proxies were unmodified
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_1, implementation: this.implV1Address });
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
-    });
-
-    it('should upgrade the version of all proxies given the contract alias', async function() {
-      // Upgrade all 'Impl' proxies
-      await update({ contractAlias: 'Impl', proxyAddress: undefined, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
-
-      // Keep WithLibraryImpl unmodified
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
-    });
-
-    it('should upgrade the version of all proxies in the app', async function() {
-      await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
-    });
-
-    it('should not attempt to upgrade a proxy not owned', async function() {
-      const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
-      await setAdmin({ proxyAddress, newAdmin: anotherAccount, network, txParams, networkFile: this.networkFile })
-      await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_1, implementation: this.implV1Address });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
-    });
-
-    it('should upgrade the remaining proxies if one was already upgraded', async function() {
-      // Upgrade a single proxy
-      const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
-      await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
-
-      // Upgrade all
-      await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
-    });
-
-    it('should upgrade a single proxy and migrate it', async function() {
-      const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
-      await update({ contractAlias: 'Impl', methodName: 'migrate', methodArgs: [42], proxyAddress, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress, value: 42 });
-    });
-
-    it('should upgrade multiple proxies and migrate them', async function() {
-      await update({ contractAlias: 'Impl', methodName: 'migrate', methodArgs: [42], proxyAddress: undefined, network, txParams, networkFile: this.networkFile });
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, value: 42 });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address, value: 42 });
-    });
-
-    it('should upgrade multiple proxies and migrate them', async function() {
-      // add non-migratable implementation for WithLibraryImpl contract
-      await add({ contractsData: [{ name: 'UnmigratableImplV2', alias: 'WithLibraryImpl' }], packageFile: this.packageFile })
-      await push({ network, txParams, networkFile: this.networkFile });
-
-      await update({ contractAlias: undefined, proxyAddress: undefined, all: true, methodName: "migrate", methodArgs: [42], network, txParams, networkFile: this.networkFile })
-        .should.be.rejectedWith(/failed to update/);
-
-      await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, value: 42 });
-      await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address, value: 42 });
-      await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
-    });
-
-    it('should refuse to upgrade a proxy to an undeployed contract', async function() {
-      const contracts = this.networkFile.contracts
-      delete contracts['Impl'];
-      this.networkFile.contracts = contracts
-
-      await update({ contractAlias: 'Impl', proxyAddress: null, network, txParams, networkFile: this.networkFile })
-        .should.be.rejectedWith('Contracts Impl are not deployed.')
-    });
-
-    describe('with local modifications', function () {
-      beforeEach('changing local network file to have a different bytecode', async function () {
-        const contracts = this.networkFile.contracts
-        contracts['Impl'].localBytecodeHash = '0xabcd';
-        this.networkFile.contracts = contracts
+    describe('updating', function () {
+      beforeEach('setup', async function() {
+        await createProxies.call(this);
+        await bumpVersion.call(this);
       });
 
-      it('should refuse to upgrade a proxy for a modified contract', async function () {
-        await update({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile })
-          .should.be.rejectedWith('Contracts Impl have changed since the last deploy.');
+      it('should upgrade the version of a proxy given its address', async function() {
+        // Upgrade single proxy
+        const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
+        await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
+
+        // Check other proxies were unmodified
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_1, implementation: this.implV1Address });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
       });
 
-      it('should upgrade a proxy for a modified contract if force is set', async function () {
-        await update({ contractAlias: 'Impl', network, txParams, force: true, networkFile: this.networkFile });
-        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address })
-      });
-    });
+      it('should upgrade the version of all proxies given the contract alias', async function() {
+        // Upgrade all 'Impl' proxies
+        await update({ contractAlias: 'Impl', proxyAddress: undefined, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
 
-    describe('warnings', function () {
-      beforeEach('capturing log output', function () {
-        this.logs = new CaptureLogs();
-      });
-
-      afterEach(function () {
-        this.logs.restore();
+        // Keep WithLibraryImpl unmodified
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
       });
 
-      it('should not warn when migrating a contract', async function() {
-        await update({ contractAlias: 'Impl', network, txParams, methodName: 'migrate', methodArgs: [42], networkFile: this.networkFile });
-        this.logs.errors.should.have.lengthOf(0);
+      it('should upgrade the version of all proxies in the app', async function() {
+        await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
       });
 
-      it('should not warn when a contract has no migrate method', async function() {
-        await add({ contractsData: [{ name: 'WithLibraryImplV1', alias: 'NoMigrate' }], packageFile: this.packageFile });
+      it('should not attempt to upgrade a proxy not owned', async function() {
+        const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
+        await setAdmin({ proxyAddress, newAdmin: anotherAccount, network, txParams, networkFile: this.networkFile })
+        await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_1, implementation: this.implV1Address });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
+      });
+
+      it('should upgrade the remaining proxies if one was already upgraded', async function() {
+        // Upgrade a single proxy
+        const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
+        await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
+
+        // Upgrade all
+        await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
+      });
+
+      it('should upgrade a single proxy and migrate it', async function() {
+        const proxyAddress = this.networkFile.getProxies({ contract: 'Impl'})[0].address;
+        await update({ contractAlias: 'Impl', methodName: 'migrate', methodArgs: [42], proxyAddress, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress, value: 42 });
+      });
+
+      it('should upgrade multiple proxies and migrate them', async function() {
+        await update({ contractAlias: 'Impl', methodName: 'migrate', methodArgs: [42], proxyAddress: undefined, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, value: 42 });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address, value: 42 });
+      });
+
+      it('should upgrade multiple proxies and migrate them', async function() {
+        // add non-migratable implementation for WithLibraryImpl contract
+        await add({ contractsData: [{ name: 'UnmigratableImplV2', alias: 'WithLibraryImpl' }], packageFile: this.packageFile })
         await push({ network, txParams, networkFile: this.networkFile });
 
-        await update({ contractAlias: 'NoMigrate', network, txParams, networkFile: this.networkFile });
-        this.logs.errors.should.have.lengthOf(0);
+        await update({ contractAlias: undefined, proxyAddress: undefined, all: true, methodName: "migrate", methodArgs: [42], network, txParams, networkFile: this.networkFile })
+          .should.be.rejectedWith(/failed to update/);
+
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, value: 42 });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address, value: 42 });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_1, implementation: this.withLibraryImplV1Address });
+      });
+
+      it('should refuse to upgrade a proxy to an undeployed contract', async function() {
+        const contracts = this.networkFile.contracts
+        delete contracts['Impl'];
+        this.networkFile.contracts = contracts
+
+        await update({ contractAlias: 'Impl', proxyAddress: null, network, txParams, networkFile: this.networkFile })
+          .should.be.rejectedWith('Contracts Impl are not deployed.')
+      });
+
+      describe('with local modifications', function () {
+        beforeEach('changing local network file to have a different bytecode', async function () {
+          const contracts = this.networkFile.contracts
+          contracts['Impl'].localBytecodeHash = '0xabcd';
+          this.networkFile.contracts = contracts
+        });
+
+        it('should refuse to upgrade a proxy for a modified contract', async function () {
+          await update({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile })
+            .should.be.rejectedWith('Contracts Impl have changed since the last deploy.');
+        });
+
+        it('should upgrade a proxy for a modified contract if force is set', async function () {
+          await update({ contractAlias: 'Impl', network, txParams, force: true, networkFile: this.networkFile });
+          await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address })
+        });
+      });
+
+      describe('warnings', function () {
+        beforeEach('capturing log output', function () {
+          this.logs = new CaptureLogs();
+        });
+
+        afterEach(function () {
+          this.logs.restore();
+        });
+
+        it('should not warn when migrating a contract', async function() {
+          await update({ contractAlias: 'Impl', network, txParams, methodName: 'migrate', methodArgs: [42], networkFile: this.networkFile });
+          this.logs.errors.should.have.lengthOf(0);
+        });
+
+        it('should not warn when a contract has no migrate method', async function() {
+          await add({ contractsData: [{ name: 'WithLibraryImplV1', alias: 'NoMigrate' }], packageFile: this.packageFile });
+          await push({ network, txParams, networkFile: this.networkFile });
+
+          await update({ contractAlias: 'NoMigrate', network, txParams, networkFile: this.networkFile });
+          this.logs.errors.should.have.lengthOf(0);
+        });
       });
     });
   };
 
+  const shouldHandleUpdateWithMinimalProxies = function () {
+    describe('updating with minimal proxies', function () {
+      beforeEach('setup', async function() {
+        await createProxies.call(this);
+        await createProxy({ kind: ProxyType.Minimal, contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+        await bumpVersion.call(this);
+      });
+
+      it('should not attempt to upgrade a minimal proxy', async function() {
+        await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
+        await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'Impl', 1, { version: version_2, implementation: this.implV2Address });
+        await assertProxyInfo(this.networkFile, 'Impl', 2, { version: version_1, implementation: this.implV1Address, minimal: true });
+        await assertProxyInfo(this.networkFile, 'WithLibraryImpl', 0, { version: version_2, implementation: this.withLibraryImplV2Address });
+      });
+    });
+  }
+
   const shouldHandleUpdateOnDependency = function () {
-    beforeEach('setup', async function() {
-      this.networkFile = this.packageFile.networkFile(network)
+    describe('updating on dependency', function () {
+      beforeEach('setup', async function() {
+        this.networkFile = this.packageFile.networkFile(network)
 
-      await push({ network, txParams, deployDependencies: true, networkFile: this.networkFile });
-      await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-      await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+        await push({ network, txParams, deployDependencies: true, networkFile: this.networkFile });
+        await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+        await createProxy({ packageName: 'mock-stdlib-undeployed', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
 
-      await bumpVersion({ version: version_2, txParams, packageFile: this.packageFile });
-      await link({ txParams, dependencies: ['mock-stdlib-undeployed-2@1.2.0'], packageFile: this.packageFile });
-      await push({ network, txParams, deployDependencies: true, networkFile: this.networkFile });
+        await bump({ version: version_2, txParams, packageFile: this.packageFile });
+        await link({ txParams, dependencies: ['mock-stdlib-undeployed-2@1.2.0'], packageFile: this.packageFile });
+        await push({ network, txParams, deployDependencies: true, networkFile: this.networkFile });
 
-      // We modify the proxies' package to v2, so we can upgrade them, simulating an upgrade to mock-stdlib-undeployed
-      this.networkFile.data.proxies = mapKeys(this.networkFile.data.proxies, (value, key) => key.replace('mock-stdlib-undeployed', 'mock-stdlib-undeployed-2'))
-    });
+        // We modify the proxies' package to v2, so we can upgrade them, simulating an upgrade to mock-stdlib-undeployed
+        this.networkFile.data.proxies = mapKeys(this.networkFile.data.proxies, (value, key) => key.replace('mock-stdlib-undeployed', 'mock-stdlib-undeployed-2'))
+      });
 
-    it('should upgrade the version of a proxy given its address', async function() {
-      const proxyAddress = this.networkFile.getProxies({ contract: 'Greeter'})[0].address;
-      await update({ proxyAddress, network, txParams, networkFile: this.networkFile });
+      it('should upgrade the version of a proxy given its address', async function() {
+        const proxyAddress = this.networkFile.getProxies({ contract: 'Greeter'})[0].address;
+        await update({ proxyAddress, network, txParams, networkFile: this.networkFile });
 
-      await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0', address: proxyAddress });
-      const upgradedProxy = Greeter_V2.at(proxyAddress);
-      (await upgradedProxy.methods.version().call()).should.eq('1.2.0');
+        await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0', address: proxyAddress });
+        const upgradedProxy = Greeter_V2.at(proxyAddress);
+        (await upgradedProxy.methods.version().call()).should.eq('1.2.0');
 
-      const anotherProxyAddress = this.networkFile.getProxies({ contract: 'Greeter'})[1].address;
-      const notUpgradedProxy = Greeter_V1.at(anotherProxyAddress);
-      (await notUpgradedProxy.methods.version().call()).should.eq('1.1.0');
-    });
+        const anotherProxyAddress = this.networkFile.getProxies({ contract: 'Greeter'})[1].address;
+        const notUpgradedProxy = Greeter_V1.at(anotherProxyAddress);
+        (await notUpgradedProxy.methods.version().call()).should.eq('1.1.0');
+      });
 
-    it('should upgrade the version of all proxies given their name', async function() {
-      await update({ packageName: 'mock-stdlib-undeployed-2', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+      it('should upgrade the version of all proxies given their name', async function() {
+        await update({ packageName: 'mock-stdlib-undeployed-2', contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
-    });
+        const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
+        const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
+      });
 
-    it('should upgrade the version of all proxies given their package', async function() {
-      await update({ packageName: 'mock-stdlib-undeployed-2', network, txParams, networkFile: this.networkFile });
+      it('should upgrade the version of all proxies given their package', async function() {
+        await update({ packageName: 'mock-stdlib-undeployed-2', network, txParams, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
-    });
+        const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
+        const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
+      });
 
-    it('should upgrade the version of all proxies', async function() {
-      await update({ network, txParams, all: true, networkFile: this.networkFile });
+      it('should upgrade the version of all proxies', async function() {
+        await update({ network, txParams, all: true, networkFile: this.networkFile });
 
-      const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
-      const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
-      (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
+        const { address: proxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(proxyAddress).methods.version().call()).should.eq('1.2.0');
+        const { address: anotherProxyAddress } = await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: '1.2.0' });
+        (await Greeter_V2.at(anotherProxyAddress).methods.version().call()).should.eq('1.2.0');
+      });
     });
   };
 
@@ -266,6 +299,7 @@ contract('update script', function(accounts) {
     });
 
     shouldHandleUpdateScript();
+    shouldHandleUpdateWithMinimalProxies();
   })
 
   describe('on application contract in unpublished mode', function () {
@@ -276,6 +310,7 @@ contract('update script', function(accounts) {
     });
 
     shouldHandleUpdateScript();
+    shouldHandleUpdateWithMinimalProxies();
   })
 
   describe('on dependency contract', function () {

--- a/packages/lib/contracts/mocks/DummyImplementation.sol
+++ b/packages/lib/contracts/mocks/DummyImplementation.sol
@@ -25,12 +25,10 @@ contract DummyImplementation {
     value = _value;
   }
 
-event Bar(uint256 v);
   function initialize(uint256 _value, string memory _text, uint256[] memory _values) public {
     value = _value;
     text = _text;
     values = _values;
-    emit Bar(_value);
   }
 
   function get() public pure returns (bool) {

--- a/packages/lib/contracts/mocks/DummyImplementation.sol
+++ b/packages/lib/contracts/mocks/DummyImplementation.sol
@@ -25,10 +25,12 @@ contract DummyImplementation {
     value = _value;
   }
 
+event Bar(uint256 v);
   function initialize(uint256 _value, string memory _text, uint256[] memory _values) public {
     value = _value;
     text = _text;
     values = _values;
+    emit Bar(_value);
   }
 
   function get() public pure returns (bool) {

--- a/packages/lib/contracts/upgradeability/ProxyFactory.sol
+++ b/packages/lib/contracts/upgradeability/ProxyFactory.sol
@@ -6,7 +6,6 @@ import "../cryptography/ECDSA.sol";
 contract ProxyFactory {
   
   event ProxyCreated(address proxy);
-  event Foo(bytes data);
 
   bytes32 private contractCodeHash;
 
@@ -32,9 +31,7 @@ contract ProxyFactory {
     if(_data.length > 0) {
       (bool success,) = proxy.call(_data);
       require(success);
-      emit Foo(_data);
-    }
-    
+    }    
   }
 
   function deploy(uint256 _salt, address _logic, address _admin, bytes memory _data) public returns (address) {

--- a/packages/lib/contracts/upgradeability/ProxyFactory.sol
+++ b/packages/lib/contracts/upgradeability/ProxyFactory.sol
@@ -6,6 +6,7 @@ import "../cryptography/ECDSA.sol";
 contract ProxyFactory {
   
   event ProxyCreated(address proxy);
+  event Foo(bytes data);
 
   bytes32 private contractCodeHash;
 
@@ -13,6 +14,27 @@ contract ProxyFactory {
     contractCodeHash = keccak256(
       type(InitializableAdminUpgradeabilityProxy).creationCode
     );
+  }
+
+  function deployMinimal(address _logic, bytes memory _data) public returns (address proxy) {
+    // Adapted from https://github.com/optionality/clone-factory/blob/32782f82dfc5a00d103a7e61a17a5dedbd1e8e9d/contracts/CloneFactory.sol
+    bytes20 targetBytes = bytes20(_logic);
+    assembly {
+      let clone := mload(0x40)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+      proxy := create(0, clone, 0x37)
+    }
+    
+    emit ProxyCreated(address(proxy));
+
+    if(_data.length > 0) {
+      (bool success,) = proxy.call(_data);
+      require(success);
+      emit Foo(_data);
+    }
+    
   }
 
   function deploy(uint256 _salt, address _logic, address _admin, bytes memory _data) public returns (address) {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -34,6 +34,7 @@ const assertEvent = helpers.assertEvent;
 
 // model objects
 import Proxy from './proxy/Proxy';
+import MinimalProxy from './proxy/MinimalProxy';
 import ProxyAdmin from './proxy/ProxyAdmin';
 import ProxyFactory from './proxy/ProxyFactory';
 import App from './application/App';
@@ -97,5 +98,6 @@ export {
   Contract,
   ProxyAdminProject,
   ValidationInfo,
-  AppProxyMigrator
+  AppProxyMigrator,
+  MinimalProxy
 };

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -212,6 +212,18 @@ class BaseAppProject extends BasePackageProject {
     return contract.at(proxy.address);
   }
 
+  public async createMinimalProxy(contract, contractInterface: ContractInterface = {}): Promise<Contract> {
+    const { contractName, packageName, initMethod, initArgs } = this.getContractInterface(contract, contractInterface);
+    const implementationAddress = await this.app.getImplementation(packageName, contractName);
+    const initCallData = this.getInitCallData(contract, initMethod, initArgs, implementationAddress, 'Creating');
+
+    const proxyFactory = await this.ensureProxyFactory();
+    const proxy = await proxyFactory.createMinimalProxy(implementationAddress, initCallData);
+
+    log.info(`Instance created at ${proxy.address}`);
+    return contract.at(proxy.address);
+  }
+
   // REFACTOR: De-duplicate from BaseSimpleProject
   public async getProxyDeploymentAddress(salt: string, sender?: string): Promise<string> {
     const proxyFactory = await this.ensureProxyFactory();

--- a/packages/lib/src/project/AppProject.ts
+++ b/packages/lib/src/project/AppProject.ts
@@ -212,7 +212,7 @@ class BaseAppProject extends BasePackageProject {
     return contract.at(proxy.address);
   }
 
-  public async createMinimalProxy(contract, contractInterface: ContractInterface = {}): Promise<Contract> {
+  public async createMinimalProxy(contract: Contract, contractInterface: ContractInterface = {}): Promise<Contract> {
     const { contractName, packageName, initMethod, initArgs } = this.getContractInterface(contract, contractInterface);
     const implementationAddress = await this.app.getImplementation(packageName, contractName);
     const initCallData = this.getInitCallData(contract, initMethod, initArgs, implementationAddress, 'Creating');

--- a/packages/lib/src/project/BaseSimpleProject.ts
+++ b/packages/lib/src/project/BaseSimpleProject.ts
@@ -122,6 +122,18 @@ export default abstract class BaseSimpleProject {
     return contract.at(proxy.address);
   }
 
+  public async createMinimalProxy(contract, { packageName, contractName, initMethod, initArgs, redeployIfChanged }: ContractInterface = {}): Promise<Contract> {
+    if (!isEmpty(initArgs) && !initMethod) initMethod = 'initialize';
+    const implementationAddress = await this._getOrDeployImplementation(contract, packageName, contractName, redeployIfChanged);
+    const initCallData = this._getAndLogInitCallData(contract, initMethod, initArgs, implementationAddress, 'Creating');
+
+    const proxyFactory = await this.ensureProxyFactory();
+    const proxy = await proxyFactory.createMinimalProxy(implementationAddress, initCallData);
+
+    log.info(`Instance created at ${proxy.address}`);
+    return contract.at(proxy.address);
+  }
+
   // REFACTOR: De-duplicate from AppProject
   public async getProxyDeploymentAddress(salt: string, sender?: string): Promise<string> {
     const proxyFactory = await this.ensureProxyFactory();

--- a/packages/lib/src/proxy/MinimalProxy.ts
+++ b/packages/lib/src/proxy/MinimalProxy.ts
@@ -1,0 +1,19 @@
+import ZWeb3 from '../artifacts/ZWeb3';
+import { toAddress } from '../utils/Addresses';
+
+export default class MinimalProxy {
+  public address: string;
+
+  public static at(address: string): MinimalProxy {
+    return new this(address);
+  }
+
+  constructor(address: string) {
+    this.address = toAddress(address);
+  }
+
+  public async implementation(): Promise<string> {
+    const code = await ZWeb3.getCode(this.address);
+    return `0x${code.slice(22, 62)}`;
+  }
+}

--- a/packages/lib/src/proxy/MinimalProxy.ts
+++ b/packages/lib/src/proxy/MinimalProxy.ts
@@ -13,6 +13,10 @@ export default class MinimalProxy {
   }
 
   public async implementation(): Promise<string> {
+    // Implementation address is in bytes 10-29
+    // (see http://eips.ethereum.org/EIPS/eip-1167)
+    // We are slicing on the hex representation, hence 2 chars per byte,
+    // and have also to account for the initial 0x in the string
     const code = await ZWeb3.getCode(this.address);
     return `0x${code.slice(22, 62)}`;
   }

--- a/packages/lib/test/src/ProxyFactory.test.js
+++ b/packages/lib/test/src/ProxyFactory.test.js
@@ -6,11 +6,12 @@ import Contracts from '../../src/artifacts/Contracts';
 import assertRevert from '../../src/test/helpers/assertRevert';
 import ProxyFactory from '../../src/proxy/ProxyFactory';
 import { signDeploy, signer } from '../../src/test/helpers/signing';
+import ZWeb3 from '../../src/artifacts/ZWeb3';
 
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
 
-function behavesLikeProxyFactory(accounts, user, createProxy) {
+function behavesLikeCreate2ProxyFactory(accounts, user, createProxy) {
   const [_, admin, anotherAdmin, anotherFrom] = accounts.map(utils.toChecksumAddress);
 
   const salt1 = "2";
@@ -81,7 +82,7 @@ contract('ProxyFactory model', function(accounts) {
   });
 
   describe('#deploy', function () {
-    behavesLikeProxyFactory(accounts, sender, async (factory, ... args) => {
+    behavesLikeCreate2ProxyFactory(accounts, sender, async (factory, ... args) => {
       return factory.createProxy(... args);
     });
   });
@@ -97,9 +98,38 @@ contract('ProxyFactory model', function(accounts) {
       actualSigner.should.eq(signer);
     });
 
-    behavesLikeProxyFactory(accounts, signer, async (factory, ... args) => {
+    behavesLikeCreate2ProxyFactory(accounts, signer, async (factory, ... args) => {
       const createArgs = args.length === 3 ? [... args, ''] : args; // append empty initdata if not supplied
       return factory.createProxy(... createArgs, signDeploy(factory.address, ... createArgs));
+    });
+  });
+
+  describe('#deployMinimal', function () {
+    it('deploys minimal proxy', async function () {
+      const proxy = await this.factory.createMinimalProxy(this.implementationV1.address);
+      const impl = await ImplV1.at(proxy.address);  
+      (await impl.methods.version().call()).should.eq("V1");
+    });
+
+    it('deploys and initializes minimal proxy', async function () {
+      const initData = this.implementationV1.methods.initialize(10, "foo", [20, 30]).encodeABI();      
+      const proxy = await this.factory.createMinimalProxy(this.implementationV1.address, initData);
+      const impl = await ImplV1.at(proxy.address);
+      (await impl.methods.version().call()).should.eq("V1");
+      (await impl.methods.value().call()).should.eq("10");
+      (await impl.methods.text().call()).should.eq("foo");
+    });
+
+    it('reverts on minimal proxy deploy', async function () {
+      // ImplV1 does not have a migrate method, so it should revert
+      const initData = this.implementationV2.methods.migrate(10).encodeABI();
+      await assertRevert(this.factory.createMinimalProxy(this.implementationV1.address, initData));
+    });
+
+    it('reports implementation address', async function () {
+      const proxy = await this.factory.createMinimalProxy(this.implementationV1.address);
+      const impl = await proxy.implementation();
+      impl.should.equalIgnoreCase(this.implementationV1.address);
     });
   });
   


### PR DESCRIPTION
Adds PR for [EIP 1167 minimal](http://eips.ethereum.org/EIPS/eip-1167) non-upgradeable proxies. A user may now use the `--minimal` flag on the `create` command, which spawns a minimal proxy instead of a regular one. Under the hood, it spawns a `ProxyFactory` which is used to create and initialize the non-upgradeable proxies in a single tx.