### PR TITLE
Handles swarm hash metadata for solidity 0.5.2

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -165,6 +165,14 @@
         "@types/node": "*"
       }
     },
+    "@types/cbor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
+      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -648,6 +656,29 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cbor": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.1.5.tgz",
+      "integrity": "sha512-WqpISHl7/kk1u1uoaqctGyGiET3+wGN4A6pPsFCzEBztJJlCVxnMB4JwcuuNSrMiV4V6UBlxMkhNzJrUxDWO1A==",
+      "requires": {
+        "bignumber.js": "^8.0.2",
+        "commander": "^2.19.0",
+        "json-text-sequence": "^0.1",
+        "nofilter": "^1.0.1"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+        },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        }
+      }
+    },
     "chai": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
@@ -1063,6 +1094,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -4315,6 +4351,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -7908,6 +7961,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -8697,6 +8767,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -9261,6 +9339,11 @@
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
       }
+    },
+    "nofilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.2.tgz",
+      "integrity": "sha512-d38SORxm9UNoDsnPXajV9nBEebKX4/paXAlyRGnSjZuFbLLZDFUO4objr+tbybqsbqGXDWllb6gQoKUDc9q3Cg=="
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -39,9 +39,11 @@
   },
   "homepage": "https://github.com/zeppelinos/zos/tree/master/packages/lib#readme",
   "dependencies": {
+    "@types/cbor": "^2.0.0",
     "@types/web3": "^1.0.14",
     "axios": "^0.18.0",
     "bignumber.js": "^7.2.0",
+    "cbor": "^4.1.5",
     "chalk": "^2.4.1",
     "ethers": "^4.0.20",
     "glob": "^7.1.3",

--- a/packages/lib/src/utils/Bytecode.ts
+++ b/packages/lib/src/utils/Bytecode.ts
@@ -46,7 +46,7 @@ export function tryRemoveMetadata(bytecode: string): string {
   const length = parseInt(rawLength, 16);
 
   // Bail on unreasonable values for length (meaning we read something else other than metadata length)
-  if (length > 200) return bytecode;
+  if (length * 2 > bytecode.length - 4) return bytecode;
 
   // Gather what we assume is the CBOR encoded metadata, and try to parse it
   const metadataStart = bytecode.length - length * 2 - 4;

--- a/packages/lib/src/utils/Bytecode.ts
+++ b/packages/lib/src/utils/Bytecode.ts
@@ -1,6 +1,10 @@
 import crypto from 'crypto';
 import { ZERO_ADDRESS } from './Addresses';
 import Contract from '../artifacts/Contract';
+import cbor from 'cbor';
+import Logger from '../utils/Logger';
+
+const log = new Logger('Bytecode');
 
 export function bodyCode(contract: Contract): string {
   return splitCode(contract).body;
@@ -11,7 +15,7 @@ export function constructorCode(contract: Contract): string {
 }
 
 export function bytecodeDigest(rawBytecode: string): string {
-  const bytecode: string = tryRemoveSwarmHash(rawBytecode.replace(/^0x/, ''));
+  const bytecode: string = tryRemoveMetadata(rawBytecode.replace(/^0x/, ''));
   const buffer: Buffer = Buffer.from(bytecode, 'hex');
   const hash: any = crypto.createHash('sha256');
   return hash.update(buffer).digest('hex');
@@ -31,11 +35,33 @@ export function hasUnlinkedVariables(bytecode: string): boolean {
   return getSolidityLibNames(bytecode).length > 0;
 }
 
-// Removes the last 43 bytes of the bytecode, i.e., the swarm hash that the solidity compiler appends and that
-// respects the following structure: 0xa1 0x65 'b' 'z' 'z' 'r' '0' 0x58 0x20 <32 bytes swarm hash> 0x00 0x29
-// (see https://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode)
-export function tryRemoveSwarmHash(bytecode: string): string {
-  return bytecode.replace(/a165627a7a72305820[a-fA-F0-9]{64}0029$/, '');
+// Removes the swarm hash from the CBOR encoded metadata at the end of the bytecode
+// (see https://solidity.readthedocs.io/en/v0.5.9/metadata.html)
+export function tryRemoveMetadata(bytecode: string): string {
+  // Bail on empty bytecode
+  if (!bytecode || bytecode.length <= 2) return bytecode;
+
+  // Gather length of CBOR metadata from the end of the file
+  const rawLength = bytecode.slice(bytecode.length - 4);
+  const length = parseInt(rawLength, 16);
+
+  // Bail on unreasonable values for length (meaning we read something else other than metadata length)
+  if (length > 200) return bytecode;
+
+  // Gather what we assume is the CBOR encoded metadata, and try to parse it
+  const metadataStart = bytecode.length - length * 2 - 4;
+  const metadata = bytecode.slice(metadataStart, bytecode.length - 4);
+
+  // Parse it to see if it is indeed valid metadata
+  try {
+    cbor.decode(Buffer.from(metadata, 'hex'));
+  } catch (err) {
+    log.warn(`Error parsing contract metadata: ${err.message}. Ignoring.`);
+    return bytecode;
+  }
+
+  // Return bytecode without it
+  return bytecode.slice(0, metadataStart);
 }
 
 // Replaces the solidity library address inside its bytecode with zeros

--- a/packages/lib/test/src/utils/Bytecode.test.js
+++ b/packages/lib/test/src/utils/Bytecode.test.js
@@ -2,41 +2,49 @@
 
 require('../../setup');
 
-import { tryRemoveSwarmHash } from '../../../src/utils/Bytecode';
+import { tryRemoveMetadata } from '../../../src/utils/Bytecode';
 
 describe('contracts util functions', function() {
-  describe('tryRemoveSwarmHash', function() {
-    describe('with valid swarm hash', function() {
-      it('removes swarm hash from bytecode', function() {
-        const swarmHash =
-          '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
-        const swarmHashWrapper = `a165627a7a72305820${swarmHash}0029`;
-        const bytecode = `0x01234567890abcdef${swarmHashWrapper}`;
+  describe('tryRemoveMetadata', function() {
+    const contractBytecode = '01234567890abcdef';
 
-        tryRemoveSwarmHash(bytecode).should.eq('0x01234567890abcdef');
-      });
+    it('removes metadata from solidity 0.4 bytecode', function() {
+      const swarmHash =
+        '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
+      const swarmHashWrapper = `65627a7a72305820${swarmHash}`;
+      const metadata = `a1${swarmHashWrapper}0029`;
+      const bytecode = `0x${contractBytecode}${metadata}`;
+
+      tryRemoveMetadata(bytecode).should.eq(`0x${contractBytecode}`);
     });
 
-    describe('with a swarm hash size different than 32 bytes', function() {
-      it('does not change the bytecode', function() {
-        const invalidSwarmHash =
-          '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b4';
-        const swarmHashWrapper = `27a7a72305820${invalidSwarmHash}0029`;
-        const bytecode = `0x01234567890abcdefa16560029${swarmHashWrapper}`;
+    it('removes metadata from solidity 0.5 bytecode', function() {
+      const swarmHash =
+        '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
+      const swarmHashWrapper = `65627a7a72305820${swarmHash}`;
+      const solcVersionWrapper = '64736f6c6343000509';
+      const metadata = `a2${swarmHashWrapper}${solcVersionWrapper}0032`;
+      const bytecode = `0x${contractBytecode}${metadata}`;
 
-        tryRemoveSwarmHash(bytecode).should.eq(bytecode);
-      });
+      tryRemoveMetadata(bytecode).should.eq(`0x${contractBytecode}`);
     });
 
-    describe('with an invalid swarm hash format', function() {
-      it('does not change the bytecode', function() {
-        const swarmHash =
-          '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
-        const invalidSwarmHashWrapper = `a165627a7a7230${swarmHash}abab29`;
-        const bytecode = `0x01234567890abcdef${invalidSwarmHashWrapper}`;
+    it('does not change the bytecode if metadata encoding is invalid', function() {
+      const swarmHash =
+        '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
+      const invalidSwarmHashWrapper = `a165627a7a72305821${swarmHash}0029`;
+      const bytecode = `0x${contractBytecode}${invalidSwarmHashWrapper}`;
 
-        tryRemoveSwarmHash(bytecode).should.eq(bytecode);
-      });
+      tryRemoveMetadata(bytecode).should.eq(bytecode);
+    });
+
+    it('does not change the bytecode if metadata length is not reliable', function() {
+      const swarmHash =
+        '69b1869ae52f674ffccdd8f6d35de04d578a778e919a1b41b7a2177668e08e1a';
+      const invalidSwarmHashWrapper = `a165627a7a72305821${swarmHash}9929`;
+      const bytecode = `0x${contractBytecode}${invalidSwarmHashWrapper}`;
+
+      tryRemoveMetadata(bytecode).should.eq(bytecode);
     });
   });
 });


### PR DESCRIPTION
Since Solidity 0.5.2, the swarm hash is included along with the compiler version, CBOR encoded at the end of the runtime bytecode. This handles both metadata versions and removes the swarm hash from both of them.

Fixes #844