### PR TITLE
Fix directory path replacement

### DIFF
--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -106,7 +106,7 @@ export default class Contracts {
   private static _getFromPath(targetPath: string): Contract {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const schema = require(targetPath);
-    schema.directory = targetPath.replace(/\/\w*\.json$/, '/');
+    schema.directory = path.dirname(targetPath);
     if (schema.bytecode === '')
       throw new Error(
         `A bytecode must be provided for contract ${schema.contractName}.`,

--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -106,7 +106,7 @@ export default class Contracts {
   private static _getFromPath(targetPath: string): Contract {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const schema = require(targetPath);
-    schema.directory = targetPath.replace(/contracts\/.*\.json$/, 'contracts');
+    schema.directory = targetPath.replace(/\/\w*\.json$/, '/');
     if (schema.bytecode === '')
       throw new Error(
         `A bytecode must be provided for contract ${schema.contractName}.`,


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/927. The main problem was that the previous regexp was not precise enough to cover some edge (well, not precisely edge) cases  if having a project directory path such as: `foo/bar/bazcontracts`, or anything with a `contracts` at the end of the directory name.
Now, we are using `path#dirname` instead (thanks @ylv-io!!)
If approved, I will add this to the `release/2.3` branch.