### PR TITLE
Improve parsing of interactive args

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -102,6 +102,14 @@
         "@types/node": "*"
       }
     },
+    "@types/cbor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
+      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/fs-extra": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz",
@@ -657,6 +665,17 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cbor": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.1.5.tgz",
+      "integrity": "sha512-WqpISHl7/kk1u1uoaqctGyGiET3+wGN4A6pPsFCzEBztJJlCVxnMB4JwcuuNSrMiV4V6UBlxMkhNzJrUxDWO1A==",
+      "requires": {
+        "bignumber.js": "^8.0.2",
+        "commander": "^2.19.0",
+        "json-text-sequence": "^0.1",
+        "nofilter": "^1.0.1"
+      }
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -1069,6 +1088,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -2921,6 +2945,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -3055,6 +3087,11 @@
       "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
       "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
     },
+    "lodash.findlast": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
+      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
+    },
     "lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
@@ -3064,6 +3101,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -3086,10 +3128,20 @@
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
       "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.intersection": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
       "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+    },
+    "lodash.invertby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.invertby/-/lodash.invertby-4.7.0.tgz",
+      "integrity": "sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA="
     },
     "lodash.isarray": {
       "version": "4.0.0",
@@ -3125,6 +3177,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -3180,13 +3237,17 @@
     "lodash.random": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.random/-/lodash.random-3.2.0.tgz",
-      "integrity": "sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0=",
-      "dev": true
+      "integrity": "sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0="
     },
     "lodash.reverse": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.reverse/-/lodash.reverse-4.0.1.tgz",
       "integrity": "sha1-Hyr+2s4uFuZg86p8WdMwCm8l0Tw="
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.topairs": {
       "version": "4.3.0",
@@ -3213,6 +3274,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
       "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "lolex": {
       "version": "2.7.5",
@@ -3536,6 +3607,11 @@
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
       }
+    },
+    "nofilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.2.tgz",
+      "integrity": "sha512-d38SORxm9UNoDsnPXajV9nBEebKX4/paXAlyRGnSjZuFbLLZDFUO4objr+tbybqsbqGXDWllb6gQoKUDc9q3Cg=="
     },
     "npm-programmatic": {
       "version": "0.0.12",
@@ -4967,6 +5043,96 @@
       "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
       "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
     },
+    "truffle-flattener": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.3.0.tgz",
+      "integrity": "sha512-ppJ9xI0tDuvCYjQlcWwMBcOKZph5U4YpG/gChyUVDxOjUIniG5g7y9vZho2PRj1FohPPnOjg1KOAVNlk/bPZrw==",
+      "requires": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "find-up": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "solidity-parser-antlr": "^0.4.0",
+        "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "@resolver-engine/core": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+          "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+          "requires": {
+            "debug": "^3.1.0",
+            "request": "^2.85.0"
+          }
+        },
+        "@resolver-engine/fs": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+          "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+          "requires": {
+            "@resolver-engine/core": "^0.2.1",
+            "debug": "^3.1.0"
+          }
+        },
+        "@resolver-engine/imports": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+          "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+          "requires": {
+            "@resolver-engine/core": "^0.2.1",
+            "debug": "^3.1.0",
+            "hosted-git-info": "^2.6.0"
+          }
+        },
+        "@resolver-engine/imports-fs": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+          "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+          "requires": {
+            "@resolver-engine/fs": "^0.2.1",
+            "@resolver-engine/imports": "^0.2.2",
+            "debug": "^3.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
+      }
+    },
     "truffle-provider": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.3.tgz",
