### PR TITLE
Use block gas limit for transactions on ganache

### DIFF
--- a/packages/cli/scripts/test.sh
+++ b/packages/cli/scripts/test.sh
@@ -18,6 +18,7 @@ ganache_running() {
 }
 
 start_ganache() {
+  node_modules/.bin/ganache-cli --version
   node_modules/.bin/ganache-cli --networkId 4447 -p $ganache_port > /dev/null &
   ganache_pid=$!
 }

--- a/packages/lib/contracts/mocks/MockStandaloneERC721.sol
+++ b/packages/lib/contracts/mocks/MockStandaloneERC721.sol
@@ -1,0 +1,1138 @@
+pragma solidity ^0.5.0;
+
+import "../Initializable.sol";
+
+// File: contracts/introspection/IERC165.sol
+
+/**
+ * @title IERC165
+ * @dev https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md
+ */
+interface IERC165 {
+    /**
+     * @notice Query if a contract implements an interface
+     * @param interfaceId The interface identifier, as specified in ERC-165
+     * @dev Interface identification is specified in ERC-165. This function
+     * uses less than 30,000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+// File: contracts/token/MockERC721/IMockERC721.sol
+
+
+
+/**
+ * @title MockERC721 Non-Fungible Token Standard basic interface
+ * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+ */
+contract IMockERC721 is Initializable, IERC165 {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function balanceOf(address owner) public view returns (uint256 balance);
+    function ownerOf(uint256 tokenId) public view returns (address owner);
+
+    function approve(address to, uint256 tokenId) public;
+    function getApproved(uint256 tokenId) public view returns (address operator);
+
+    function setApprovalForAll(address operator, bool _approved) public;
+    function isApprovedForAll(address owner, address operator) public view returns (bool);
+
+    function transferFrom(address from, address to, uint256 tokenId) public;
+    function safeTransferFrom(address from, address to, uint256 tokenId) public;
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public;
+}
+
+// File: contracts/token/MockERC721/IMockERC721Receiver.sol
+
+/**
+ * @title MockERC721 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ * from MockERC721 asset contracts.
+ */
+contract IMockERC721Receiver {
+    /**
+     * @notice Handle the receipt of an NFT
+     * @dev The MockERC721 smart contract calls this function on the recipient
+     * after a `safeTransfer`. This function MUST return the function selector,
+     * otherwise the caller will revert the transaction. The selector to be
+     * returned can be obtained as `this.onMockERC721Received.selector`. This
+     * function MAY throw to revert and reject the transfer.
+     * Note: the MockERC721 contract address is always the message sender.
+     * @param operator The address which called `safeTransferFrom` function
+     * @param from The address which previously owned the token
+     * @param tokenId The NFT identifier which is being transferred
+     * @param data Additional data with no specified format
+     * @return `bytes4(keccak256("onMockERC721Received(address,address,uint256,bytes)"))`
+     */
+    function onMockERC721Received(address operator, address from, uint256 tokenId, bytes memory data)
+    public returns (bytes4);
+}
+
+// File: contracts/math/SafeMath.sol
+
+/**
+ * @title SafeMath
+ * @dev Unsigned math operations with safety checks that revert on error
+ */
+library SafeMath {
+    /**
+    * @dev Multiplies two unsigned integers, reverts on overflow.
+    */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b);
+
+        return c;
+    }
+
+    /**
+    * @dev Integer division of two unsigned integers truncating the quotient, reverts on division by zero.
+    */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Solidity only automatically asserts when dividing by 0
+        require(b > 0);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+    * @dev Subtracts two unsigned integers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+    */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+    * @dev Adds two unsigned integers, reverts on overflow.
+    */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a);
+
+        return c;
+    }
+
+    /**
+    * @dev Divides two unsigned integers and returns the remainder (unsigned integer modulo),
+    * reverts when dividing by zero.
+    */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0);
+        return a % b;
+    }
+}
+
+// File: contracts/utils/Address.sol
+
+/**
+ * Utility library of inline functions on addresses
+ */
+library Address {
+    /**
+     * Returns whether the target address is a contract
+     * @dev This function will return false if invoked during the constructor of a contract,
+     * as the code is not actually created until after the constructor finishes.
+     * @param account address of the account to check
+     * @return whether the target address is a contract
+     */
+    function isContract(address account) internal view returns (bool) {
+        uint256 size;
+        // XXX Currently there is no better way to check if there is a contract in an address
+        // than to check the size of the code at that address.
+        // See https://ethereum.stackexchange.com/a/14016/36603
+        // for more details about how this works.
+        // TODO Check this again before the Serenity release, because all addresses will be
+        // contracts then.
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+}
+
+// File: contracts/introspection/ERC165.sol
+
+
+
+/**
+ * @title ERC165
+ * @author Matt Condon (@shrugs)
+ * @dev Implements ERC165 using a lookup table.
+ */
+contract ERC165 is Initializable, IERC165 {
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+    /**
+     * 0x01ffc9a7 ===
+     *     bytes4(keccak256('supportsInterface(bytes4)'))
+     */
+
+    /**
+     * @dev a mapping of interface id to whether or not it's supported
+     */
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    /**
+     * @dev A contract implementing SupportsInterfaceWithLookup
+     * implement ERC165 itself
+     */
+    function initialize() public initializer {
+        _registerInterface(_INTERFACE_ID_ERC165);
+    }
+
+    /**
+     * @dev implement supportsInterface(bytes4) using a lookup table
+     */
+    function supportsInterface(bytes4 interfaceId) public view returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    /**
+     * @dev internal method for registering an interface
+     */
+    function _registerInterface(bytes4 interfaceId) internal {
+        require(interfaceId != 0xffffffff);
+        _supportedInterfaces[interfaceId] = true;
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/MockERC721.sol
+
+/**
+ * @title MockERC721 Non-Fungible Token Standard basic implementation
+ * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+ */
+contract MockERC721 is Initializable, ERC165, IMockERC721 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // Equals to `bytes4(keccak256("onMockERC721Received(address,address,uint256,bytes)"))`
+    // which can be also obtained as `IMockERC721Receiver(0).onMockERC721Received.selector`
+    bytes4 private constant _MockERC721_RECEIVED = 0x150b7a02;
+
+    // Mapping from token ID to owner
+    mapping (uint256 => address) private _tokenOwner;
+
+    // Mapping from token ID to approved address
+    mapping (uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to number of owned token
+    mapping (address => uint256) private _ownedTokensCount;
+
+    // Mapping from owner to operator approvals
+    mapping (address => mapping (address => bool)) private _operatorApprovals;
+
+    bytes4 private constant _INTERFACE_ID_MockERC721 = 0x80ac58cd;
+    /*
+     * 0x80ac58cd ===
+     *     bytes4(keccak256('balanceOf(address)')) ^
+     *     bytes4(keccak256('ownerOf(uint256)')) ^
+     *     bytes4(keccak256('approve(address,uint256)')) ^
+     *     bytes4(keccak256('getApproved(uint256)')) ^
+     *     bytes4(keccak256('setApprovalForAll(address,bool)')) ^
+     *     bytes4(keccak256('isApprovedForAll(address,address)')) ^
+     *     bytes4(keccak256('transferFrom(address,address,uint256)')) ^
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) ^
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)'))
+     */
+
+    function initialize() public initializer {
+        ERC165.initialize();
+
+        // register the supported interfaces to conform to MockERC721 via ERC165
+        _registerInterface(_INTERFACE_ID_MockERC721);
+    }
+
+    function _hasBeenInitialized() internal view returns (bool) {
+        return supportsInterface(_INTERFACE_ID_MockERC721);
+    }
+
+    /**
+     * @dev Gets the balance of the specified address
+     * @param owner address to query the balance of
+     * @return uint256 representing the amount owned by the passed address
+     */
+    function balanceOf(address owner) public view returns (uint256) {
+        require(owner != address(0));
+        return _ownedTokensCount[owner];
+    }
+
+    /**
+     * @dev Gets the owner of the specified token ID
+     * @param tokenId uint256 ID of the token to query the owner of
+     * @return owner address currently marked as the owner of the given token ID
+     */
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        address owner = _tokenOwner[tokenId];
+        require(owner != address(0));
+        return owner;
+    }
+
+    /**
+     * @dev Approves another address to transfer the given token ID
+     * The zero address indicates there is no approved address.
+     * There can only be one approved address per token at a given time.
+     * Can only be called by the token owner or an approved operator.
+     * @param to address to be approved for the given token ID
+     * @param tokenId uint256 ID of the token to be approved
+     */
+    function approve(address to, uint256 tokenId) public {
+        address owner = ownerOf(tokenId);
+        require(to != owner);
+        require(msg.sender == owner || isApprovedForAll(owner, msg.sender));
+
+        _tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    /**
+     * @dev Gets the approved address for a token ID, or zero if no address set
+     * Reverts if the token ID does not exist.
+     * @param tokenId uint256 ID of the token to query the approval of
+     * @return address currently approved for the given token ID
+     */
+    function getApproved(uint256 tokenId) public view returns (address) {
+        require(_exists(tokenId));
+        return _tokenApprovals[tokenId];
+    }
+
+    /**
+     * @dev Sets or unsets the approval of a given operator
+     * An operator is allowed to transfer all tokens of the sender on their behalf
+     * @param to operator address to set the approval
+     * @param approved representing the status of the approval to be set
+     */
+    function setApprovalForAll(address to, bool approved) public {
+        require(to != msg.sender);
+        _operatorApprovals[msg.sender][to] = approved;
+        emit ApprovalForAll(msg.sender, to, approved);
+    }
+
+    /**
+     * @dev Tells whether an operator is approved by a given owner
+     * @param owner owner address which you want to query the approval of
+     * @param operator operator address which you want to query the approval of
+     * @return bool whether the given operator is approved by the given owner
+     */
+    function isApprovedForAll(address owner, address operator) public view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev Transfers the ownership of a given token ID to another address
+     * Usage of this method is discouraged, use `safeTransferFrom` whenever possible
+     * Requires the msg sender to be the owner, approved, or operator
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+    */
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        require(_isApprovedOrOwner(msg.sender, tokenId));
+
+        _transferFrom(from, to, tokenId);
+    }
+
+    /**
+     * @dev Safely transfers the ownership of a given token ID to another address
+     * If the target address is a contract, it must implement `onMockERC721Received`,
+     * which is called upon a safe transfer, and return the magic value
+     * `bytes4(keccak256("onMockERC721Received(address,address,uint256,bytes)"))`; otherwise,
+     * the transfer is reverted.
+     *
+     * Requires the msg sender to be the owner, approved, or operator
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+    */
+    function safeTransferFrom(address from, address to, uint256 tokenId) public {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /**
+     * @dev Safely transfers the ownership of a given token ID to another address
+     * If the target address is a contract, it must implement `onMockERC721Received`,
+     * which is called upon a safe transfer, and return the magic value
+     * `bytes4(keccak256("onMockERC721Received(address,address,uint256,bytes)"))`; otherwise,
+     * the transfer is reverted.
+     * Requires the msg sender to be the owner, approved, or operator
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param _data bytes data to send along with a safe transfer check
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory _data) public {
+        transferFrom(from, to, tokenId);
+        require(_checkOnMockERC721Received(from, to, tokenId, _data));
+    }
+
+    /**
+     * @dev Returns whether the specified token exists
+     * @param tokenId uint256 ID of the token to query the existence of
+     * @return whether the token exists
+     */
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        address owner = _tokenOwner[tokenId];
+        return owner != address(0);
+    }
+
+    /**
+     * @dev Returns whether the given spender can transfer a given token ID
+     * @param spender address of the spender to query
+     * @param tokenId uint256 ID of the token to be transferred
+     * @return bool whether the msg.sender is approved for the given token ID,
+     *    is an operator of the owner, or is the owner of the token
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        address owner = ownerOf(tokenId);
+        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
+    }
+
+    /**
+     * @dev Internal function to mint a new token
+     * Reverts if the given token ID already exists
+     * @param to The address that will own the minted token
+     * @param tokenId uint256 ID of the token to be minted
+     */
+    function _mint(address to, uint256 tokenId) internal {
+        require(to != address(0));
+        require(!_exists(tokenId));
+
+        _tokenOwner[tokenId] = to;
+        _ownedTokensCount[to] = _ownedTokensCount[to].add(1);
+
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token
+     * Reverts if the token does not exist
+     * Deprecated, use _burn(uint256) instead.
+     * @param owner owner of the token to burn
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(address owner, uint256 tokenId) internal {
+        require(ownerOf(tokenId) == owner);
+
+        _clearApproval(tokenId);
+
+        _ownedTokensCount[owner] = _ownedTokensCount[owner].sub(1);
+        _tokenOwner[tokenId] = address(0);
+
+        emit Transfer(owner, address(0), tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token
+     * Reverts if the token does not exist
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(uint256 tokenId) internal {
+        _burn(ownerOf(tokenId), tokenId);
+    }
+
+    /**
+     * @dev Internal function to transfer ownership of a given token ID to another address.
+     * As opposed to transferFrom, this imposes no restrictions on msg.sender.
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+    */
+    function _transferFrom(address from, address to, uint256 tokenId) internal {
+        require(ownerOf(tokenId) == from);
+        require(to != address(0));
+
+        _clearApproval(tokenId);
+
+        _ownedTokensCount[from] = _ownedTokensCount[from].sub(1);
+        _ownedTokensCount[to] = _ownedTokensCount[to].add(1);
+
+        _tokenOwner[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Internal function to invoke `onMockERC721Received` on a target address
+     * The call is not executed if the target address is not a contract
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param _data bytes optional data to send along with the call
+     * @return whether the call correctly returned the expected magic value
+     */
+    function _checkOnMockERC721Received(address from, address to, uint256 tokenId, bytes memory _data)
+        internal returns (bool)
+    {
+        if (!to.isContract()) {
+            return true;
+        }
+
+        bytes4 retval = IMockERC721Receiver(to).onMockERC721Received(msg.sender, from, tokenId, _data);
+        return (retval == _MockERC721_RECEIVED);
+    }
+
+    /**
+     * @dev Private function to clear current approval of a given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+     */
+    function _clearApproval(uint256 tokenId) private {
+        if (_tokenApprovals[tokenId] != address(0)) {
+            _tokenApprovals[tokenId] = address(0);
+        }
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/IMockERC721Enumerable.sol
+
+
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+ * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+ */
+contract IMockERC721Enumerable is Initializable, IMockERC721 {
+    function totalSupply() public view returns (uint256);
+    function tokenOfOwnerByIndex(address owner, uint256 index) public view returns (uint256 tokenId);
+
+    function tokenByIndex(uint256 index) public view returns (uint256);
+}
+
+// File: contracts/token/MockERC721/MockERC721Enumerable.sol
+
+
+
+
+
+/**
+ * @title ERC-721 Non-Fungible Token with optional enumeration extension logic
+ * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+ */
+contract MockERC721Enumerable is Initializable, ERC165, MockERC721, IMockERC721Enumerable {
+    // Mapping from owner to list of owned token IDs
+    mapping(address => uint256[]) private _ownedTokens;
+
+    // Mapping from token ID to index of the owner tokens list
+    mapping(uint256 => uint256) private _ownedTokensIndex;
+
+    // Array with all token ids, used for enumeration
+    uint256[] private _allTokens;
+
+    // Mapping from token id to position in the allTokens array
+    mapping(uint256 => uint256) private _allTokensIndex;
+
+    bytes4 private constant _INTERFACE_ID_MockERC721_ENUMERABLE = 0x780e9d63;
+    /**
+     * 0x780e9d63 ===
+     *     bytes4(keccak256('totalSupply()')) ^
+     *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) ^
+     *     bytes4(keccak256('tokenByIndex(uint256)'))
+     */
+
+    /**
+     * @dev Constructor function
+     */
+    function initialize() public initializer {
+        require(MockERC721._hasBeenInitialized());
+
+        // register the supported interface to conform to MockERC721 via ERC165
+        _registerInterface(_INTERFACE_ID_MockERC721_ENUMERABLE);
+    }
+
+    function _hasBeenInitialized() internal view returns (bool) {
+        return supportsInterface(_INTERFACE_ID_MockERC721_ENUMERABLE);
+    }
+
+    /**
+     * @dev Gets the token ID at a given index of the tokens list of the requested owner
+     * @param owner address owning the tokens list to be accessed
+     * @param index uint256 representing the index to be accessed of the requested tokens list
+     * @return uint256 token ID at the given index of the tokens list owned by the requested address
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index) public view returns (uint256) {
+        require(index < balanceOf(owner));
+        return _ownedTokens[owner][index];
+    }
+
+    /**
+     * @dev Gets the total amount of tokens stored by the contract
+     * @return uint256 representing the total amount of tokens
+     */
+    function totalSupply() public view returns (uint256) {
+        return _allTokens.length;
+    }
+
+    /**
+     * @dev Gets the token ID at a given index of all the tokens in this contract
+     * Reverts if the index is greater or equal to the total number of tokens
+     * @param index uint256 representing the index to be accessed of the tokens list
+     * @return uint256 token ID at the given index of the tokens list
+     */
+    function tokenByIndex(uint256 index) public view returns (uint256) {
+        require(index < totalSupply());
+        return _allTokens[index];
+    }
+
+    /**
+     * @dev Internal function to transfer ownership of a given token ID to another address.
+     * As opposed to transferFrom, this imposes no restrictions on msg.sender.
+     * @param from current owner of the token
+     * @param to address to receive the ownership of the given token ID
+     * @param tokenId uint256 ID of the token to be transferred
+    */
+    function _transferFrom(address from, address to, uint256 tokenId) internal {
+        super._transferFrom(from, to, tokenId);
+
+        _removeTokenFromOwnerEnumeration(from, tokenId);
+
+        _addTokenToOwnerEnumeration(to, tokenId);
+    }
+
+    /**
+     * @dev Internal function to mint a new token
+     * Reverts if the given token ID already exists
+     * @param to address the beneficiary that will own the minted token
+     * @param tokenId uint256 ID of the token to be minted
+     */
+    function _mint(address to, uint256 tokenId) internal {
+        super._mint(to, tokenId);
+
+        _addTokenToOwnerEnumeration(to, tokenId);
+
+        _addTokenToAllTokensEnumeration(tokenId);
+    }
+
+    /**
+     * @dev Internal function to burn a specific token
+     * Reverts if the token does not exist
+     * Deprecated, use _burn(uint256) instead
+     * @param owner owner of the token to burn
+     * @param tokenId uint256 ID of the token being burned
+     */
+    function _burn(address owner, uint256 tokenId) internal {
+        super._burn(owner, tokenId);
+
+        _removeTokenFromOwnerEnumeration(owner, tokenId);
+        // Since tokenId will be deleted, we can clear its slot in _ownedTokensIndex to trigger a gas refund
+        _ownedTokensIndex[tokenId] = 0;
+
+        _removeTokenFromAllTokensEnumeration(tokenId);
+    }
+
+    /**
+     * @dev Gets the list of token IDs of the requested owner
+     * @param owner address owning the tokens
+     * @return uint256[] List of token IDs owned by the requested address
+     */
+    function _tokensOfOwner(address owner) internal view returns (uint256[] storage) {
+        return _ownedTokens[owner];
+    }
+
+    /**
+     * @dev Private function to add a token to this extension's ownership-tracking data structures.
+     * @param to address representing the new owner of the given token ID
+     * @param tokenId uint256 ID of the token to be added to the tokens list of the given address
+     */
+    function _addTokenToOwnerEnumeration(address to, uint256 tokenId) private {
+        _ownedTokensIndex[tokenId] = _ownedTokens[to].length;
+        _ownedTokens[to].push(tokenId);
+    }
+
+    /**
+     * @dev Private function to add a token to this extension's token tracking data structures.
+     * @param tokenId uint256 ID of the token to be added to the tokens list
+     */
+    function _addTokenToAllTokensEnumeration(uint256 tokenId) private {
+        _allTokensIndex[tokenId] = _allTokens.length;
+        _allTokens.push(tokenId);
+    }
+
+    /**
+     * @dev Private function to remove a token from this extension's ownership-tracking data structures. Note that
+     * while the token is not assigned a new owner, the _ownedTokensIndex mapping is _not_ updated: this allows for
+     * gas optimizations e.g. when performing a transfer operation (avoiding double writes).
+     * This has O(1) time complexity, but alters the order of the _ownedTokens array.
+     * @param from address representing the previous owner of the given token ID
+     * @param tokenId uint256 ID of the token to be removed from the tokens list of the given address
+     */
+    function _removeTokenFromOwnerEnumeration(address from, uint256 tokenId) private {
+        // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
+        // then delete the last slot (swap and pop).
+
+        uint256 lastTokenIndex = _ownedTokens[from].length.sub(1);
+        uint256 tokenIndex = _ownedTokensIndex[tokenId];
+
+        // When the token to delete is the last token, the swap operation is unnecessary
+        if (tokenIndex != lastTokenIndex) {
+            uint256 lastTokenId = _ownedTokens[from][lastTokenIndex];
+
+            _ownedTokens[from][tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+            _ownedTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+        }
+
+        // This also deletes the contents at the last position of the array
+        _ownedTokens[from].length--;
+
+        // Note that _ownedTokensIndex[tokenId] hasn't been cleared: it still points to the old slot (now occcupied by
+        // lasTokenId, or just over the end of the array if the token was the last one).
+    }
+
+    /**
+     * @dev Private function to remove a token from this extension's token tracking data structures.
+     * This has O(1) time complexity, but alters the order of the _allTokens array.
+     * @param tokenId uint256 ID of the token to be removed from the tokens list
+     */
+    function _removeTokenFromAllTokensEnumeration(uint256 tokenId) private {
+        // To prevent a gap in the tokens array, we store the last token in the index of the token to delete, and
+        // then delete the last slot (swap and pop).
+
+        uint256 lastTokenIndex = _allTokens.length.sub(1);
+        uint256 tokenIndex = _allTokensIndex[tokenId];
+
+        // When the token to delete is the last token, the swap operation is unnecessary. However, since this occurs so
+        // rarely (when the last minted token is burnt) that we still do the swap here to avoid the gas cost of adding
+        // an 'if' statement (like in _removeTokenFromOwnerEnumeration)
+        uint256 lastTokenId = _allTokens[lastTokenIndex];
+
+        _allTokens[tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+        _allTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+
+        // This also deletes the contents at the last position of the array
+        _allTokens.length--;
+        _allTokensIndex[tokenId] = 0;
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/IMockERC721Metadata.sol
+
+
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+ * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+ */
+contract IMockERC721Metadata is Initializable, IMockERC721 {
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}
+
+// File: contracts/token/MockERC721/MockERC721Metadata.sol
+
+
+
+
+
+contract MockERC721Metadata is Initializable, ERC165, MockERC721, IMockERC721Metadata {
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    // Optional mapping for token URIs
+    mapping(uint256 => string) private _tokenURIs;
+
+    bytes4 private constant _INTERFACE_ID_MockERC721_METADATA = 0x5b5e139f;
+    /**
+     * 0x5b5e139f ===
+     *     bytes4(keccak256('name()')) ^
+     *     bytes4(keccak256('symbol()')) ^
+     *     bytes4(keccak256('tokenURI(uint256)'))
+     */
+
+    /**
+     * @dev Constructor function
+     */
+    function initialize(string memory name, string memory symbol) public initializer {
+        require(MockERC721._hasBeenInitialized());
+
+        _name = name;
+        _symbol = symbol;
+
+        // register the supported interfaces to conform to MockERC721 via ERC165
+        _registerInterface(_INTERFACE_ID_MockERC721_METADATA);
+    }
+
+    function _hasBeenInitialized() internal view returns (bool) {
+        return supportsInterface(_INTERFACE_ID_MockERC721_METADATA);
+    }
+
+    /**
+     * @dev Gets the token name
+     * @return string representing the token name
+     */
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Gets the token symbol
+     * @return string representing the token symbol
+     */
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns an URI for a given token ID
+     * Throws if the token ID does not exist. May return an empty string.
+     * @param tokenId uint256 ID of the token to query
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(_exists(tokenId));
+        return _tokenURIs[tokenId];
+    }
+
+    /**
+     * @dev Internal function to set the token URI for a given token
+     * Reverts if the token ID does not exist
+     * @param tokenId uint256 ID of the token to set its URI
+     * @param uri string URI to assign
+     */
+    function _setTokenURI(uint256 tokenId, string memory uri) internal {
+        require(_exists(tokenId));
+        _tokenURIs[tokenId] = uri;
+    }
+
+    /**
+     * @dev Internal function to burn a specific token
+     * Reverts if the token does not exist
+     * Deprecated, use _burn(uint256) instead
+     * @param owner owner of the token to burn
+     * @param tokenId uint256 ID of the token being burned by the msg.sender
+     */
+    function _burn(address owner, uint256 tokenId) internal {
+        super._burn(owner, tokenId);
+
+        // Clear metadata (if any)
+        if (bytes(_tokenURIs[tokenId]).length != 0) {
+            delete _tokenURIs[tokenId];
+        }
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/access/Roles.sol
+
+/**
+ * @title Roles
+ * @dev Library for managing addresses assigned to a Role.
+ */
+library Roles {
+    struct Role {
+        mapping (address => bool) bearer;
+    }
+
+    /**
+     * @dev give an account access to this role
+     */
+    function add(Role storage role, address account) internal {
+        require(account != address(0));
+        require(!has(role, account));
+
+        role.bearer[account] = true;
+    }
+
+    /**
+     * @dev remove an account's access to this role
+     */
+    function remove(Role storage role, address account) internal {
+        require(account != address(0));
+        require(has(role, account));
+
+        role.bearer[account] = false;
+    }
+
+    /**
+     * @dev check if an account has this role
+     * @return bool
+     */
+    function has(Role storage role, address account) internal view returns (bool) {
+        require(account != address(0));
+        return role.bearer[account];
+    }
+}
+
+// File: contracts/access/roles/MinterRole.sol
+
+
+
+
+contract MinterRole is Initializable {
+    using Roles for Roles.Role;
+
+    event MinterAdded(address indexed account);
+    event MinterRemoved(address indexed account);
+
+    Roles.Role private _minters;
+
+    function initialize(address sender) public initializer {
+        if (!isMinter(sender)) {
+            _addMinter(sender);
+        }
+    }
+
+    modifier onlyMinter() {
+        require(isMinter(msg.sender));
+        _;
+    }
+
+    function isMinter(address account) public view returns (bool) {
+        return _minters.has(account);
+    }
+
+    function addMinter(address account) public onlyMinter {
+        _addMinter(account);
+    }
+
+    function renounceMinter() public {
+        _removeMinter(msg.sender);
+    }
+
+    function _addMinter(address account) internal {
+        _minters.add(account);
+        emit MinterAdded(account);
+    }
+
+    function _removeMinter(address account) internal {
+        _minters.remove(account);
+        emit MinterRemoved(account);
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/MockERC721MetadataMintable.sol
+
+
+
+
+
+/**
+ * @title MockERC721MetadataMintable
+ * @dev MockERC721 minting logic with metadata
+ */
+contract MockERC721MetadataMintable is Initializable, MockERC721, MockERC721Metadata, MinterRole {
+    function initialize(address sender) public initializer {
+        require(MockERC721._hasBeenInitialized());
+        require(MockERC721Metadata._hasBeenInitialized());
+        MinterRole.initialize(sender);
+    }
+
+    /**
+     * @dev Function to mint tokens
+     * @param to The address that will receive the minted tokens.
+     * @param tokenId The token id to mint.
+     * @param tokenURI The token URI of the minted token.
+     * @return A boolean that indicates if the operation was successful.
+     */
+    function mintWithTokenURI(address to, uint256 tokenId, string memory tokenURI) public onlyMinter returns (bool) {
+        _mint(to, tokenId);
+        _setTokenURI(tokenId, tokenURI);
+        return true;
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/access/roles/PauserRole.sol
+
+
+
+
+contract PauserRole is Initializable {
+    using Roles for Roles.Role;
+
+    event PauserAdded(address indexed account);
+    event PauserRemoved(address indexed account);
+
+    Roles.Role private _pausers;
+
+    function initialize(address sender) public initializer {
+        if (!isPauser(sender)) {
+            _addPauser(sender);
+        }
+    }
+
+    modifier onlyPauser() {
+        require(isPauser(msg.sender));
+        _;
+    }
+
+    function isPauser(address account) public view returns (bool) {
+        return _pausers.has(account);
+    }
+
+    function addPauser(address account) public onlyPauser {
+        _addPauser(account);
+    }
+
+    function renouncePauser() public {
+        _removePauser(msg.sender);
+    }
+
+    function _addPauser(address account) internal {
+        _pausers.add(account);
+        emit PauserAdded(account);
+    }
+
+    function _removePauser(address account) internal {
+        _pausers.remove(account);
+        emit PauserRemoved(account);
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/lifecycle/Pausable.sol
+
+
+
+/**
+ * @title Pausable
+ * @dev Base contract which allows children to implement an emergency stop mechanism.
+ */
+contract Pausable is Initializable, PauserRole {
+    event Paused(address account);
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    function initialize(address sender) public initializer {
+        PauserRole.initialize(sender);
+
+        _paused = false;
+    }
+
+    /**
+     * @return true if the contract is paused, false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused);
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     */
+    modifier whenPaused() {
+        require(_paused);
+        _;
+    }
+
+    /**
+     * @dev called by the owner to pause, triggers stopped state
+     */
+    function pause() public onlyPauser whenNotPaused {
+        _paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     */
+    function unpause() public onlyPauser whenPaused {
+        _paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/MockERC721Pausable.sol
+
+
+
+
+/**
+ * @title MockERC721 Non-Fungible Pausable token
+ * @dev MockERC721 modified with pausable transfers.
+ **/
+contract MockERC721Pausable is Initializable, MockERC721, Pausable {
+    function initialize(address sender) public initializer {
+        require(MockERC721._hasBeenInitialized());
+        Pausable.initialize(sender);
+    }
+
+    function approve(address to, uint256 tokenId) public whenNotPaused {
+        super.approve(to, tokenId);
+    }
+
+    function setApprovalForAll(address to, bool approved) public whenNotPaused {
+        super.setApprovalForAll(to, approved);
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public whenNotPaused {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    uint256[50] private ______gap;
+}
+
+// File: contracts/token/MockERC721/StandaloneMockERC721.sol
+
+
+
+
+
+
+
+
+/**
+ * @title Standard MockERC721 token, with minting and pause functionality.
+ *
+ */
+contract MockStandaloneERC721
+    is Initializable, MockERC721, MockERC721Enumerable, MockERC721Metadata, MockERC721MetadataMintable, MockERC721Pausable
+{
+    function initialize(string memory name, string memory symbol, address[] memory minters, address[] memory pausers) public initializer {
+        MockERC721.initialize();
+        MockERC721Enumerable.initialize();
+        MockERC721Metadata.initialize(name, symbol);
+
+        // Initialize the minter and pauser roles, and renounce them
+        MockERC721MetadataMintable.initialize(address(this));
+        _removeMinter(address(this));
+
+        MockERC721Pausable.initialize(address(this));
+        _removePauser(address(this));
+
+        // Add the requested minters and pausers (this can be done after renouncing since
+        // these are the internal calls)
+        for (uint256 i = 0; i < minters.length; ++i) {
+            _addMinter(minters[i]);
+        }
+
+        for (uint256 i = 0; i < pausers.length; ++i) {
+            _addPauser(pausers[i]);
+        }
+    }
+}

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -228,6 +228,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3505,9 +3506,9 @@
       }
     },
     "ganache-cli": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.3.0.tgz",
-      "integrity": "sha512-8SyzfX2ipRVBx1fBZLg3j8I3E334U3Vazk5mEpYcWqnIjC2ace6jtOXHG4aTuAvSz3+HzQ8p8pRjOJxdDZ2pnQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.4.3.tgz",
+      "integrity": "sha512-3G+CK4ojipDvxQHlpX8PjqaOMRWVcaLZZSW97Bv7fdcPTXQwkji2yY5CY6J12Atiub4M4aJc0va+q3HXeerbIA==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -3933,6 +3934,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
@@ -3973,13 +3975,15 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "asn1": {
           "version": "0.2.4",
@@ -3995,6 +3999,7 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -4760,7 +4765,8 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -4807,6 +4813,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -4840,6 +4847,7 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
           "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -4858,6 +4866,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4924,6 +4933,7 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -4992,6 +5002,7 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -5002,6 +5013,7 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -5011,7 +5023,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -5024,7 +5037,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -5036,7 +5050,8 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -5048,7 +5063,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -5197,6 +5213,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -5223,13 +5240,15 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
           "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -5244,19 +5263,22 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-js": {
           "version": "2.6.5",
@@ -5275,6 +5297,7 @@
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
@@ -5376,7 +5399,8 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "decompress": {
           "version": "4.2.0",
@@ -5409,6 +5433,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -5418,6 +5443,7 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -5558,7 +5584,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -5575,7 +5602,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -5619,7 +5647,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -5635,7 +5664,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.113",
@@ -5662,7 +5692,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -5761,7 +5792,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5779,7 +5811,8 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5864,6 +5897,7 @@
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -5947,7 +5981,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -5964,6 +5998,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -6314,6 +6365,7 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6323,7 +6375,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6341,7 +6394,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "events": {
           "version": "3.0.0",
@@ -6364,6 +6418,7 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
           "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
@@ -6402,6 +6457,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6410,7 +6466,8 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6482,7 +6539,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -6495,6 +6553,7 @@
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -6510,6 +6569,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6518,7 +6578,8 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6562,25 +6623,29 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
           "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
@@ -6610,6 +6675,7 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -6639,7 +6705,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "getpass": {
           "version": "0.1.7",
@@ -6685,6 +6752,7 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -6712,7 +6780,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
           "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "2.0.0",
@@ -6752,7 +6821,8 @@
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
           "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "has-symbols": {
           "version": "1.0.0",
@@ -6765,6 +6835,7 @@
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -6839,6 +6910,7 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -6850,7 +6922,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -6876,7 +6949,8 @@
           "version": "1.1.12",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
           "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "immediate": {
           "version": "3.2.3",
@@ -6919,7 +6993,8 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
           "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-arrayish": {
           "version": "0.2.1",
@@ -6986,13 +7061,15 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
           "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-regex": {
           "version": "1.0.4",
@@ -7007,7 +7084,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
           "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -7053,6 +7131,7 @@
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
@@ -7436,7 +7515,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -7487,7 +7567,8 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "memdown": {
           "version": "1.4.1",
@@ -7524,7 +7605,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "merkle-patricia-tree": {
           "version": "2.3.1",
@@ -7584,7 +7666,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "miller-rabin": {
           "version": "4.0.1",
@@ -7601,7 +7684,8 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
           "version": "1.38.0",
@@ -7622,7 +7706,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -7721,13 +7806,15 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
           "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "negotiator": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -7758,6 +7845,7 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -7767,7 +7855,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7800,6 +7889,7 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -7809,6 +7899,7 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -7847,19 +7938,22 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
           "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "p-finally": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "p-timeout": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -7869,6 +7963,7 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
           "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -7901,7 +7996,8 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
           "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "path-exists": {
           "version": "2.1.0",
@@ -7928,7 +8024,8 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "path-type": {
           "version": "1.1.0",
@@ -8000,7 +8097,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "private": {
           "version": "0.1.8",
@@ -8035,6 +8133,7 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
           "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.8.0"
@@ -8148,6 +8247,7 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -8178,19 +8278,22 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
           "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "range-parser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
           "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.3",
@@ -8508,6 +8611,7 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
           "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -8529,6 +8633,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -8537,7 +8642,8 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8546,6 +8652,7 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -8558,6 +8665,7 @@
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -8589,7 +8697,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -8614,13 +8723,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -8702,7 +8813,8 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.2",
@@ -8726,7 +8838,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -8867,6 +8980,7 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -8905,6 +9019,7 @@
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "any-promise": "^1.0.0"
           }
@@ -8914,6 +9029,7 @@
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "thenify": ">= 3.1.0 < 4"
           }
@@ -8938,7 +9054,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tmp": {
           "version": "0.0.33",
@@ -8953,7 +9070,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -9011,6 +9129,7 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
@@ -9056,7 +9175,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
           "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unbzip2-stream": {
           "version": "1.3.3",
@@ -9073,7 +9193,8 @@
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unorm": {
           "version": "1.5.0",
@@ -9085,7 +9206,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uri-js": {
           "version": "4.2.2",
@@ -9101,6 +9223,7 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -9109,13 +9232,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "utf8": {
           "version": "3.0.0",
@@ -9134,7 +9259,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.3.2",
@@ -9156,7 +9282,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -9202,6 +9329,7 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
           "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -9214,6 +9342,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
           "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-eth-iban": "1.0.0-beta.35",
@@ -9225,6 +9354,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
           "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9238,6 +9368,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
           "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "1.1.1"
@@ -9248,6 +9379,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
           "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9261,6 +9393,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
           "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "1.1.1",
             "underscore": "1.8.3",
@@ -9293,6 +9426,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
           "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
@@ -9304,7 +9438,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9381,6 +9516,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
           "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "web3-utils": "1.0.0-beta.35"
@@ -9390,7 +9526,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9399,6 +9536,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
           "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -9412,6 +9550,7 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
           "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -9452,7 +9591,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -9469,6 +9608,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -9500,6 +9656,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
           "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "xhr2-cookies": "1.1.0"
@@ -9510,6 +9667,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
           "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.3",
             "underscore": "1.8.3",
@@ -9521,10 +9679,11 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
           "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
           },
           "dependencies": {
             "debug": {
@@ -9532,6 +9691,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -9540,6 +9700,7 @@
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
               "dev": true,
+              "optional": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -9567,6 +9728,7 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
           "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -9581,13 +9743,15 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "utf8": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
               "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9653,6 +9817,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -9676,6 +9841,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -9691,6 +9857,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -9700,6 +9867,7 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -11522,7 +11690,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -15258,7 +15427,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       },
       "dependencies": {
         "underscore": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -79,7 +79,7 @@
     "chai-bignumber": "^2.0.2",
     "chai-string": "^1.5.0",
     "coveralls": "^3.0.0",
-    "ganache-cli": "^6.3.0",
+    "ganache-cli": "^6.4.3",
     "ganache-core": "^2.5.1",
     "lodash.foreach": "^4.5.0",
     "lodash.noop": "^3.0.1",

--- a/packages/lib/scripts/test.sh
+++ b/packages/lib/scripts/test.sh
@@ -18,6 +18,7 @@ ganache_running() {
 }
 
 start_ganache() {
+  node_modules/.bin/ganache-cli --version
   node_modules/.bin/ganache-cli --networkId 4447 -p $ganache_port -d > /dev/null &
   ganache_pid=$!
 }

--- a/packages/lib/test/src/utils/Transactions.test.js
+++ b/packages/lib/test/src/utils/Transactions.test.js
@@ -24,6 +24,10 @@ contract('Transactions', function(accounts) {
     this.DummyImplementation = Contracts.getFromLocal('DummyImplementation');
   });
 
+  afterEach(function () {
+    sinon.restore();
+  });
+
   const assertGasLt = async (txHash, expected) => {
     const { gas } = await ZWeb3.getTransaction(txHash);
     gas.should.be.at.most(parseInt(expected));
@@ -78,10 +82,6 @@ contract('Transactions', function(accounts) {
     });
 
     describe('gas', function () {
-      afterEach('restore stubs', function () {
-        sinon.restore();
-      })
-
       describe('when there is a default gas amount defined', function () {
         describe('when a gas amount is given', function () {
           it('uses specified gas', async function () {
@@ -111,6 +111,10 @@ contract('Transactions', function(accounts) {
         });
 
         describe('when no gas amount is given', function () {
+          beforeEach(function () {
+            sinon.stub(ZWeb3, 'isGanacheNode').resolves(false);
+          });
+
           it('estimates gas', async function () {
             const receipt = await Transactions.sendTransaction(this.instance.methods.initialize, DEFAULT_PARAMS);
             await assertGasLt(receipt.transactionHash, 1000000);
@@ -125,7 +129,7 @@ contract('Transactions', function(accounts) {
 
           it.skip('retries estimating gas', async function () {
             const stub = sinon.stub(this.instance.methods.initialize, 'estimateGas')
-            _.times(3, i => stub.onCall(i).throws('Error', 'gas required exceeds allowance or always failing transaction'))
+            times(3, i => stub.onCall(i).throws('Error', 'gas required exceeds allowance or always failing transaction'))
             stub.returns(800000)
 
             const receipt = await Transactions.sendTransaction(this.instance.methods.initialize, DEFAULT_PARAMS);
@@ -147,9 +151,8 @@ contract('Transactions', function(accounts) {
         sinon.stub(ZWeb3, 'isMainnet').resolves(true)
       });
 
-      afterEach('return to testnet and undo stub', async function() {
+      afterEach('return to testnet', async function() {
         delete state.gasPrice;
-        sinon.restore();
       });
 
       describe('uses an API to determine gas price', async function() {
@@ -202,10 +205,6 @@ contract('Transactions', function(accounts) {
     });
 
     describe('gas', function () {
-      afterEach('restore stubs', function () {
-        sinon.restore();
-      })
-
       describe('when there is a default gas amount defined', function () {
         describe('when a gas amount is given', function () {
           it('uses specified gas', async function () {
@@ -235,6 +234,10 @@ contract('Transactions', function(accounts) {
         });
 
         describe('when no gas amount is given', function () {
+          beforeEach(function () {
+            sinon.stub(ZWeb3, 'isGanacheNode').resolves(false);
+          })
+
           it('estimates gas', async function () {
             const receipt = await Transactions.sendDataTransaction(this.instance, { data: this.encodedCall });
             await assertGasLt(receipt.transactionHash, 1000000);
@@ -246,7 +249,7 @@ contract('Transactions', function(accounts) {
             stub.returns(800000)
 
             const receipt = await Transactions.sendDataTransaction(this.instance, { data: this.encodedCall });
-            await assertGas(receipt.transactionHash, 800000 * 1.25 + 15000);
+            await assertGas(receipt.transactionHash, 800000 * 1.25);
           });
 
           it('retries estimating gas up to 3 times', async function () {
@@ -267,9 +270,8 @@ contract('Transactions', function(accounts) {
           sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
 
-        afterEach('return to testnet and undo stub', async function() {
+        afterEach('return to testnet', async function() {
           delete state.gasPrice;
-          sinon.restore();
         });
 
         it('uses gas price API when gas not specified', async function () {
@@ -289,9 +291,8 @@ contract('Transactions', function(accounts) {
           sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });
 
-        afterEach('Return to testnet and undo stub', async function() {
+        afterEach('return to testnet', async function() {
           delete state.gasPrice;
-          sinon.restore();
         });
 
         it('produces an error when gas price API gives giant value', async function () {
@@ -345,10 +346,6 @@ contract('Transactions', function(accounts) {
     });
 
     describe('gas', function () {
-      afterEach('restore stubs', function () {
-        sinon.restore();
-      })
-
       describe('when there is a default gas amount defined', function () {
         describe('when a gas amount is given', function () {
           it('uses specified gas', async function () {
@@ -381,6 +378,10 @@ contract('Transactions', function(accounts) {
         });
 
         describe('when no gas amount is given', function () {
+          beforeEach(function () {
+            sinon.stub(ZWeb3, 'isGanacheNode').resolves(false);
+          })
+
           it('estimates gas', async function () {
             const transactionParams = { data: this.encodedCall };
             const receipt = await Transactions.sendRawTransaction(this.instance.address, transactionParams);
@@ -394,7 +395,7 @@ contract('Transactions', function(accounts) {
 
             const transactionParams = { data: this.encodedCall };
             const receipt = await Transactions.sendRawTransaction(this.instance.address, transactionParams);
-            await assertGas(receipt.transactionHash, 800000 * 1.25 + 15000);
+            await assertGas(receipt.transactionHash, 800000 * 1.25);
           });
 
           it('retries estimating gas up to 3 times', async function () {
@@ -416,9 +417,8 @@ contract('Transactions', function(accounts) {
           sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
         });
 
-        afterEach('return to testnet and undo stub', async function() {
+        afterEach('return to testnet', async function() {
           delete state.gasPrice;
-          sinon.restore();
         });
 
         it('uses gas price API when gas not specified', async function () {
@@ -442,9 +442,8 @@ contract('Transactions', function(accounts) {
           sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
         });
 
-        afterEach('Return to testnet and undo stub', async function() {
+        afterEach('return to testnet', async function() {
           delete state.gasPrice;
-          sinon.restore();
         });
 
         it('produces an error when gas price API gives giant value', async function () {
@@ -473,10 +472,6 @@ contract('Transactions', function(accounts) {
       });
 
       describe('gas', function () {
-        afterEach('restore stubs', function () {
-          sinon.restore();
-        });
-
         describe('when there is a default gas amount defined', function () {
           describe('when a gas amount is given', function () {
             it('uses specified gas', async function () {
@@ -507,9 +502,19 @@ contract('Transactions', function(accounts) {
 
           describe('when no gas amount is given', function () {
             it('estimates gas', async function () {
+              sinon.stub(ZWeb3, 'isGanacheNode').resolves(false);
               const instance = await Transactions.deployContract(this.DummyImplementation);
               await assertGasLt(instance.deployment.transactionHash, 1000000);
             });
+
+            // Regression test for zeppelinos/zos#837
+            it('uses enough gas for initializing a large contract', async function () {
+              const MockStandaloneERC721 = Contracts.getFromLocal('MockStandaloneERC721');;
+              const logic = await Transactions.deployContract(MockStandaloneERC721);
+              const initData = logic.methods.initialize('NFTToken', 'NFT', [account2], [account2]).encodeABI();
+              const Proxy = Contracts.getFromLocal('AdminUpgradeabilityProxy');
+              await Transactions.deployContract(Proxy, [logic.options.address, account2, initData]);
+            });            
           });
         });
       });
@@ -521,9 +526,8 @@ contract('Transactions', function(accounts) {
             sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
           });
 
-          afterEach('Return to testnet and undo stub', async function() {
+          afterEach('return to testnet', async function() {
             delete state.gasPrice;
-            sinon.restore();
           });
 
           it('uses gas price API when gas not specified', async function () {
@@ -545,9 +549,8 @@ contract('Transactions', function(accounts) {
             sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
           });
 
-          afterEach('Return to testnet and undo stub', async function() {
+          afterEach('return to testnet', async function() {
             delete state.gasPrice;
-            sinon.restore();
           });
 
           it('produces an error when gas price API gives giant value', async function () {
@@ -578,10 +581,6 @@ contract('Transactions', function(accounts) {
       });
 
       describe('gas', function () {
-        afterEach('restore stubs', function () {
-          sinon.restore();
-        })
-
         describe('when there is a default gas amount defined', function () {
           describe('when a gas amount is given', function () {
             it('uses specified gas', async function () {
@@ -611,6 +610,10 @@ contract('Transactions', function(accounts) {
           });
 
           describe('when no gas amount is given', function () {
+            beforeEach(function () {
+              sinon.stub(ZWeb3, 'isGanacheNode').resolves(false);
+            });
+
             it('estimates gas', async function () {
               const instance = await Transactions.deployContract(this.WithConstructorImplementation, [42, "foo"]);
               await assertGasLt(instance.deployment.transactionHash, 1000000);
@@ -622,7 +625,7 @@ contract('Transactions', function(accounts) {
               stub.returns(800000)
 
               const instance = await Transactions.deployContract(this.WithConstructorImplementation, [42, "foo"]);
-              await assertGas(instance.deployment.transactionHash, 800000 * 1.25 + 15000);
+              await assertGas(instance.deployment.transactionHash, 800000 * 1.25);
             });
 
             it('retries estimating gas up to 3 times', async function () {
@@ -643,9 +646,8 @@ contract('Transactions', function(accounts) {
             sinon.stub(axios, 'get').resolves({ data: { average: 49 } })
           });
 
-          afterEach('Return to testnet and undo stub', async function() {
+          afterEach('return to testnet', async function() {
             delete state.gasPrice;
-            sinon.restore();
           });
 
           it('uses gas price API when gas not specified', async function () {
@@ -667,9 +669,8 @@ contract('Transactions', function(accounts) {
             sinon.stub(axios, 'get').resolves({ data: { average: 1234123412341234 } })
           });
 
-          afterEach('return to testnet and undo stub', async function() {
+          afterEach('return to testnet', async function() {
             delete state.gasPrice;
-            sinon.restore();
           });
 
           it('produces an error when gas price API gives giant value', async function () {
@@ -686,8 +687,7 @@ contract('Transactions', function(accounts) {
       this.mineInterval = setInterval(advanceBlock, 100);
     })
 
-    afterEach('undo stub and disable mining', async function () {
-      sinon.restore()
+    afterEach('disable mining', async function () {
       if (this.mineInterval) clearInterval(this.mineInterval);
       await sleep(100);
     })


### PR DESCRIPTION
Recent versions of ganache (>= 6.4.0) return too low values for gas estimation, causing some transactions to fail.

- Use block gas limit for estimates when on ganache
- Update to ganache 6.4 to reproduce the issue
- Add a sample standalone erc721 to reproduce the issue
- Refactor sinon.restore calls in transaction tests

Fixes #846 
Related to https://github.com/trufflesuite/ganache-core/issues/428