### PR TITLE
Handle paths with spaces when compiling artifacts

### DIFF
--- a/packages/cli/mocks/mock-stdlib-with-deps/node_modules/mock-dep/contracts/GreeterDep.sol
+++ b/packages/cli/mocks/mock-stdlib-with-deps/node_modules/mock-dep/contracts/GreeterDep.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.0;
 
-contract GreeterDep {
+import "./subdep/GreeterSubdep.sol";
+
+contract GreeterDep is GreeterSubdep {
   function isGreeter() public pure returns (bool) {
     return true;
   }

--- a/packages/cli/mocks/mock-stdlib-with-deps/node_modules/mock-dep/contracts/subdep/GreeterSubdep.sol
+++ b/packages/cli/mocks/mock-stdlib-with-deps/node_modules/mock-dep/contracts/subdep/GreeterSubdep.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+contract GreeterSubdep {
+  function isReallyGreeter() public pure returns (bool) {
+    return true;
+  }
+}

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2844,6 +2844,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5440,7 +5445,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "find-up": "^3.0.0",
     "fs-extra": "^7.0.1",
     "inquirer": "^6.2.2",
+    "is-url": "^1.2.4",
     "lockfile": "^1.0.4",
     "lodash.castarray": "^4.4.0",
     "lodash.compact": "^3.0.1",

--- a/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
+++ b/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
@@ -2,6 +2,7 @@ import { ResolverEngine } from '@resolver-engine/core';
 import pathSys from 'path';
 import urlSys from 'url';
 import { getImports } from '../../../utils/solidity';
+import isUrl from 'is-url';
 
 // Adapted from resolver-engine
 // https://github.com/Crypto-Punkers/resolver-engine/blob/master/packages/imports/src/parsers/importparser.ts
@@ -102,7 +103,7 @@ export async function gatherSources(
     workingDir += '/';
   }
 
-  const absoluteRoots = roots.map(what => urlSys.resolve(workingDir, what));
+  const absoluteRoots = roots.map(what => resolvePath(workingDir, what));
   for (const absWhat of absoluteRoots) {
     queue.push({ cwd: workingDir, file: absWhat, relativeTo: workingDir });
     alreadyImported.add(absWhat);
@@ -121,7 +122,7 @@ export async function gatherSources(
     // if not - return the same name it was imported with
     let relativePath: string;
     if (fileData.file[0] === '.') {
-      relativePath = urlSys.resolve(fileData.relativeTo, fileData.file);
+      relativePath = resolvePath(fileData.relativeTo, fileData.file);
       result.push({
         url: relativePath,
         source: resolvedFile.source,
@@ -140,7 +141,7 @@ export async function gatherSources(
     for (const foundImport of foundImports) {
       let importName: string;
       if (foundImport[0] === '.') {
-        importName = urlSys.resolve(relativePath, foundImport);
+        importName = resolvePath(relativePath, foundImport);
       } else {
         importName = foundImport;
       }
@@ -156,6 +157,25 @@ export async function gatherSources(
   }
 
   return result;
+}
+
+function resolvePath(workingDir: string, relativePath: string): string {
+  // If the working dir is an URL (a file imported from an URL location)
+  // or the relative path is an URL (an URL imported from a local file)
+  // use url.resolve, which will work in both cases.
+  // > url.resolve('/local/folder/', 'http://example.com/myfile.sol')
+  // 'http://example.com/myfile.sol'
+  // > url.resolve('http://example.com/', 'myfile.sol')
+  // 'http://example.com/myfile.sol'
+  //
+  // If not, use path.resolve, since using url.resolve will escape certain
+  // charaters (e.g. a space as an %20), breaking the path
+  // > url.resolve('/local/path/with spaces/', 'myfile.sol')
+  // '/local/path/with%20spaces/myfile.sol'
+
+  return isUrl(workingDir) || isUrl(relativePath)
+    ? urlSys.resolve(workingDir, relativePath)
+    : pathSys.resolve(workingDir, relativePath);
 }
 
 /**

--- a/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
+++ b/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
@@ -175,7 +175,7 @@ function resolvePath(workingDir: string, relativePath: string): string {
 
   return isUrl(workingDir) || isUrl(relativePath)
     ? urlSys.resolve(workingDir, relativePath)
-    : pathSys.resolve(workingDir, relativePath);
+    : pathSys.resolve(pathSys.dirname(workingDir), relativePath);
 }
 
 /**

--- a/packages/cli/src/models/files/ZosPackageFile.ts
+++ b/packages/cli/src/models/files/ZosPackageFile.ts
@@ -61,6 +61,8 @@ export default class ZosPackageFile {
       throw e;
     }
     checkVersion(this.data.zosversion, this.fileName);
+    if (!this.data.contracts) this.data.contracts = {};
+    if (!this.data.dependencies) this.data.dependencies = {};
   }
 
   public exists(): boolean {

--- a/packages/cli/test/mocks/mock-stdlib with spaces/contracts/GreeterImpl.sol
+++ b/packages/cli/test/mocks/mock-stdlib with spaces/contracts/GreeterImpl.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.0;
+
+import "./GreeterLib.sol";
+
+contract GreeterImpl {
+  using GreeterLib for string;
+  event Greeting(string greeting);
+
+  function greet(string memory who) public {
+    emit Greeting(greeting(who));
+  }
+
+  function greeting(string memory who) public pure returns (string memory) {
+    return who.wrap();
+  }
+
+  function version() public pure returns (string memory) {
+    return "1.1.0";
+  }
+}

--- a/packages/cli/test/mocks/mock-stdlib with spaces/contracts/GreeterLib.sol
+++ b/packages/cli/test/mocks/mock-stdlib with spaces/contracts/GreeterLib.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library GreeterLib {
+  function wrap(string memory self) public pure returns (string memory) {
+    return self;
+  }
+}

--- a/packages/cli/test/mocks/mock-stdlib with spaces/package.json
+++ b/packages/cli/test/mocks/mock-stdlib with spaces/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mock-stdlib-with-spaces",
+  "version": "1.1.0",
+  "description": "Mock stdlib for tests in zos-cli",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "test": "truffle test"
+  },
+  "author": "santiago@zeppelin.solutions",
+  "license": "MIT"
+}

--- a/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
+++ b/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
@@ -125,4 +125,25 @@ describe('SolidityProjectCompiler', function() {
       FileSystem.parseJson(dependencyArtifactPath).bytecode.should.not.be.null;
     });
   });
+
+  describe('in mock-stdlib-with-spaces project', function() {
+    this.timeout(20000);
+
+    const inputDir = `${rootDir}/test/mocks/mock-stdlib with spaces/contracts`;
+    const outputDir = `${baseTestBuildDir}/mock-stdlib with spaces`;
+    const greeterArtifactPath = `${outputDir}/GreeterImpl.json`;
+
+    before('compiling', async function() {
+      await compileProject({ inputDir, outputDir, version: '0.5.9' });
+    });
+
+    it('compiles project contracts', async function() {
+      FileSystem.exists(greeterArtifactPath).should.be.true;
+      const schema = FileSystem.parseJson(greeterArtifactPath);
+      schema.bytecode.should.not.be.null;
+      schema.sourcePath.should.be.eq(
+        `test/mocks/mock-stdlib with spaces/contracts/GreeterImpl.sol`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
A project in a path with spaces would fail to lookup any contracts or imports. The issue has been reported in the resolver-engine repo (https://github.com/Crypto-Punkers/resolver-engine/issues/176) and patched here.

This PR also includes a commit to handle empty nodes in the zos.json config file, as they were causing the CI to fail when testing zepkit integration (kudos @ylv-io for getting that suite working!).

Fixes #951
Fixes #952

_Needs rebase after #957 is merged_