### PR TITLE
Check duplicated artifact names

### DIFF
--- a/packages/cli/contracts/mocks/ImplV1Clash.sol
+++ b/packages/cli/contracts/mocks/ImplV1Clash.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+import "mock-stdlib-2/contracts/GreeterImpl.sol";
+
+// This contract relies on GreeterImpl from mock-stdlib-2, which should clash with the GreeterImpl from ImplV1
+contract ImplV1Clash is GreeterImpl {
+  uint256 public value;
+
+  function initialize(uint256 _value) public {
+    value = _value;
+  }
+
+  function say() public pure returns (string memory) {
+    return "ImplV1Clash";
+  }
+}

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -351,7 +351,7 @@ export default class NetworkController {
       contract.schema.storageInfo = getStorageLayout(contract, buildArtifacts);
       return validationPasses(newWarnings);
     } catch (err) {
-      log.error(`Error while validating contract ${contract.schema.contractName}`, err);
+      log.error(`Error while validating contract ${contract.schema.contractName}:`, err);
       return false;
     }
   }

--- a/packages/cli/test/helpers/captureLogs.js
+++ b/packages/cli/test/helpers/captureLogs.js
@@ -8,7 +8,7 @@ export default class CaptureLogs {
     this.originalError = Logger.prototype.error
     Logger.prototype.info = msg => this.infos.push(msg)
     Logger.prototype.warn = msg => this.warns.push(msg)
-    Logger.prototype.error = msg => this.errors.push(msg)
+    Logger.prototype.error = (msg, ex) => this.errors.push(ex ? `${msg} ${ex.message}` : msg)
   }
 
   get text() {

--- a/packages/cli/test/scripts/push.test.js
+++ b/packages/cli/test/scripts/push.test.js
@@ -579,6 +579,26 @@ contract('push script', function([_, owner]) {
     shouldSetDependency();
     shouldUpdateDependency();
   });
+
+  describe('an unpublished project with duplicated contracts', function() {
+    deployingDependency();
+
+    beforeEach('setting package-with-stdlib with two libs', async function () {
+      const packageFile = new ZosPackageFile('test/mocks/packages/package-with-stdlib.zos.json')
+      packageFile.publish = false
+      packageFile.addContract('ImplV1Clash', 'ImplV1Clash');
+      this.networkFile = packageFile.networkFile(network)
+    });
+
+    it('fails nicely if there are duplicated contract names', async function () {
+      const logs = new CaptureLogs();
+      await push({ network, txParams, networkFile: this.networkFile }).should.be.rejectedWith(/validation errors/);
+      logs.text.should.not.match(/Cannot read property 'forEach' of undefined/);
+      logs.text.should.match(/There is more than one contract named GreeterImpl/);
+      logs.restore();
+    });
+  });
+
 });
 
 async function getImplementationFromApp(contractAlias) {

--- a/packages/lib/src/artifacts/BuildArtifacts.ts
+++ b/packages/lib/src/artifacts/BuildArtifacts.ts
@@ -42,7 +42,7 @@ export class BuildArtifacts {
   }
 
   public getArtifactsFromSourcePath(sourcePath: string): Artifact[] {
-    return this.sourcesToArtifacts[sourcePath];
+    return this.sourcesToArtifacts[sourcePath] || [];
   }
 
   public getSourcePathFromArtifact(artifact: Artifact): string {

--- a/packages/lib/src/validations/index.ts
+++ b/packages/lib/src/validations/index.ts
@@ -14,7 +14,7 @@ import { getStorageLayout, getStructsOrEnums } from './Storage';
 import { compareStorageLayouts, Operation } from './Layout';
 import { hasInitialValuesInDeclarations } from './InitialValues';
 import Contract from '../artifacts/Contract.js';
-import { StorageInfo } from '../utils/ContractAST';
+import ContractAST, { StorageInfo } from '../utils/ContractAST';
 
 const log = new Logger('validate');
 
@@ -29,6 +29,7 @@ export interface ValidationInfo {
 }
 
 export function validate(contract: Contract, existingContractInfo: any = {}, buildArtifacts?: any): any {
+  checkArtifactsForImportedSources(contract, buildArtifacts);
   const storageValidation = validateStorage(contract, existingContractInfo, buildArtifacts);
   const uninitializedBaseContracts = [];
 
@@ -90,4 +91,8 @@ function tryGetUninitializedBaseContracts(contract: Contract): string[] {
     log.error(`- Skipping uninitialized base contracts validation due to error: ${error.message}`);
     return [];
   }
+}
+
+function checkArtifactsForImportedSources(contract: Contract, buildArtifacts: any): void | never {
+  new ContractAST(contract, buildArtifacts, { nodesFilter: ['ContractDefinition'] }).getBaseContractsRecursively();
 }


### PR DESCRIPTION
If there are two contracts with the same name on the same project, truffle will compile them to the same artifact (ContractName.json), overwriting one of them. This causes some validations to fail, such as storage validations, since they expect a set of AST nodes that is not found due to the overwritten artifact. It also yields false negatives in other validations, such as no-delegatecalls, since it looks for all parent contracts, but it could end up loading an incorrect one (since the right one was overwritten).

This change walks through the set of ancestors of a given contract, and checks that the referenced AST ID for each of them is present among the set of imported artifacts. While this was doable by just trying to load the nodes that corresponded to the linearized base contracts, they only contain the IDs of the nodes, and not their friendly names. So we added a method to recursively walk the set of ancestors, keeping track of both id and name, so we can show a more descriptive message to the user:

```
Error while validating contract MyChildContract: Cannot find source data for contract MyContract (base contract of MyChildContract). This often happens because either:
- An incremental compilation step went wrong. Clear your build folder and recompile.
- There is more than one contract named MyContract in your project (including dependencies). Make sure all contracts have a unique name, and that you are not importing dependencies with duplicated contract names (for example, openzeppelin-eth and openzeppelin-solidity).
```

Fixes #389