@@ -5020,6 +5186,11 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y="
     },
     "tsutils": {
       "version": "3.14.0",
@@ -5626,6 +5797,162 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
+    },
+    "zos-lib": {
+      "version": "2.4.0-rc.1",
+      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.4.0-rc.1.tgz",
+      "integrity": "sha512-Z0f5JI4Erhr1rLeM/WnDSEuSVc79L02ZawAW5BuokBa+Rwwrb03i4CXo5WVHbrDRlgysohMNMzly/gkPvEWTzg==",
+      "requires": {
+        "@types/cbor": "^2.0.0",
+        "@types/web3": "^1.0.14",
+        "axios": "^0.18.0",
+        "bignumber.js": "^7.2.0",
+        "cbor": "^4.1.5",
+        "chalk": "^2.4.1",
+        "ethers": "^4.0.20",
+        "glob": "^7.1.3",
+        "lodash.concat": "^4.5.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.every": "^4.6.0",
+        "lodash.findlast": "^4.6.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.invertby": "^4.7.0",
+        "lodash.isarray": "^4.0.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isstring": "^4.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.pickby": "^4.6.0",
+        "lodash.random": "^3.2.0",
+        "lodash.reverse": "^4.0.1",
+        "lodash.some": "^4.6.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.values": "^4.3.0",
+        "lodash.without": "^4.4.0",
+        "semver": "^5.5.1",
+        "spinnies": "^0.3.2",
+        "truffle-flattener": "^1.3.0",
+        "web3": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.30",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.30.tgz",
+          "integrity": "sha512-1a39Y+q5zTfrXCLndV+CHsTHq+T5/TvAx5y0S/PKd700C0lfU70CJnU7q89bd+4pIuWp05TkrEsrTj2dXhkcSA==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "spinnies": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.3.2.tgz",
+          "integrity": "sha512-WOvGI8X3h2XbAu/VBzIG99qJTeWCZ5RjyZtuLc4Q6qwAIv1/OPA2aL9j5wYEhwNsWLbBDHH5bLk/bOJTpexljw==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
+      }
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
     "lodash.findindex": "^4.6.0",
     "lodash.flatmap": "^4.5.0",
     "lodash.flatten": "^4.4.0",
+    "lodash.flattendeep": "^4.4.0",
     "lodash.foreach": "^4.5.0",
     "lodash.frompairs": "^4.0.1",
     "lodash.groupby": "^4.6.0",

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -7,8 +7,6 @@ import {
   promptIfNeeded,
   networksList,
   promptForNetwork,
-  argsList,
-  methodsList,
   proxiesList,
   proxyInfo,
   InquirerQuestions,
@@ -52,7 +50,6 @@ async function action(options: any): Promise<void> {
   );
   const methodParams = await promptForMethodParams(
     contractFullName,
-    getCommandProps,
     options,
     {},
     Mutability.Constant,
@@ -71,7 +68,7 @@ async function promptForProxy(
 ): Promise<SendTxSelectionParams> {
   const { interactive } = options;
   const opts = { proxy: proxyAddress };
-  const props = getCommandProps({ network });
+  const props = getCommandProps(network);
   const { proxy: promptedProxy } = await promptIfNeeded(
     { opts, props },
     interactive,
@@ -80,28 +77,7 @@ async function promptForProxy(
   return promptedProxy;
 }
 
-function getCommandProps({
-  network,
-  contractFullName,
-  methodName,
-  methodArgs,
-}: SendTxPropsParams = {}): InquirerQuestions {
-  const methods = methodsList(contractFullName, Mutability.Constant);
-  const args = argsList(
-    contractFullName,
-    methodName,
-    Mutability.Constant,
-  ).reduce((accum, argName, index) => {
-    return {
-      ...accum,
-      [argName]: {
-        message: `${argName}:`,
-        type: 'input',
-        when: () => !methodArgs || !methodArgs[index],
-      },
-    };
-  }, {});
-
+function getCommandProps(network?: string): InquirerQuestions {
   return {
     ...networksList('network', 'list'),
     proxy: {
@@ -113,17 +89,6 @@ function getCommandProps({
           ? proxyInfo(parseContractReference(input), network)
           : input,
     },
-    methodName: {
-      type: 'list',
-      message: 'Select a method',
-      choices: methods,
-      normalize: input => {
-        if (typeof input !== 'object') {
-          return { name: input, selector: input };
-        } else return input;
-      },
-    },
-    ...args,
   };
 }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -14,7 +14,7 @@ import {
   networksList,
   contractsList,
   methodsList,
-  argsList,
+  InquirerQuestions,
 } from '../prompts/prompt';
 import promptForMethodParams from '../prompts/method-params';
 import { ProxyType } from '../scripts/interfaces';
@@ -92,7 +92,6 @@ async function action(contractFullName: string, options: any) {
   const additionalOpts = { askForMethodParams: rawInitMethod };
   const { methodName, methodArgs } = await promptForMethodParams(
     contractFullName,
-    getCommandProps,
     options,
     additionalOpts,
   );
@@ -130,46 +129,10 @@ async function promptForCreate(
   );
 }
 
-function getCommandProps({
-  contractFullName,
-  methodName,
-  methodArgs,
-}: PropsParams = {}) {
-  const initMethodsList = methodsList(contractFullName);
-  const initMethodArgsList = argsList(contractFullName, methodName).reduce(
-    (accum, { name: argName, type: argType }, index) => {
-      return {
-        ...accum,
-        [argName]: {
-          message: `${argName}:`,
-          type: 'input',
-          when: () => !methodArgs || !methodArgs[index]
-        },
-      };
-    },
-    {},
-  );
-
+function getCommandProps(): InquirerQuestions {
   return {
     ...networksList('network', 'list'),
     ...contractsList('contractFullName', 'Choose a contract', 'list', 'all'),
-    askForMethodParams: {
-      type: 'confirm',
-      message: 'Do you want to run a function after creating the instance?',
-      when: () => initMethodsList.length !== 0 && methodName !== 'initialize',
-    },
-    methodName: {
-      type: 'list',
-      message: 'Select a method',
-      choices: initMethodsList,
-      when: ({ askForMethodParams }) => askForMethodParams,
-      normalize: input => {
-        if (typeof input !== 'object') {
-          return { name: input, selector: input };
-        } else return input;
-      },
-    },
-    ...initMethodArgsList,
   };
 }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -137,13 +137,13 @@ function getCommandProps({
 }: PropsParams = {}) {
   const initMethodsList = methodsList(contractFullName);
   const initMethodArgsList = argsList(contractFullName, methodName).reduce(
-    (accum, argName, index) => {
+    (accum, { name: argName, type: argType }, index) => {
       return {
         ...accum,
         [argName]: {
           message: `${argName}:`,
           type: 'input',
-          when: () => !methodArgs || !methodArgs[index],
+          when: () => !methodArgs || !methodArgs[index]
         },
       };
     },

--- a/packages/cli/src/commands/send-tx.ts
+++ b/packages/cli/src/commands/send-tx.ts
@@ -7,8 +7,6 @@ import {
   promptIfNeeded,
   networksList,
   promptForNetwork,
-  argsList,
-  methodsList,
   proxiesList,
   proxyInfo,
   InquirerQuestions,
@@ -60,11 +58,7 @@ async function action(options: any): Promise<void> {
     network,
     options,
   );
-  const methodParams = await promptForMethodParams(
-    contractFullName,
-    getCommandProps,
-    options,
-  );
+  const methodParams = await promptForMethodParams(contractFullName, options);
   const args = pickBy({
     ...methodParams,
     proxyAddress: proxyReference,
@@ -84,7 +78,7 @@ async function promptForProxy(
 ): Promise<SendTxSelectionParams> {
   const { interactive } = options;
   const opts = { proxy: proxyAddress };
-  const props = getCommandProps({ network });
+  const props = getCommandProps(network);
   const { proxy: promptedProxy } = await promptIfNeeded(
     { opts, props },
     interactive,
@@ -93,27 +87,7 @@ async function promptForProxy(
   return promptedProxy;
 }
 
-function getCommandProps({
-  network,
-  contractFullName,
-  methodName,
-  methodArgs,
-}: SendTxPropsParams = {}): InquirerQuestions {
-  const methods = methodsList(contractFullName);
-  const args = argsList(contractFullName, methodName).reduce(
-    (accum, argName, index) => {
-      return {
-        ...accum,
-        [argName]: {
-          message: `${argName}:`,
-          type: 'input',
-          when: () => !methodArgs || !methodArgs[index],
-        },
-      };
-    },
-    {},
-  );
-
+function getCommandProps(network?: string): InquirerQuestions {
   return {
     ...networksList('network', 'list'),
     proxy: {
@@ -125,17 +99,6 @@ function getCommandProps({
           ? proxyInfo(parseContractReference(input), network)
           : input,
     },
-    methodName: {
-      type: 'list',
-      message: 'Select a method',
-      choices: methods,
-      normalize: input => {
-        if (typeof input !== 'object') {
-          return { name: input, selector: input };
-        } else return input;
-      },
-    },
-    ...args,
   };
 }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -10,7 +10,6 @@ import {
   promptIfNeeded,
   networksList,
   promptForNetwork,
-  argsList,
   methodsList,
   proxiesList,
   proxyInfo,
@@ -95,7 +94,6 @@ async function action(proxyReference: string, options: any): Promise<void> {
     promptedProxyInfo.proxyReference && !promptedProxyInfo.all
       ? await promptForMethodParams(
           promptedProxyInfo.contractFullName,
-          getCommandProps,
           options,
           additionalOpts,
         )
@@ -134,25 +132,7 @@ function getCommandProps({
   proxyReference,
   network,
   all,
-  contractFullName,
-  methodName,
-  methodArgs,
 }: UpdatePropsParams = {}): InquirerQuestions {
-  const initMethodsList = methodsList(contractFullName);
-  const initMethodArgsList = argsList(contractFullName, methodName).reduce(
-    (accum, argName, index) => {
-      return {
-        ...accum,
-        [argName]: {
-          message: `${argName}:`,
-          type: 'input',
-          when: () => !methodArgs || !methodArgs[index],
-        },
-      };
-    },
-    {},
-  );
-
   return {
     ...networksList('network', 'list'),
     pickProxyBy: {
@@ -184,23 +164,6 @@ function getCommandProps({
           ? proxyInfo(parseContractReference(input), network)
           : input,
     },
-    askForMethodParams: {
-      type: 'confirm',
-      message: 'Do you want to run a function after updating the instance?',
-      when: () => initMethodsList.length !== 0 && methodName !== 'initialize',
-    },
-    methodName: {
-      type: 'list',
-      message: 'Select a method',
-      choices: initMethodsList,
-      when: ({ askForMethodParams }) => askForMethodParams,
-      normalize: input => {
-        if (typeof input !== 'object') {
-          return { name: input, selector: input };
-        } else return input;
-      },
-    },
-    ...initMethodArgsList,
   };
 }
 

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -30,7 +30,7 @@ export default async function promptForMethodParams(
     contractFullName,
     methodName.selector,
     constant,
-  ).reduce((accum, current) => ({ ...accum, [current]: undefined }), {});
+  ).reduce((accum, { name: current }) => ({ ...accum, [current]: undefined }), {});
 
   // if there are no methodArgs defined, or the methodArgs array length provided is smaller than the
   // number of arguments in the function, prompt for remaining arguments

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -4,13 +4,24 @@ import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
 
 import { parseMethodParams } from '../utils/input';
-import { promptIfNeeded, argsList, InquirerQuestions } from './prompt';
+import {
+  promptIfNeeded,
+  argsList,
+  methodsList,
+  InquirerQuestions,
+} from './prompt';
 
 type PropsFn = (any) => InquirerQuestions;
 
+interface CommandProps {
+  contractFullName: string;
+  methodName: string;
+  methodArgs: string[];
+  additionalOpts?: { [key: string]: any };
+}
+
 export default async function promptForMethodParams(
   contractFullName: string,
-  getCommandProps: PropsFn,
   options: any,
   additionalOpts: { [key: string]: string } = {},
   constant: Mutability = Mutability.NotConstant,
@@ -18,7 +29,13 @@ export default async function promptForMethodParams(
   const { interactive } = options;
   let { methodName, methodArgs } = parseMethodParams(options, 'initialize');
   const opts = { ...additionalOpts, methodName };
-  const methodProps = getCommandProps({ contractFullName, methodName });
+
+  const methodProps = getCommandProps(
+    contractFullName,
+    methodName,
+    methodArgs,
+    additionalOpts,
+  );
 
   // prompt for method name if not provided
   ({ methodName } = await promptIfNeeded(
@@ -30,16 +47,19 @@ export default async function promptForMethodParams(
     contractFullName,
     methodName.selector,
     constant,
-  ).reduce((accum, { name: current }) => ({ ...accum, [current]: undefined }), {});
+  ).reduce(
+    (accum, { name: current }) => ({ ...accum, [current]: undefined }),
+    {},
+  );
 
   // if there are no methodArgs defined, or the methodArgs array length provided is smaller than the
   // number of arguments in the function, prompt for remaining arguments
   if (!methodArgs || methodArgs.length < Object.keys(methodArgsKeys).length) {
-    const methodArgsProps = getCommandProps({
+    const methodArgsProps = getCommandProps(
       contractFullName,
-      methodName: methodName.selector,
+      methodName.selector,
       methodArgs,
-    });
+    );
     const promptedArgs = await promptIfNeeded(
       { opts: methodArgsKeys, props: methodArgsProps },
       interactive,
@@ -51,4 +71,52 @@ export default async function promptForMethodParams(
   }
 
   return { methodName: methodName.name, methodArgs };
+}
+
+function getCommandProps(
+  contractFullName: string,
+  methodName: string,
+  methodArgs: string[],
+  additionalOpts = {},
+): InquirerQuestions {
+  const methods = methodsList(contractFullName);
+  const args = argsList(contractFullName, methodName).reduce(
+    (accum, arg, index) => {
+      return {
+        ...accum,
+        [arg.name]: {
+          message: `${arg.name}:`,
+          type: 'input',
+          when: () => !methodArgs || !methodArgs[index],
+        },
+      };
+    },
+    {},
+  );
+
+  return {
+    askForMethodParams: {
+      type: 'confirm',
+      message: 'Do you want to run a function after creating the instance?',
+      when: () =>
+        methods.length !== 0 &&
+        methodName !== 'initialize' &&
+        additionalOpts.hasOwnProperty('askForMethodParams'),
+    },
+    methodName: {
+      type: 'list',
+      message: 'Select a method',
+      choices: methods,
+      when: ({ askForMethodParams }) =>
+        !additionalOpts.hasOwnProperty('askForMethodParams') ||
+        (additionalOpts.hasOwnProperty('askForMethodParams') &&
+          askForMethodParams),
+      normalize: input => {
+        if (typeof input !== 'object') {
+          return { name: input, selector: input };
+        } else return input;
+      },
+    },
+    ...args,
+  };
 }

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -3,7 +3,7 @@ import pickBy from 'lodash.pickby';
 import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
 
-import { parseMethodParams } from '../utils/input';
+import { parseMethodParams, parseArg } from '../utils/input';
 import {
   promptIfNeeded,
   argsList,
@@ -88,7 +88,7 @@ function getCommandProps(
           message: `${arg.name}:`,
           type: 'input',
           when: () => !methodArgs || !methodArgs[index],
-          normalize: input => ({ type: arg.type, input })
+          normalize: input => parseArg(input, arg.type),
         },
       };
     },

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -88,6 +88,7 @@ function getCommandProps(
           message: `${arg.name}:`,
           type: 'input',
           when: () => !methodArgs || !methodArgs[index],
+          normalize: input => ({ type: arg.type, input })
         },
       };
     },

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -34,6 +34,7 @@ export default async function promptForMethodParams(
     contractFullName,
     methodName,
     methodArgs,
+    constant,
     additionalOpts,
   );
 
@@ -59,7 +60,9 @@ export default async function promptForMethodParams(
       contractFullName,
       methodName.selector,
       methodArgs,
+      constant,
     );
+
     const promptedArgs = await promptIfNeeded(
       { opts: methodArgsKeys, props: methodArgsProps },
       interactive,
@@ -77,10 +80,11 @@ function getCommandProps(
   contractFullName: string,
   methodName: string,
   methodArgs: string[],
+  constant: Mutability,
   additionalOpts = {},
 ): InquirerQuestions {
-  const methods = methodsList(contractFullName);
-  const args = argsList(contractFullName, methodName).reduce(
+  const methods = methodsList(contractFullName, constant);
+  const args = argsList(contractFullName, methodName, constant).reduce(
     (accum, arg, index) => {
       return {
         ...accum,

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -230,14 +230,12 @@ export function argsList(
   methodIdentifier: string,
   constant?: Mutability,
   packageFile?: ZosPackageFile,
-): string[] {
+): { name: string, type: string }[] {
   const method = contractMethods(contractFullName, constant, packageFile).find(
     ({ name, selector }) =>
       selector === methodIdentifier || name === methodIdentifier,
   );
-  if (method) {
-    return method.inputs.map(({ name: inputName }) => inputName);
-  } else return [];
+  return method ? method.inputs : [];
 }
 
 function contractMethods(

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -230,7 +230,7 @@ export function argsList(
   methodIdentifier: string,
   constant?: Mutability,
   packageFile?: ZosPackageFile,
-): { name: string, type: string }[] {
+): { name: string; type: string }[] {
   const method = contractMethods(contractFullName, constant, packageFile).find(
     ({ name, selector }) =>
       selector === methodIdentifier || name === methodIdentifier,

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -1,40 +1,16 @@
 import BN from 'bignumber.js';
-import { encodeParams } from 'zos-lib';
+import flattenDeep from 'lodash.flattendeep';
+import { encodeParams, Loggy } from 'zos-lib';
 
+// TODO: Deprecate in favor of a combination of parseArg and parseArray
 export function parseArgs(args: string): string[] | never {
   if (typeof args !== 'string') throw Error(`Cannot parse ${typeof args}`);
 
   // The following is inspired from ethereum/remix (Copyright (c) 2016)
   // https://github.com/ethereum/remix/blob/89f34fc4f35eca0c386379550c300205d35bfae0/remix-lib/src/execution/txFormat.js#L51-L53
   try {
-    const START_LOOKBEHIND = '(?<=^|([,[]\\s*))'; // Character before match is start of line, comma or opening bracket.
-    const END_LOOKAHEAD = '(?=$|([,\\]]\\s*))'; // Character after match is end of line, comma or closing bracket.
-
-    // Replace non quoted hex string by quoted hex string.
-    const MATCH_HEX = new RegExp(
-      START_LOOKBEHIND + '(0[xX][0-9a-fA-F]+)' + END_LOOKAHEAD,
-      'g',
-    );
-    args = args.replace(MATCH_HEX, '"$2"');
-
-    // Replace scientific notation numbers by regular numbers.
-    const MATCH_SCIENTIFIC = new RegExp(
-      START_LOOKBEHIND +
-        '(\\s*[-]?\\d+(\\.\\d+)?e(\\+)?\\d+\\s*)' +
-        END_LOOKAHEAD,
-      'g',
-    );
-    args = args.replace(MATCH_SCIENTIFIC, val => `${new BN(val).toString(10)}`);
-
-    // Replace non quoted number by quoted number.
-    const MATCH_WORDS = new RegExp(
-      START_LOOKBEHIND + '([-]?\\w+)' + END_LOOKAHEAD,
-      'g',
-    );
-    args = args.replace(MATCH_WORDS, '"$2"');
-
     // Parse string to array.
-    const parsedArgs = JSON.parse('[' + args + ']');
+    const parsedArgs = JSON.parse(`[${quoteArguments(args)}]`);
 
     // Replace boolean strings with boolean literals.
     return parsedArgs.map(value => {
@@ -46,6 +22,199 @@ export function parseArgs(args: string): string[] | never {
     });
   } catch (e) {
     throw Error(`Error parsing arguments: ${e}`);
+  }
+}
+
+function quoteArguments(args: string) {
+  const START_LOOKBEHIND = '(?<=^|([,[]\\s*))'; // Character before match is start of line, comma or opening bracket.
+  const END_LOOKAHEAD = '(?=$|([,\\]]\\s*))'; // Character after match is end of line, comma or closing bracket.
+
+  // Replace non quoted hex string by quoted hex string.
+  const MATCH_HEX = new RegExp(
+    START_LOOKBEHIND + '(0[xX][0-9a-fA-F]+)' + END_LOOKAHEAD,
+    'g',
+  );
+  args = args.replace(MATCH_HEX, '"$2"');
+
+  // Replace scientific notation numbers by regular numbers.
+  const MATCH_SCIENTIFIC = new RegExp(
+    START_LOOKBEHIND +
+      '(\\s*[-]?\\d+(\\.\\d+)?e(\\+)?\\d+\\s*)' +
+      END_LOOKAHEAD,
+    'g',
+  );
+  args = args.replace(MATCH_SCIENTIFIC, val => `${new BN(val).toString(10)}`);
+
+  // Replace non quoted number by quoted number.
+  const MATCH_WORDS = new RegExp(
+    START_LOOKBEHIND + '([-]?\\w+)' + END_LOOKAHEAD,
+    'g',
+  );
+  args = args.replace(MATCH_WORDS, '"$2"');
+  return args;
+}
+
+export function parseArg(input: string | string[], type: string): any {
+  const TRUE_VALUES = ['y', 'yes', 't', 'true', '1'];
+  const FALSE_VALUES = ['n', 'no', 'f', 'false', '0'];
+  const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
+
+  // TODO: Handle tuples in ABI specification
+
+  // Integers: passed via bignumber to handle signs and scientific notation
+  if (
+    (type.startsWith('uint') ||
+      type.startsWith('int') ||
+      type.startsWith('fixed') ||
+      type.startsWith('ufixed')) &&
+    requireInputString(input)
+  ) {
+    const parsed = new BN(input);
+    if (parsed.isNaN())
+      throw new Error(`Could not parse '${input}' as ${type}`);
+    return parsed.toString(10);
+  }
+
+  // Booleans: match against true, t, yes, 1, etc
+  else if (type === 'bool' && requireInputString(input)) {
+    const lowercaseInput = input.toLowerCase();
+    if (TRUE_VALUES.includes(lowercaseInput)) return true;
+    else if (FALSE_VALUES.includes(lowercaseInput)) return false;
+    else throw new Error(`Could not parse boolean value ${input}`);
+  }
+
+  // Arrays: recursively parse as needed
+  else if (type.match(ARRAY_TYPE_REGEX)) {
+    const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
+    const inputs =
+      typeof input === 'string' ? parseArray(stripBrackets(input)) : input;
+    return inputs.map(input => parseArg(input, arrayType));
+  }
+
+  // Bytes, strings, addresses: untouched, as web3 handles most validations
+  else if (
+    type.startsWith('bytes') ||
+    type === 'string' ||
+    type === 'address'
+  ) {
+    return input;
+  }
+
+  // Warn if we see a type we don't recognise, but return it as is
+  Loggy.noSpin.warn(
+    __filename,
+    'parseArg',
+    `Unknown argument ${type} (skipping input validation)`,
+  );
+  return input;
+}
+
+export function stripBrackets(inputMaybeWithBrackets: string): string {
+  return `${inputMaybeWithBrackets
+    .replace(/^\s*\[/, '')
+    .replace(/\]\s*$/, '')}`;
+}
+
+function requireInputString(arg: string | string[]): arg is string {
+  if (typeof arg !== 'string') {
+    throw new Error(
+      `Expected ${flattenDeep(arg).join(
+        ',',
+      )} to be a scalar value but was an array`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Parses a string as an arbitrarily nested array of strings. Handles
+ * unquoted strings in the input, or quotes using both simple and double quotes.
+ * @param input string to parse
+ * @returns parsed ouput.
+ * The return type is a lie! This function returns a recursive type,
+ * with arbitrarily nested string arrays, but ts has a hard time handling that,
+ * so we're fooling it into thinking it's just one level deep.
+ */
+export function parseArray(input: string): (string | string[])[] {
+  let i = 0; // index for traversing input
+
+  function innerParseQuotedString(quoteChar: string): string {
+    const start = i;
+    while (i < input.length) {
+      const char = input[i++];
+      if (char === quoteChar) return input.slice(start, i - 1);
+      else continue;
+    }
+
+    throw new Error(`Unterminated string literal ${input.slice(start)}`);
+  }
+
+  function innerParseUnquotedString(): string {
+    const start = i;
+    while (i < input.length) {
+      const char = input[i++];
+      if (char === ',') {
+        return input.slice(start, i - 1);
+      } else if (char === '"' || char === "'") {
+        throw new Error(`Unexpected quote at position ${i}`);
+      } else if (char === '[' || char === "'") {
+        throw new Error(`Unexpected opening bracket at position ${i}`);
+      } else if (char === ']') {
+        return input.slice(start, --i);
+      }
+    }
+    return input.slice(start, i);
+  }
+
+  function requireCommaOrClosing(): void {
+    while (i < input.length) {
+      const char = input[i++];
+      if (char === ' ') {
+        continue;
+      } else if (char === ',') {
+        return;
+      } else if (char === ']') {
+        i--;
+        return;
+      } else {
+        throw new Error(`Expected a comma after ${input.slice(0, i - 1)}`);
+      }
+    }
+  }
+
+  function innerParseArray(requireClosingBracket = true): string[] {
+    const result = [];
+    const start = i;
+    while (i < input.length) {
+      const char = input[i++];
+      if (char === ' ') {
+        continue;
+      } else if (char === '"' || char === "'") {
+        result.push(innerParseQuotedString(char));
+        requireCommaOrClosing();
+      } else if (char === '[') {
+        const innerArray = innerParseArray();
+        result.push(innerArray);
+        requireCommaOrClosing();
+      } else if (char === ']') {
+        return result;
+      } else {
+        i--;
+        const unquotedString = innerParseUnquotedString();
+        const trimmedString = unquotedString.replace(/\s+$/, '');
+        result.push(trimmedString);
+      }
+    }
+    if (requireClosingBracket)
+      throw new Error(`Unclosed array ${input.slice(start)}`);
+    return result;
+  }
+
+  try {
+    return innerParseArray(false);
+  } catch (err) {
+    err.message = `Malformed array argument ${input}: ${err.message}`;
+    throw err;
   }
 }
 
@@ -61,6 +230,7 @@ export function parseMethodParams(
   if (!methodName && typeof methodArgs !== 'undefined')
     methodName = defaultMethod;
 
+  // TODO: Change to use parseArray instead
   if (typeof methodArgs === 'string') methodArgs = parseArgs(methodArgs);
   else if (!methodArgs || typeof methodArgs === 'boolean' || methodName)
     methodArgs = [];

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -352,7 +352,7 @@ describe('prompt', function() {
             this.packageFile,
           );
           args.should.be.an('array');
-          args[0].should.eq('who');
+          args[0].should.deep.equal({ name: 'who', type: 'string' });
         });
       });
     });


### PR DESCRIPTION
Parses arguments to call a method (such as in the call, send-tx, update, or create commands) according to the argument type. 

In order to accepts arrays with elements with and without quotes (so something simple like `foo,bar` would work, without requiring the user to input `["foo","bar"]`), I wrote a simple parser by hand. Please take a good look at it.

I'm also merging the PR onto `release/2.4` directly to publish a new RC, but I'd appreciate if either @jcarpanelli or @ylv-io could review this PR after merged in case something slipped through.