### PR TITLE
Add interactivity env

### DIFF
--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -17,13 +17,13 @@ const register: (program: any) => any = (program) => program
   .action(action);
 
 async function action(options: any): Promise<void> {
-  const { network: networkInArgs } = options;
+  const { network: networkInArgs, interactive } = options;
   const { network: networkInSession } = Session.getOptions();
   const defaults = { network: Session.getNetwork() };
   const opts = { network: networkInSession || networkInArgs };
   const props = getCommandProps();
 
-  const promptedOpts = await promptIfNeeded({ opts, defaults, props });
+  const promptedOpts = await promptIfNeeded({ opts, defaults, props }, interactive);
   const { network, txParams } = await ConfigVariablesInitializer.initNetworkConfiguration(promptedOpts);
   if (!await hasToMigrateProject(network)) process.exit(0);
 

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -49,7 +49,7 @@ interface MethodOptions {
   constant?: boolean;
 }
 
-export let DEFAULT_INTERACTIVE_STATUS = true;
+export let DISABLE_INTERACTIVITY: boolean = (!!process.env.ZOS_NON_INTERACTIVE || process.env.DEBIAN_FRONTEND === 'noninteractive');
 
 /*
  * This function will parse and wrap both arguments and options into inquirer questions, where
@@ -59,8 +59,10 @@ export let DEFAULT_INTERACTIVE_STATUS = true;
  * inquirer questions attributes (such as question type, message and name) and `defaults` is an object with
  * default values for each args/props attributes.
  * */
-export async function promptIfNeeded({ args = {}, opts = {}, defaults, props }: PromptParams, interactive = DEFAULT_INTERACTIVE_STATUS): Promise<any> {
+export async function promptIfNeeded({ args = {}, opts = {}, defaults, props }: PromptParams, interactive): Promise<any> {
   const argsAndOpts  = { ...args, ...opts };
+
+  if(DISABLE_INTERACTIVITY) interactive = false;
 
   const argsAndOptsQuestions = Object.keys(argsAndOpts)
     .filter(name => argsAndOpts[name] === undefined || (typeof argsAndOpts[name] !== 'boolean' && isEmpty(argsAndOpts[name])))

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -2,6 +2,9 @@
 
 require('../setup');
 import sinon from 'sinon';
+
+import * as prompt from '../../src/prompts/prompt';
+
 import inquirer from 'inquirer';
 import { ContractMethodMutability as Mutability } from 'zos-lib';
 
@@ -71,6 +74,25 @@ describe('prompt', function() {
           const questions = this.stub.getCall(0).args[0];
 
           questions.should.have.lengthOf(0);
+        });
+      });
+
+      context('with DISABLE_INTERACTIVITY environment variable set', function() {
+
+        beforeEach('disable interactivity', function() {
+          prompt.DISABLE_INTERACTIVITY = true;
+        });
+  
+        afterEach('enable interactivity', function() {
+          prompt.DISABLE_INTERACTIVITY = false;
+        });
+
+        it('does not prompt', async function() {
+          const args = { foo: undefined, bar: undefined };
+          await promptIfNeeded({ args, props: this.props }, this.interactive);
+          const call = this.stub.getCall(0);
+
+          (call === null).should.be.true;
         });
       });
     });

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -20,6 +20,7 @@ describe('prompt', function() {
         this.stub = sinon.stub(inquirer, 'prompt').returns({});
         this.props = { foo: { message: 'message1', type: 'input' }, bar: { message: 'message2', type: 'input' } };
         this.interactive = true;
+        prompt.DISABLE_INTERACTIVITY = false;
       });
 
       afterEach('restore stub', function() {

--- a/packages/cli/test/setup.js
+++ b/packages/cli/test/setup.js
@@ -4,13 +4,11 @@ import { ZWeb3, Contracts } from 'zos-lib'
 import Dependency from '../src/models/dependency/Dependency'
 import ZosPackageFile from '../src/models/files/ZosPackageFile'
 import ZosNetworkFile from '../src/models/files/ZosNetworkFile'
-const prompt = require('../src/prompts/prompt');
 
 useTestZosPackageFile()
 doNotInstallStdlib()
 ZWeb3.initialize(web3.currentProvider)
 setArtifactDefaults()
-prompt.DEFAULT_INTERACTIVE_STATUS = false
 
 require('chai')
   .use(require('chai-as-promised'))


### PR DESCRIPTION
Implements #874;
Would help to implement tools like Solidity Hot Loader which have to run all commands in non interactive mode.
You can set `zos` in non interactive mode by setting either `ZOS_NON_INTERACTIVE` env variable or `DEBIAN_FRONTEND` to `noninteractive`.

@jcarpanelli can you take a look at line 59 and 70 in prompt.test.js? These two test have the same code but different names. Pretty sure that is not what intended.