### PR TITLE
Fix prompt#contractsList with source fromLocal

### DIFF
--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -120,7 +120,7 @@ export function contractsList(name: string, message: string, type: string, sourc
   } else if(source === 'fromLocal') {
     const contractsFromLocal = Object
       .keys(localPackageFile.contracts)
-      .map(alias => ({ name: this.contracts[alias], alias }))
+      .map(alias => ({ name: localPackageFile.contracts[alias], alias }))
       .map(({ name: contractName, alias }) => {
         const label = contractName === alias ? alias : `${alias}[${contractName}]`;
         return { name: label, value: alias };

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -97,20 +97,45 @@ describe('prompt', function() {
     describe('#contractsList', function() {
       beforeEach('set stub and initialize', function() {
         sinon.stub(Truffle, 'getContractNames').returns(['Foo', 'Bar']);
+        sinon.stub(ZosPackageFile.prototype, 'dependencies').get(() => ({'mock-stdlib': '1.1.0'}));
+        sinon.stub(ZosPackageFile.prototype, 'contracts').get(() => ({ 'Foo': 'Foo', 'BarAlias': 'Bar' }));
       });
 
       afterEach('restore stub', function() {
         sinon.restore();
       });
 
-      it('returns an object with correct keys and values', function() {
-        const contracts = contractsList('keyName', 'Im a message', 'listy');
+      it('returns an object with correct keys and values from build dir', function() {
+        const contracts = contractsList('keyName', 'Im a message', 'listy', 'fromBuildDir');
 
         contracts.should.be.an('object');
         contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
         contracts.keyName.type.should.eq('listy');
         contracts.keyName.message.should.eq('Im a message');
         contracts.keyName.choices.should.include.members(['Foo', 'Bar']);
+      });
+
+      it('returns an object with correct keys and values from local', function() {
+        const contracts = contractsList('keyName', 'Im a message', 'listy', 'fromLocal');
+
+        contracts.should.be.an('object');
+        contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
+        contracts.keyName.type.should.eq('listy');
+        contracts.keyName.message.should.eq('Im a message');
+        contracts.keyName.choices.should.deep.include.members([
+          { name: 'Foo', value: 'Foo' },
+          { name: 'BarAlias[Bar]', value: 'BarAlias' }
+        ]);
+      });
+
+      it('returns an object with all correct keys and values', function() {
+        const contracts = contractsList('keyName', 'Im a message', 'listy', 'all');
+
+        contracts.should.be.an('object');
+        contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
+        contracts.keyName.type.should.eq('listy');
+        contracts.keyName.message.should.eq('Im a message');
+        contracts.keyName.choices.should.include.members(['Foo', 'Bar', 'mock-stdlib/Foo', 'mock-stdlib/BarAlias']);
       });
     });
 


### PR DESCRIPTION
Fixes bug on `source === 'fromLocal'` branch, and adds tests.

Fixes #884