### PR TITLE
Use relative paths in compiled artifacts

### DIFF
--- a/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
@@ -101,9 +101,12 @@ class SolidityProjectCompiler {
       this.inputDir,
       ImportsFsEngine(),
     );
+    const cwd = process.cwd();
     this.contracts = importFiles.map(file => ({
       fileName: path.basename(file.url),
-      filePath: file.url,
+      filePath: path.isAbsolute(file.url)
+        ? path.relative(cwd, file.url)
+        : file.url,
       source: file.source,
       lastModified: tryFunc(() => statSync(file.url).mtimeMs),
     }));

--- a/packages/cli/test/models/compiler/solidity/SolidityContractsCompiler.test.js
+++ b/packages/cli/test/models/compiler/solidity/SolidityContractsCompiler.test.js
@@ -1,248 +1,336 @@
-require('../../../setup')
+require('../../../setup');
 
 import CaptureLogs from '../../../helpers/captureLogs';
 import { compile } from '../../../../src/models/compiler/solidity/SolidityContractsCompiler';
-import { setSolcCachePath, setSolcBinEnv } from '../../../../src/models/compiler/solidity/CompilerProvider';
+import {
+  setSolcCachePath,
+  setSolcBinEnv,
+} from '../../../../src/models/compiler/solidity/CompilerProvider';
 import sinon from 'sinon';
 import axios from 'axios';
 import path from 'path';
 
-describe('SolidityContractsCompiler', function () {
-
+describe('SolidityContractsCompiler', function() {
   const contract_Solc04 = {
     fileName: 'Example04.sol',
     filePath: '/test/Example04.sol',
-    source: 'pragma solidity ^0.4.24; contract Example04 { function f() public pure returns (string memory) { return "bla"; } }'
-  }
+    source:
+      'pragma solidity ^0.4.24; contract Example04 { function f() public pure returns (string memory) { return "bla"; } }',
+  };
 
   const anotherContract_Solc04 = {
     fileName: 'AnotherExample04.sol',
     filePath: '/test/AnotherExample04.sol',
-    source: 'pragma solidity 0.4.24; contract AnotherExample04 { function f() public pure returns (uint) { return 2; } }'
-  }
+    source:
+      'pragma solidity 0.4.24; contract AnotherExample04 { function f() public pure returns (uint) { return 2; } }',
+  };
 
   const contractWithWarnings_Solc04 = {
     fileName: 'ExampleWithWarnings04.sol',
     filePath: '/test/ExampleWithWarnings04.sol',
-    source: 'pragma solidity ^0.4.24; contract ExampleWithWarnings04 { function f() public returns (uint) { return 2; } }'
-  }
+    source:
+      'pragma solidity ^0.4.24; contract ExampleWithWarnings04 { function f() public returns (uint) { return 2; } }',
+  };
 
   const contractWithErrors_Solc04 = {
     fileName: 'ExampleWithErrors04.sol',
     filePath: '/test/ExampleWithErrors04.sol',
-    source: 'pragma solidity ^0.4.24; contract ExampleWithErrors04 { function f() public { return 2; } }'
-  }
+    source:
+      'pragma solidity ^0.4.24; contract ExampleWithErrors04 { function f() public { return 2; } }',
+  };
 
   const contract_Solc05 = {
     fileName: 'Example05.sol',
     filePath: '/test/Example05.sol',
-    source: 'pragma solidity ^0.5.0; contract Example05 { function f() public pure returns (string memory) { return "bla"; } }'
-  }
+    source:
+      'pragma solidity ^0.5.0; contract Example05 { function f() public pure returns (string memory) { return "bla"; } }',
+  };
 
   const anotherContract_Solc05 = {
     fileName: 'AnotherExample05.sol',
     filePath: '/test/AnotherExample05.sol',
-    source: 'pragma solidity ^0.5.0; contract AnotherExample05 { function f() public pure returns (uint) { return 2; } }'
-  }
+    source:
+      'pragma solidity ^0.5.0; contract AnotherExample05 { function f() public pure returns (uint) { return 2; } }',
+  };
 
   const contractWithWarnings_Solc05 = {
     fileName: 'ExampleWithWarnings05.sol',
     filePath: '/test/ExampleWithWarnings05.sol',
-    source: 'pragma solidity ^0.5.0; contract ExampleWithWarnings05 { function f() public { } }'
-  }
+    source:
+      'pragma solidity ^0.5.0; contract ExampleWithWarnings05 { function f() public { } }',
+  };
 
   const contractWithErrors_Solc05 = {
     fileName: 'ExampleWithErrors05.sol',
     filePath: '/test/ExampleWithErrors.sol',
-    source: 'pragma solidity ^0.5.0; contract ExampleWithErrors05 { function f() public { return 2; } }'
-  }
+    source:
+      'pragma solidity ^0.5.0; contract ExampleWithErrors05 { function f() public { return 2; } }',
+  };
 
   const contractNoPragma_Solc05 = {
     fileName: 'ExampleNoPragma05.sol',
     filePath: '/test/ExampleNoPragma05.sol',
-    source: 'contract ExampleNoPragma05 { function f() public pure returns (string memory) { return "bla"; } }'
-  }
+    source:
+      'contract ExampleNoPragma05 { function f() public pure returns (string memory) { return "bla"; } }',
+  };
 
