### PR TITLE
[release 2.3] Pick contract functions always from ABI instead of using AST.

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -14,7 +14,7 @@ import isEqual from 'lodash.isequal';
 import concat from 'lodash.concat';
 import toPairs from 'lodash.topairs';
 
-import { Contracts, Contract, Logger, FileSystem as fs, Proxy, Transactions, semanticVersionToString, contractMethodsFromAst } from 'zos-lib';
+import { Contracts, Contract, Logger, FileSystem as fs, Proxy, Transactions, semanticVersionToString, contractMethodsFromAbi } from 'zos-lib';
 import { ProxyAdminProject, AppProject, flattenSourceCode, getStorageLayout, BuildArtifacts, getBuildArtifacts, getSolidityLibNames } from 'zos-lib';
 import { validate, newValidationErrors, validationPasses, App, ZWeb3, ProxyAdmin, SimpleProject, AppProxyMigrator } from 'zos-lib';
 import { isMigratableZosversion } from '../files/ZosVersion';
@@ -595,7 +595,7 @@ export default class NetworkController {
     // If there is an initializer called, assume it's ok
     if (calledInitMethod) return;
     // Otherwise, warn the user to invoke it
-    const contractMethods = contractMethodsFromAst(contract);
+    const contractMethods = contractMethodsFromAbi(contract);
     const initializerMethods = contractMethods
       .filter(({ hasInitializer, name }) => hasInitializer || name === 'initialize')
       .map(({ name }) => name);

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -3,7 +3,7 @@ import flatten from 'lodash.flatten';
 import isEmpty from 'lodash.isempty';
 import groupBy from 'lodash.groupby';
 import inquirer from 'inquirer';
-import { contractMethodsFromAst, contractMethodsFromAbi, ContractMethodMutability as Mutability } from 'zos-lib';
+import { contractMethodsFromAbi, ContractMethodMutability as Mutability } from 'zos-lib';
 
 import Session from '../models/network/Session';
 import Truffle from '../models/initializer/truffle/Truffle';
@@ -173,9 +173,7 @@ function contractMethods(contractFullName: string, constant: Mutability = Mutabi
   if (!localController.hasContract(packageName, contractAlias)) return [];
   const contract = localController.getContractClass(packageName, contractAlias);
 
-  return constant === Mutability.Constant
-    ? contractMethodsFromAbi(contract, constant)
-    : contractMethodsFromAst(contract, constant);
+  return contractMethodsFromAbi(contract, constant);
 }
 
 export function proxyInfo(contractInfo: any, network: string): any {

--- a/packages/lib/test/src/artifacts/Contract.test.js
+++ b/packages/lib/test/src/artifacts/Contract.test.js
@@ -4,7 +4,7 @@ require('../../setup')
 import utils from 'web3-utils';
 
 import Contracts from '../../../src/artifacts/Contracts'
-import { contractMethodsFromAst, contractMethodsFromAbi, ContractMethodMutability as Mutability } from '../../../src/artifacts/Contract';
+import { contractMethodsFromAbi, ContractMethodMutability as Mutability } from '../../../src/artifacts/Contract';
 
 const ContractWithStructInConstructor = Contracts.getFromLocal('WithStructInConstructor');
 const ContractWithConstructorImplementation = Contracts.getFromLocal('WithConstructorImplementation');
@@ -73,82 +73,6 @@ contract('Contract', function(accounts) {
      * nonInitializable(uint256)
      * fail()
    */
-    describe('#contractMethodsFromAst', function() {
-      context('when querying constant methods', function() {
-        beforeEach('set methods', function() {
-          this.methods = contractMethodsFromAst(InitializableMock, Mutability.Constant);
-        });
-
-        it('returns only public functions', function() {
-          const nonPublicMethods = this.methods.find(method => method.visibility !== 'public');
-          const publicMethods = this.methods.filter(method => method.visibility === 'public');
-          expect(nonPublicMethods).to.be.undefined;
-          expect(publicMethods).to.have.lengthOf(this.methods.length);
-        });
-
-        it('returns methods without initializers', function() {
-          const methods = this.methods.filter(({ hasInitializer }) => !hasInitializer);
-          expect(methods).to.have.lengthOf(1);
-          expect(methods[0].name).to.eq('fail');
-        });
-
-        it('sets selectors', function() {
-          expect(this.methods).to.have.lengthOf(1);
-          expect(this.methods[0].selector).to.eq('fail()');
-        });
-
-        it('sets method inputs', function() {
-          expect(this.methods).to.have.lengthOf(1);
-          expect(this.methods[0].inputs).to.be.empty;
-        });
-      });
-
-      context('when querying non-constant methods', function() {
-        beforeEach('set methods', function() {
-          this.methods = contractMethodsFromAst(InitializableMock, Mutability.NotConstant);
-        });
-
-        it('returns only public functions', function() {
-          const nonPublicMethods = this.methods.find(method => method.visibility !== 'public');
-          const publicMethods = this.methods.filter(method => method.visibility === 'public');
-          expect(nonPublicMethods).to.be.undefined;
-          expect(publicMethods).to.have.lengthOf(this.methods.length);
-        });
-
-        it('returns methods with initializers', function() {
-          const methods = this.methods.filter(({ hasInitializer }) => hasInitializer);
-          expect(methods).to.have.lengthOf(3);
-          expect(methods[0].name).to.eq('initialize');
-          expect(methods[1].name).to.eq('initializeNested');
-          expect(methods[2].name).to.eq('initializeWithX');
-        });
-
-        it('returns methods without initializers', function() {
-          const methods = this.methods.filter(({ hasInitializer }) => !hasInitializer);
-          expect(methods).to.have.lengthOf(1);
-          expect(methods[0].name).to.eq('nonInitializable');
-        });
-
-        it('sets selectors', function() {
-          expect(this.methods).to.have.lengthOf(4);
-          expect(this.methods[0].selector).to.eq('initialize()');
-          expect(this.methods[1].selector).to.eq('initializeNested()');
-          expect(this.methods[2].selector).to.eq('initializeWithX(uint256)');
-          expect(this.methods[3].selector).to.eq('nonInitializable(uint256)');
-        });
-
-        it('sets method inputs', function() {
-          expect(this.methods[0].inputs).to.be.empty;
-          expect(this.methods[1].inputs).to.be.empty;
-          expect(this.methods[2].inputs).to.have.lengthOf(1)
-          expect(this.methods[2].inputs[0].name).to.eq('_x');
-          expect(this.methods[2].inputs[0].type).to.eq('uint256');
-          expect(this.methods[3].inputs[0].name).to.eq('_x');
-          expect(this.methods[3].inputs[0].type).to.eq('uint256');
-        });
-      });
-    });
-
     describe('#contractMethodsFromAbi', function() {
       context('when querying constant methods', function() {
         beforeEach('set methods', function() {
@@ -160,15 +84,37 @@ contract('Contract', function(accounts) {
           this.methods.forEach(method => expect(method.type).to.eq('function'))
         });
 
+        it('returns methods without initializers', function() {
+          const methods = this.methods.filter(({ hasInitializer }) => !hasInitializer);
+          expect(methods).to.have.lengthOf(3);
+          expect(methods[0].name).to.eq('x');
+          expect(methods[1].name).to.eq('initializerRan');
+          expect(methods[2].name).to.eq('fail');
+        });
+
         it('sets selectors', function() {
           const selectors = this.methods.map(({ selector }) => selector);
           expect(selectors).to.include('x()', 'initializerRan()', 'fail()')
         });
       });
 
-      context('when querying constant methods', function() {
+      context('when querying non-constant methods', function() {
         beforeEach('set methods', function() {
           this.methods = contractMethodsFromAbi(InitializableMock, Mutability.NotConstant);
+        });
+
+        it('returns methods without initializers', function() {
+          const methods = this.methods.filter(({ hasInitializer }) => !hasInitializer);
+          expect(methods).to.have.lengthOf(1);
+          expect(methods[0].name).to.eq('nonInitializable');
+        });
+
+        it('returns methods with initializers', function() {
+          const methods = this.methods.filter(({ hasInitializer }) => hasInitializer);
+          expect(methods).to.have.lengthOf(3);
+          expect(methods[0].name).to.eq('initialize');
+          expect(methods[1].name).to.eq('initializeNested');
+          expect(methods[2].name).to.eq('initializeWithX');
         });
 
         it('returns an array of methods', function() {


### PR DESCRIPTION
Cherry-picked from  `fix/pick-contracts-from-abi-and-not-from-ast`. Fixes #900.