### PR TITLE
Remove references to `lodash`

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -228,7 +228,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3934,7 +3933,6 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
@@ -3975,15 +3973,13 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "asn1": {
           "version": "0.2.4",
@@ -3999,7 +3995,6 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -4765,8 +4760,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -4813,7 +4807,6 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -4847,7 +4840,6 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
           "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -4866,7 +4858,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4933,7 +4924,6 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -5002,7 +4992,6 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -5013,7 +5002,6 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -5023,8 +5011,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -5037,8 +5024,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -5050,8 +5036,7 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -5063,8 +5048,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -5213,7 +5197,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -5240,15 +5223,13 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
           "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -5263,22 +5244,19 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-js": {
           "version": "2.6.5",
@@ -5297,7 +5275,6 @@
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
@@ -5399,8 +5376,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "decompress": {
           "version": "4.2.0",
@@ -5433,7 +5409,6 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -5443,7 +5418,6 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -5584,8 +5558,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -5602,8 +5575,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -5647,8 +5619,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -5664,8 +5635,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.113",
@@ -5692,8 +5662,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -5792,8 +5761,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5811,8 +5779,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5897,7 +5864,6 @@
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -5981,7 +5947,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -6348,7 +6314,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6358,8 +6323,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6377,8 +6341,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.0.0",
@@ -6401,7 +6364,6 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
           "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
@@ -6440,7 +6402,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6449,8 +6410,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6522,8 +6482,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -6536,7 +6495,6 @@
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -6552,7 +6510,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6561,8 +6518,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6606,29 +6562,25 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
           "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
@@ -6658,7 +6610,6 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -6688,8 +6639,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "getpass": {
           "version": "0.1.7",
@@ -6735,7 +6685,6 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -6763,8 +6712,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
           "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
@@ -6804,8 +6752,7 @@
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
           "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
@@ -6818,7 +6765,6 @@
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -6893,7 +6839,6 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -6905,8 +6850,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -6932,8 +6876,7 @@
           "version": "1.1.12",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
           "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "immediate": {
           "version": "3.2.3",
@@ -6976,8 +6919,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
           "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
@@ -7044,15 +6986,13 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
           "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
@@ -7067,8 +7007,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
           "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -7114,7 +7053,6 @@
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
@@ -7498,8 +7436,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -7550,8 +7487,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "memdown": {
           "version": "1.4.1",
@@ -7588,8 +7524,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "merkle-patricia-tree": {
           "version": "2.3.1",
@@ -7649,8 +7584,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "miller-rabin": {
           "version": "4.0.1",
@@ -7667,8 +7601,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.38.0",
@@ -7689,8 +7622,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -7789,15 +7721,13 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
           "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -7828,7 +7758,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -7838,8 +7767,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7872,7 +7800,6 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -7882,7 +7809,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -7921,22 +7847,19 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
           "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "p-timeout": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
-          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -7946,7 +7869,6 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
           "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -7979,8 +7901,7 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
           "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
@@ -8007,8 +7928,7 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
@@ -8080,8 +8000,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "private": {
           "version": "0.1.8",
@@ -8116,7 +8035,6 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
           "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.8.0"
@@ -8230,7 +8148,6 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -8261,22 +8178,19 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
           "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
           "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.3",
@@ -8594,7 +8508,6 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
           "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -8616,7 +8529,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -8625,8 +8537,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8635,7 +8546,6 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -8648,7 +8558,6 @@
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -8680,8 +8589,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -8706,15 +8614,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -8796,8 +8702,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.2",
@@ -8821,8 +8726,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -8963,7 +8867,6 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -9002,7 +8905,6 @@
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "^1.0.0"
           }
@@ -9012,7 +8914,6 @@
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "thenify": ">= 3.1.0 < 4"
           }
@@ -9037,8 +8938,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tmp": {
           "version": "0.0.33",
@@ -9053,8 +8953,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -9112,7 +9011,6 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
@@ -9158,8 +9056,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
           "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unbzip2-stream": {
           "version": "1.3.3",
@@ -9176,8 +9073,7 @@
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unorm": {
           "version": "1.5.0",
@@ -9189,8 +9085,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uri-js": {
           "version": "4.2.2",
@@ -9206,7 +9101,6 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -9215,15 +9109,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "utf8": {
           "version": "3.0.0",
@@ -9242,8 +9134,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.3.2",
@@ -9265,8 +9156,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -9312,7 +9202,6 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
           "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -9325,7 +9214,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
           "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-eth-iban": "1.0.0-beta.35",
@@ -9337,7 +9225,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
           "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9351,7 +9238,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
           "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "1.1.1"
@@ -9362,7 +9248,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
           "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9376,7 +9261,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
           "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "1.1.1",
             "underscore": "1.8.3",
@@ -9409,7 +9293,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
           "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
@@ -9421,8 +9304,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9499,7 +9381,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
           "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "web3-utils": "1.0.0-beta.35"
@@ -9509,8 +9390,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9519,7 +9399,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
           "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9533,7 +9412,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
           "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -9574,7 +9452,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -9622,7 +9500,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
           "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "xhr2-cookies": "1.1.0"
@@ -9633,7 +9510,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
           "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.3",
             "underscore": "1.8.3",
@@ -9645,11 +9521,10 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
           "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "debug": {
@@ -9657,7 +9532,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -9666,7 +9540,6 @@
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
               "dev": true,
-              "optional": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -9694,7 +9567,6 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
           "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -9709,15 +9581,13 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "utf8": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
               "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9783,7 +9653,6 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -9807,7 +9676,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -9823,7 +9691,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -9833,7 +9700,6 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -11530,6 +11396,12 @@
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
+    "lodash.noop": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
+      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw=",
+      "dev": true
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -11650,8 +11522,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -15387,7 +15258,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "underscore": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -82,6 +82,7 @@
     "ganache-cli": "^6.3.0",
     "ganache-core": "^2.5.1",
     "lodash.foreach": "^4.5.0",
+    "lodash.noop": "^3.0.1",
     "lodash.times": "^4.3.2",
     "lodash.zipwith": "^4.2.0",
     "mock-dependency": "file:test/mocks/mock-dependency",

--- a/packages/lib/src/helpers/encodeCall.ts
+++ b/packages/lib/src/helpers/encodeCall.ts
@@ -1,7 +1,6 @@
 // TODO: Once we migrate to Web3 1.x, we could replace these two dependencies with Web3, since it uses these two under the hood: https://github.com/ethereum/web3.js/blob/1.0/packages/web3-eth-abi/src/index.js
 import { defaultAbiCoder, ParamType } from 'ethers/utils/abi-coder';
 import ZWeb3 from '../artifacts/ZWeb3';
-import _ from 'lodash';
 
 export function encodeParams(types: Array<string | ParamType> = [], rawValues: any[] = []): string {
   return defaultAbiCoder.encode(types, rawValues);

--- a/packages/lib/test/contracts/application/App.test.js
+++ b/packages/lib/test/contracts/application/App.test.js
@@ -6,7 +6,6 @@ import shouldManageProxies from './ManageProxies.behavior';
 import shouldManagePackages from './ManagePackages.behavior';
 import shouldBehaveLikeOwnable from '../../../src/test/behaviors/Ownable';
 import { toSemanticVersion } from '../../../src/utils/Semver';
-import lodash from 'lodash';
 import utils from 'web3-utils';
 
 const Package = Contracts.getFromLocal('Package')
@@ -16,7 +15,7 @@ const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 const DummyImplementationV2 = Contracts.getFromLocal('DummyImplementationV2')
 
 contract('App', (accounts) => {
-  accounts = lodash.map(accounts, utils.toChecksumAddress); // Required by Web3 v1.x.
+  accounts = accounts.map(utils.toChecksumAddress); // Required by Web3 v1.x.
 
   const [_, appOwner, packageOwner, directoryOwner, anotherAccount] = accounts;
 

--- a/packages/lib/test/contracts/application/ImplementationDirectory.test.js
+++ b/packages/lib/test/contracts/application/ImplementationDirectory.test.js
@@ -7,13 +7,12 @@ import { ZERO_ADDRESS } from '../../../src/utils/Addresses'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeOwnable from '../../../src/test/behaviors/Ownable'
 import utils from 'web3-utils';
-import lodash from 'lodash';
 
 const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
 
 contract('ImplementationDirectory', function(accounts) {
-  accounts = lodash.map(accounts, utils.toChecksumAddress); // Required by Web3 v1.x.
+  accounts = accounts.map(utils.toChecksumAddress); // Required by Web3 v1.x.
 
   const [_, owner, anotherAddress] = accounts;
 

--- a/packages/lib/test/src/project/ProxyAdminProject.test.js
+++ b/packages/lib/test/src/project/ProxyAdminProject.test.js
@@ -9,7 +9,7 @@ import shouldManageDependencies from './DependenciesProject.behaviour';
 import shouldManageImplementations from './Implementations.behaviour';
 import shouldManageAdminProxy from './AdminProxy.behaviour';
 import Contracts from '../../../src/artifacts/Contracts';
-import { noop } from 'lodash';
+import noop from 'lodash.noop';
 
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');

--- a/packages/lib/test/src/project/SimpleProject.test.js
+++ b/packages/lib/test/src/project/SimpleProject.test.js
@@ -5,7 +5,7 @@ import SimpleProject from '../../../src/project/SimpleProject'
 import shouldManageProxies from './ProxyProject.behaviour';
 import shouldManageDependencies from './DependenciesProject.behaviour';
 import shouldManageImplementations from './Implementations.behaviour';
-import { noop } from 'lodash';
+import noop from 'lodash.noop';
 import Contracts from '../../../src/artifacts/Contracts';
 import utils from 'web3-utils';
 

--- a/packages/lib/test/src/validations/Layout.test.js
+++ b/packages/lib/test/src/validations/Layout.test.js
@@ -3,8 +3,6 @@ require('../../setup')
 
 const should = require('chai').should()
 
-import _ from 'lodash'
-
 import Contracts from '../../../src/artifacts/Contracts'
 import { getStorageLayout } from '../../../src/validations/Storage'
 import { compareStorageLayouts } from '../../../src/validations/Layout'

--- a/packages/lib/test/src/validations/Validations.test.js
+++ b/packages/lib/test/src/validations/Validations.test.js
@@ -1,7 +1,6 @@
 'use strict'
 require('../../setup')
 
-import _ from 'lodash'
 import { validate as validateContract } from '../../../src/validations';
 import Contracts from '../../../src/artifacts/Contracts';
 


### PR DESCRIPTION
I removed some references to `lodash` (which is not installed in our repo) while porting some features to `release/2.3` in https://github.com/zeppelinos/zos/pull/876.
It seems that `tsc` is not complaining because other `zos` dependencies depend on `lodash`, but I'm removing it as this may lead to future errors.