### PR TITLE
Do not write invalid zos.json if compiling before init

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -47,7 +47,7 @@ export async function compile(
     ...compilerOptions,
     manager: useTruffle ? 'truffle' : 'zos',
   });
-  packageFile.write();
+  if (packageFile.exists()) packageFile.write();
 
   state.alreadyCompiled = true;
 }


### PR DESCRIPTION
Running zos compile in a project without zos.json would create a zos.json file without name or version, which caused the project to crash later.

There were two options to fix this:
1- Refuse to compile before init
2- Compile anyway without persisting compiler flags

I went with (2), to make it easier to use zos as a standalone compiler, without needing to init a project wherever the user wants to run it.

Fixes #955 

_Needs rebase after #957 is merged_