-  before('stub solc list', function () {
+  before('stub solc list', function() {
     setSolcCachePath(path.resolve(__dirname, '../../../../solc/'));
-    sinon.stub(axios, 'get')
+    sinon
+      .stub(axios, 'get')
       .withArgs('https://solc-bin.ethereum.org/bin/list.json')
       .resolves({ data: require('../../../../solc/list.json') });
   });
 
-  after('clear stubs', function () {
+  after('clear stubs', function() {
     sinon.restore();
   });
 
-  beforeEach('capturing logging', function () {
+  beforeEach('capturing logging', function() {
     this.logs = new CaptureLogs();
-  })
-
-  afterEach('restore logging', function () {
-    this.logs.restore()
-  })
-
-  describe('version 0.5.x binary', function () {
-    beforeEach(function () {
-      setSolcBinEnv({ PATH: `${process.env.PATH}${path.delimiter}${path.resolve(__dirname, '../../../../solc/')}` });
-    });
-
-    afterEach(function () {
-      setSolcBinEnv(null)
-    });
-
-    it('compiles using local binary if available', async function () {
-      const contracts = [contract_Solc05]
-      const output = await compile(contracts, { version: '0.5.9' });
-      assertOutput(contracts, output, { version: '0.5.9+commit.c68bc34e.Linux.g++' });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
-
-    it('fails when a contract has errors', async function () {
-      const options = { version: '0.5.0' }
-      const contracts = [contract_Solc05, contractWithErrors_Solc05]
-      await compile(contracts, options).should.be.rejectedWith(/Different number of arguments in return statement than in returns declaration/)
-    }).timeout(180000)
-
-    it('compiles using solcjs if binary version does not match', async function () {
-      const contracts = [contract_Solc05]
-      const output = await compile(contracts, { version: '0.5.0' });
-      assertOutput(contracts, output, { version: '0.5.0+commit.1d4f565a.Emscripten.clang' });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
   });
 
-  describe('version 0.5.x solcjs', function () {
-    it('compiles using solc nigthly if specified exactly', async function () {
-      const contracts = [contract_Solc05]
-      const output = await compile(contracts, { version: '0.5.10-nightly.2019.5.28' })
-      assertOutput(contracts, output, { version: '0.5.10-nightly.2019.5.28+commit.ff8898b8.Emscripten.clang' });
-      this.logs.errors.should.be.empty
-      this.logs.warns[0].should.match(/This is a pre-release compiler version/)
-    }).timeout(180000)
-    
-    it('compiles using latest release if no pragma or options are set', async function () {
-      const contracts = [contractNoPragma_Solc05]
+  afterEach('restore logging', function() {
+    this.logs.restore();
+  });
+
+  beforeEach('disable local solc lookup', function() {
+    setSolcBinEnv({ PATH: '' });
+  });
+
+  afterEach('reenable solc lookup', function() {
+    setSolcBinEnv(null);
+  });
+
+  describe('version 0.5.x binary', function() {
+    beforeEach(function() {
+      setSolcBinEnv({
+        PATH: `${process.env.PATH}${path.delimiter}${path.resolve(
+          __dirname,
+          '../../../../solc/',
+        )}`,
+      });
+    });
+
+    afterEach(function() {
+      setSolcBinEnv(null);
+    });
+
+    it('compiles using local binary if available', async function() {
+      const contracts = [contract_Solc05];
+      const output = await compile(contracts, { version: '0.5.9' });
+      assertOutput(contracts, output, {
+        version: '0.5.9+commit.c68bc34e.Linux.g++',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
+
+    it('fails when a contract has errors', async function() {
+      const options = { version: '0.5.0' };
+      const contracts = [contract_Solc05, contractWithErrors_Solc05];
+      await compile(contracts, options).should.be.rejectedWith(
+        /Different number of arguments in return statement than in returns declaration/,
+      );
+    }).timeout(180000);
+
+    it('compiles using solcjs if binary version does not match', async function() {
+      const contracts = [contract_Solc05];
+      const output = await compile(contracts, { version: '0.5.0' });
+      assertOutput(contracts, output, {
+        version: '0.5.0+commit.1d4f565a.Emscripten.clang',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
+  });
+
+  describe('version 0.5.x solcjs', function() {
+    it('compiles using solc nigthly if specified exactly', async function() {
+      const contracts = [contract_Solc05];
+      const output = await compile(contracts, {
+        version: '0.5.10-nightly.2019.5.28',
+      });
+      assertOutput(contracts, output, {
+        version: '0.5.10-nightly.2019.5.28+commit.ff8898b8.Emscripten.clang',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns[0].should.match(/This is a pre-release compiler version/);
+    }).timeout(180000);
+
+    it('compiles using latest release if no pragma or options are set', async function() {
+      const contracts = [contractNoPragma_Solc05];
       const output = await compile(contracts, {});
-      assertOutput(contracts, output, { version: '0.5.9+commit.e560f70d.Emscripten.clang' });
-      this.logs.errors.should.be.empty
-      this.logs.warns[0].should.match(/Source file does not specify required compiler version/)
-    }).timeout(180000)
+      assertOutput(contracts, output, {
+        version: '0.5.9+commit.e560f70d.Emscripten.clang',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns[0].should.match(
+        /Source file does not specify required compiler version/,
+      );
+    }).timeout(180000);
 
-    it('compiles using solc 0.5.9 based on pragma', async function () {
-      const contracts = [contract_Solc05, anotherContract_Solc05]
+    it('compiles using solc 0.5.9 based on pragma', async function() {
+      const contracts = [contract_Solc05, anotherContract_Solc05];
       const output = await compile(contracts, {});
-      assertOutput(contracts, output, { version: '0.5.9+commit.e560f70d.Emscripten.clang' });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
+      assertOutput(contracts, output, {
+        version: '0.5.9+commit.e560f70d.Emscripten.clang',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
 
-    it('compiles using solc 0.5.0 and optimizer based on options', async function () {
-      const contracts = [contract_Solc05, anotherContract_Solc05]
-      const options = { version: '0.5.0', optimizer: { enabled: true, runs: 200 }}
-      const output = await compile(contracts, options)
-      assertOutput(contracts, output, { version: '0.5.0+commit.1d4f565a.Emscripten.clang', optimizer: options.optimizer });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
+    it('compiles using solc 0.5.0 and optimizer based on options', async function() {
+      const contracts = [contract_Solc05, anotherContract_Solc05];
+      const options = {
+        version: '0.5.0',
+        optimizer: { enabled: true, runs: 200 },
+      };
+      const output = await compile(contracts, options);
+      assertOutput(contracts, output, {
+        version: '0.5.0+commit.1d4f565a.Emscripten.clang',
+        optimizer: options.optimizer,
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
 
-    it('compiles with warnings', async function () {
-      const options = { version: '0.5.0' }
-      const contracts = [contract_Solc05, anotherContract_Solc05, contractWithWarnings_Solc05]
-      const output = await compile(contracts, options)
-      assertOutput(contracts, output, { version: '0.5.0+commit.1d4f565a.Emscripten.clang' });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.have.lengthOf(1)
-      this.logs.warns[0].should.match(/Function state mutability can be restricted to pure/)
-    }).timeout(180000)
+    it('compiles with warnings', async function() {
+      const options = { version: '0.5.0' };
+      const contracts = [
+        contract_Solc05,
+        anotherContract_Solc05,
+        contractWithWarnings_Solc05,
+      ];
+      const output = await compile(contracts, options);
+      assertOutput(contracts, output, {
+        version: '0.5.0+commit.1d4f565a.Emscripten.clang',
+      });
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.have.lengthOf(1);
+      this.logs.warns[0].should.match(
+        /Function state mutability can be restricted to pure/,
+      );
+    }).timeout(180000);
 
-    it('fails when a contract has errors', async function () {
-      const options = { version: '0.5.0' }
-      const contracts = [contract_Solc05, anotherContract_Solc05, contractWithErrors_Solc05]
-      await compile(contracts, options).should.be.rejectedWith(/Different number of arguments in return statement than in returns declaration/)
-    }).timeout(180000)
-    
-    it('fails when source requires different compiler version', async function () {
-      const options = { version: '0.5.0' }
-      const contracts = [contract_Solc05, contract_Solc04]
-      await compile(contracts, options).should.be.rejectedWith(/Source file requires different compiler version/);
-    }).timeout(180000)
+    it('fails when a contract has errors', async function() {
+      const options = { version: '0.5.0' };
+      const contracts = [
+        contract_Solc05,
+        anotherContract_Solc05,
+        contractWithErrors_Solc05,
+      ];
+      await compile(contracts, options).should.be.rejectedWith(
+        /Different number of arguments in return statement than in returns declaration/,
+      );
+    }).timeout(180000);
 
-    it('fails when source require incompatible compiler versions', async function () {
-      const contracts = [contract_Solc05, contract_Solc04]
-      await compile(contracts, {}).should.be.rejectedWith(/Could not find a compiler that matches required versions/);
-    }).timeout(180000)
-  })
+    it('fails when source requires different compiler version', async function() {
+      const options = { version: '0.5.0' };
+      const contracts = [contract_Solc05, contract_Solc04];
+      await compile(contracts, options).should.be.rejectedWith(
+        /Source file requires different compiler version/,
+      );
+    }).timeout(180000);
 
-  describe('version 0.4.x', function () {
-    const version = '0.4.24+commit.e67f0147.Emscripten.clang'
-    const contracts = [contract_Solc04, anotherContract_Solc04]
-    const options = { version: '0.4.24' }
+    it('fails when source require incompatible compiler versions', async function() {
+      const contracts = [contract_Solc05, contract_Solc04];
+      await compile(contracts, {}).should.be.rejectedWith(
+        /Could not find a compiler that matches required versions/,
+      );
+    }).timeout(180000);
+  });
 
-    it('compiles using solc 0.4.24 based on pragma', async function () {  
-      const output = await compile(contracts, {})
+  describe('version 0.4.x', function() {
+    const version = '0.4.24+commit.e67f0147.Emscripten.clang';
+    const contracts = [contract_Solc04, anotherContract_Solc04];
+    const options = { version: '0.4.24' };
+
+    it('compiles using solc 0.4.24 based on pragma', async function() {
+      const output = await compile(contracts, {});
       assertOutput(contracts, output, { version });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
 
-    it('compiles using solc 0.4.24 based on options', async function () {  
-      const output = await compile(contracts, options)
+    it('compiles using solc 0.4.24 based on options', async function() {
+      const output = await compile(contracts, options);
       assertOutput(contracts, output, { version });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
 
-    it('compiles using solc 0.4.24 with optimizer based on options', async function () {
-      const options = { version: '0.4.24', optimizer: { enabled: true, runs: 200 } }
-      const output = await compile(contracts, options)
+    it('compiles using solc 0.4.24 with optimizer based on options', async function() {
+      const options = {
+        version: '0.4.24',
+        optimizer: { enabled: true, runs: 200 },
+      };
+      const output = await compile(contracts, options);
       assertOutput(contracts, output, { ...options, version });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.be.empty
-    }).timeout(180000)
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.be.empty;
+    }).timeout(180000);
 
-    it('compiles and logs warnings', async function () {
-      const contracts = [contract_Solc04, anotherContract_Solc04, contractWithWarnings_Solc04]
-      const output = await compile(contracts, options)
+    it('compiles and logs warnings', async function() {
+      const contracts = [
+        contract_Solc04,
+        anotherContract_Solc04,
+        contractWithWarnings_Solc04,
+      ];
+      const output = await compile(contracts, options);
       assertOutput(contracts, output, { version });
-      this.logs.errors.should.be.empty
-      this.logs.warns.should.have.lengthOf(1)
-      this.logs.warns[0].should.match(/Function state mutability can be restricted to pure/)
-    }).timeout(180000)
+      this.logs.errors.should.be.empty;
+      this.logs.warns.should.have.lengthOf(1);
+      this.logs.warns[0].should.match(
+        /Function state mutability can be restricted to pure/,
+      );
+    }).timeout(180000);
 
-    it('fails to compile contract with errors', async function () {
-      const contracts = [contract_Solc04, anotherContract_Solc04, contractWithErrors_Solc04]
-      await compile(contracts, options).should.be.rejectedWith(/Different number of arguments in return statement than in returns declaration/);
-    }).timeout(180000)
-      
-    it('fails when source requires different compiler version', async function () {
-      const contracts = [contract_Solc05, contract_Solc04]
-      await compile(contracts, options).should.be.rejectedWith(/Source file requires different compiler version/);
-    }).timeout(180000)
-  })
-})
+    it('fails to compile contract with errors', async function() {
+      const contracts = [
+        contract_Solc04,
+        anotherContract_Solc04,
+        contractWithErrors_Solc04,
+      ];
+      await compile(contracts, options).should.be.rejectedWith(
+        /Different number of arguments in return statement than in returns declaration/,
+      );
+    }).timeout(180000);
+
+    it('fails when source requires different compiler version', async function() {
+      const contracts = [contract_Solc05, contract_Solc04];
+      await compile(contracts, options).should.be.rejectedWith(
+        /Source file requires different compiler version/,
+      );
+    }).timeout(180000);
+  });
+});
 
 function assertOutput(contracts, output, { version, optimizer, evmVersion }) {
-  output.should.have.lengthOf(contracts.length)
+  output.should.have.lengthOf(contracts.length);
   output.forEach(data => {
-    const contract = contracts.find(contract => contract.fileName === data.fileName)
-    const { source, fileName, filePath } = contract
-    const contractName = fileName.substring(0, fileName.lastIndexOf('.'))
+    const contract = contracts.find(
+      contract => contract.fileName === data.fileName,
+    );
+    const { source, fileName, filePath } = contract;
+    const contractName = fileName.substring(0, fileName.lastIndexOf('.'));
 
-    data.contractName.should.be.eq(contractName)
-    data.source.should.be.eq(source)
-    data.sourcePath.should.be.eq(filePath)
-    data.sourceMap.should.not.be.null
-    data.deployedSourceMap.should.not.be.null
-    data.abi.should.not.be.null
-    data.ast.should.not.be.null
-    data.bytecode.should.not.be.null
-    data.deployedBytecode.should.not.be.null
-    data.compiler.name.should.be.eq('solc')
-    data.compiler.version.should.be.eq(version || '0.5.9+commit.e560f70d.Emscripten.clang')
-    data.compiler.optimizer.should.be.deep.equal(optimizer || { enabled: false })
-    data.compiler.evmVersion.should.be.eq(evmVersion || 'constantinople')
-  })
+    data.contractName.should.be.eq(contractName);
+    data.source.should.be.eq(source);
+    data.sourcePath.should.be.eq(filePath);
+    data.sourceMap.should.not.be.null;
+    data.deployedSourceMap.should.not.be.null;
+    data.abi.should.not.be.null;
+    data.ast.should.not.be.null;
+    data.bytecode.should.not.be.null;
+    data.deployedBytecode.should.not.be.null;
+    data.compiler.name.should.be.eq('solc');
+    data.compiler.version.should.be.eq(
+      version || '0.5.9+commit.e560f70d.Emscripten.clang',
+    );
+    data.compiler.optimizer.should.be.deep.equal(
+      optimizer || { enabled: false },
+    );
+    data.compiler.evmVersion.should.be.eq(evmVersion || 'constantinople');
+  });
 }

--- a/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
+++ b/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
@@ -1,114 +1,128 @@
-require('../../../setup')
+require('../../../setup');
 
-import { FileSystem } from 'zos-lib'
-import { compileProject } from '../../../../src/models/compiler/solidity/SolidityProjectCompiler'
+import { FileSystem } from 'zos-lib';
+import { compileProject } from '../../../../src/models/compiler/solidity/SolidityProjectCompiler';
 import { statSync, utimesSync } from 'fs';
 import path from 'path';
 
-describe('SolidityProjectCompiler', function () {
+describe('SolidityProjectCompiler', function() {
   const rootDir = path.resolve(__dirname, '../../../../');
   const baseTestBuildDir = `${rootDir}/test/tmp`;
-  
-  after('cleanup test build dir', function () {
-    FileSystem.removeTree(baseTestBuildDir)
+
+  after('cleanup test build dir', function() {
+    FileSystem.removeTree(baseTestBuildDir);
   });
 
-  describe('in mock-stdlib project', function () {
+  describe('in mock-stdlib project', function() {
     this.timeout(20000);
 
     const inputDir = `${rootDir}/test/mocks/mock-stdlib/contracts`;
     const outputDir = `${baseTestBuildDir}/mock-stdlib`;
     const greeterArtifactPath = `${outputDir}/GreeterImpl.json`;
-    
-    before('compiling', async function () {
+
+    before('compiling', async function() {
       await compileProject({ inputDir, outputDir, version: '0.5.9' });
     });
 
-    it('compiles all contracts in the project', function () {
+    it('compiles all contracts in the project', function() {
       FileSystem.exists(outputDir).should.be.true;
       FileSystem.readDir(outputDir).should.have.lengthOf(2);
     });
 
-    it('generates correct artifacts', function () {
+    it('generates correct artifacts', function() {
       FileSystem.readDir(outputDir).forEach(schemaFileName => {
-        const contractName = schemaFileName.substring(0, schemaFileName.lastIndexOf('.'))
-        const contractPath = `${inputDir}/${contractName}.sol`
-        const schemaPath = `${outputDir}/${schemaFileName}`
-        const schema = FileSystem.parseJson(schemaPath)
-  
-        schema.fileName.should.be.eq(`${contractName}.sol`)
-        schema.contractName.should.be.eq(contractName)
-        schema.source.should.be.eq(FileSystem.read(contractPath))
-        schema.sourcePath.should.be.eq(contractPath)
-        schema.sourceMap.should.not.be.null
-        schema.abi.should.not.be.null
-        schema.ast.should.not.be.null
-        schema.bytecode.should.not.be.null
-        schema.deployedBytecode.should.not.be.null
-        schema.compiler.name.should.be.eq('solc')
-        schema.compiler.version.should.be.eq('0.5.9+commit.e560f70d.Emscripten.clang')
-        schema.compiler.optimizer.should.be.deep.equal({ enabled: false })
-        schema.compiler.evmVersion.should.be.eq('constantinople')
+        const contractName = schemaFileName.substring(
+          0,
+          schemaFileName.lastIndexOf('.'),
+        );
+        const contractPath = `${inputDir}/${contractName}.sol`;
+        const schemaPath = `${outputDir}/${schemaFileName}`;
+        const schema = FileSystem.parseJson(schemaPath);
+
+        schema.fileName.should.be.eq(`${contractName}.sol`);
+        schema.contractName.should.be.eq(contractName);
+        schema.source.should.be.eq(FileSystem.read(contractPath));
+        schema.sourcePath.should.be.eq(
+          `test/mocks/mock-stdlib/contracts/${contractName}.sol`,
+        );
+        schema.sourceMap.should.not.be.null;
+        schema.abi.should.not.be.null;
+        schema.ast.should.not.be.null;
+        schema.bytecode.should.not.be.null;
+        schema.deployedBytecode.should.not.be.null;
+        schema.compiler.name.should.be.eq('solc');
+        schema.compiler.version.should.startWith('0.5.9+commit');
+        schema.compiler.optimizer.should.be.deep.equal({ enabled: false });
+        schema.compiler.evmVersion.should.be.eq('constantinople');
       });
     });
 
-    it('replaces library names', function () {
+    it('replaces library names', function() {
       const schema = FileSystem.parseJson(greeterArtifactPath);
       schema.bytecode.should.match(/__GreeterLib____________________________/);
-      schema.deployedBytecode.should.match(/__GreeterLib____________________________/);
+      schema.deployedBytecode.should.match(
+        /__GreeterLib____________________________/,
+      );
     });
 
-    it('does not recompile if there were no changes to sources', async function () {
+    it('does not recompile if there were no changes to sources', async function() {
       const origMtime = statSync(greeterArtifactPath).mtimeMs;
       await compileProject({ inputDir, outputDir, version: '0.5.9' });
       statSync(greeterArtifactPath).mtimeMs.should.eq(origMtime);
     });
 
-    it('recompiles if sources changed', async function () {
+    it('recompiles if sources changed', async function() {
       const { mtimeMs: origMtime, atimeMs } = statSync(greeterArtifactPath);
       utimesSync(greeterArtifactPath, atimeMs, Date.now());
       await compileProject({ inputDir, outputDir, version: '0.5.9' });
       statSync(greeterArtifactPath).mtimeMs.should.not.eq(origMtime);
     });
 
-    it('recompiles if compiler version changed', async function () {
+    it('recompiles if compiler version changed', async function() {
       const origMtime = statSync(greeterArtifactPath).mtimeMs;
       await compileProject({ inputDir, outputDir, version: '0.5.0' });
       statSync(greeterArtifactPath).mtimeMs.should.not.eq(origMtime);
       const schema = FileSystem.parseJson(greeterArtifactPath);
-      schema.compiler.version.should.eq('0.5.0+commit.1d4f565a.Emscripten.clang');
+      schema.compiler.version.should.eq(
+        '0.5.0+commit.1d4f565a.Emscripten.clang',
+      );
     });
 
-    it('recompiles if compiler settings changed', async function () {
+    it('recompiles if compiler settings changed', async function() {
       const origMtime = statSync(greeterArtifactPath).mtimeMs;
       const optimizer = { enabled: true, runs: 300 };
-      await compileProject({ inputDir, outputDir, version: '0.5.9', optimizer });
+      await compileProject({
+        inputDir,
+        outputDir,
+        version: '0.5.9',
+        optimizer,
+      });
       statSync(greeterArtifactPath).mtimeMs.should.not.eq(origMtime);
       const schema = FileSystem.parseJson(greeterArtifactPath);
-      schema.compiler.optimizer.should.be.deep.equal(optimizer)
+      schema.compiler.optimizer.should.be.deep.equal(optimizer);
     });
   });
 
-  describe('in mock-stdlib-with-deps project', function () {
+  describe('in mock-stdlib-with-deps project', function() {
     this.timeout(20000);
 
     const inputDir = `${rootDir}/mocks/mock-stdlib-with-deps/contracts`;
     const outputDir = `${baseTestBuildDir}/mock-stdlib-with-deps`;
     const greeterArtifactPath = `${outputDir}/GreeterImpl.json`;
     const dependencyArtifactPath = `${outputDir}/GreeterImpl.json`;
-    
-    before('compiling', async function () {
+
+    before('compiling', async function() {
       await compileProject({ inputDir, outputDir, version: '0.5.9' });
     });
 
-    it('compiles project contracts', async function () {
+    it('compiles project contracts', async function() {
       FileSystem.exists(greeterArtifactPath).should.be.true;
       FileSystem.parseJson(greeterArtifactPath).bytecode.should.not.be.null;
     });
 
-    it('compiles dependency contracts', async function () {
+    it('compiles dependency contracts', async function() {
       FileSystem.exists(dependencyArtifactPath).should.be.true;
       FileSystem.parseJson(dependencyArtifactPath).bytecode.should.not.be.null;
-    })
+    });
   });
-})
+});


### PR DESCRIPTION
Removes absolute paths in artifacts, to make sure they are portable between workstations. Fixes any issues with isLocalContract check, and generates metadata independent of the computer where it was compiled (important for EXTCODEHASH checks).

Fixes #933