### PR TITLE
Fix error when printing errors in verbose mode

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -2287,7 +2287,6 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
@@ -2328,15 +2327,13 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "asn1": {
           "version": "0.2.4",
@@ -2352,7 +2349,6 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -3118,8 +3114,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -3134,6 +3129,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
           "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
           }
@@ -3155,6 +3151,7 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3164,7 +3161,6 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -3190,14 +3186,14 @@
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
         },
         "body-parser": {
           "version": "1.18.3",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
           "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -3216,7 +3212,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -3236,12 +3231,14 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+          "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+          "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -3281,7 +3278,6 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -3350,7 +3346,6 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -3361,7 +3356,6 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -3371,8 +3365,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -3385,8 +3378,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -3398,20 +3390,19 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+          "dev": true
         },
         "bytes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -3497,6 +3488,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -3559,7 +3551,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -3586,15 +3577,13 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
           "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -3609,22 +3598,19 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-js": {
           "version": "2.6.5",
@@ -3643,7 +3629,6 @@
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
@@ -3664,6 +3649,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -3676,6 +3662,7 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -3743,8 +3730,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "decompress": {
           "version": "4.2.0",
@@ -3777,7 +3763,6 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -3787,7 +3772,6 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -3928,8 +3912,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -3946,8 +3929,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -3980,6 +3962,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+          "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
             "create-hash": "^1.1.2",
@@ -3990,8 +3973,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -4007,8 +3989,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.113",
@@ -4020,6 +4001,7 @@
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
           "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -4034,8 +4016,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -4134,8 +4115,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -4153,8 +4133,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -4239,7 +4218,6 @@
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -4323,17 +4301,8 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
                 "ethereumjs-util": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
-                  }
-                }
               }
             },
             "ethereum-common": {
@@ -4345,8 +4314,10 @@
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
-                "bn.js": "^4.11.8"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             },
             "ethereumjs-block": {
@@ -4523,6 +4494,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -4696,7 +4668,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -4706,8 +4677,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4715,6 +4685,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
           "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
             "strip-hex-prefix": "1.0.0"
@@ -4724,8 +4695,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
           "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.0.0",
@@ -4737,6 +4707,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+          "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
@@ -4747,7 +4718,6 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
           "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
@@ -4786,7 +4756,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4795,8 +4764,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4868,20 +4836,19 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+          "dev": true
         },
         "finalhandler": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -4897,7 +4864,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4906,8 +4872,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4951,29 +4916,25 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
           "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
@@ -5003,7 +4964,6 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -5033,8 +4993,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "getpass": {
           "version": "0.1.7",
@@ -5080,7 +5039,6 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -5108,8 +5066,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
           "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
@@ -5149,8 +5106,7 @@
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
           "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
@@ -5163,7 +5119,6 @@
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -5172,6 +5127,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -5181,6 +5137,7 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
           "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
@@ -5208,6 +5165,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+          "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -5235,7 +5193,6 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -5247,8 +5204,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -5274,8 +5230,7 @@
           "version": "1.1.12",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
           "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "immediate": {
           "version": "3.2.3",
@@ -5296,7 +5251,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
         },
         "invariant": {
           "version": "2.2.4",
@@ -5317,8 +5273,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
           "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
@@ -5371,7 +5326,8 @@
         "is-hex-prefixed": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+          "dev": true
         },
         "is-natural-number": {
           "version": "4.0.1",
@@ -5384,15 +5340,13 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
           "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
@@ -5407,8 +5361,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
           "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -5428,7 +5381,8 @@
         "is-typedarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
@@ -5453,7 +5407,6 @@
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
@@ -5576,6 +5529,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -5836,8 +5790,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -5877,6 +5830,7 @@
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -5887,8 +5841,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "memdown": {
           "version": "1.4.1",
@@ -5925,8 +5878,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "merkle-patricia-tree": {
           "version": "2.3.1",
@@ -5986,8 +5938,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "miller-rabin": {
           "version": "4.0.1",
@@ -6004,8 +5955,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.38.0",
@@ -6026,8 +5976,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -6041,12 +5990,14 @@
         "minimalistic-assert": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+          "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -6099,7 +6050,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "mz": {
           "version": "2.7.0",
@@ -6116,21 +6068,20 @@
         "nan": {
           "version": "2.10.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
           "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -6161,7 +6112,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -6171,8 +6121,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6205,7 +6154,6 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -6215,7 +6163,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -6254,22 +6201,19 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
           "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "p-timeout": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
-          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -6279,7 +6223,6 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
           "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -6312,8 +6255,7 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
           "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
@@ -6340,8 +6282,7 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
@@ -6413,8 +6354,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "private": {
           "version": "0.1.8",
@@ -6449,7 +6389,6 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
           "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.8.0"
@@ -6563,7 +6502,6 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -6594,22 +6532,19 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
           "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
           "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.3",
@@ -6805,6 +6740,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -6814,6 +6750,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
           "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1"
           }
@@ -6827,7 +6764,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "safe-event-emitter": {
           "version": "1.0.1",
@@ -6879,6 +6817,7 @@
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
           "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
+          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "bip66": "^1.1.3",
@@ -6923,7 +6862,6 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
           "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -6945,7 +6883,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6954,8 +6891,7 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6964,7 +6900,6 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -6977,7 +6912,6 @@
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -7009,13 +6943,13 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -7034,15 +6968,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -7124,8 +7056,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.2",
@@ -7149,8 +7080,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -7212,6 +7142,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
           "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
@@ -7290,7 +7221,6 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -7329,7 +7259,6 @@
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "^1.0.0"
           }
@@ -7339,7 +7268,6 @@
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "thenify": ">= 3.1.0 < 4"
           }
@@ -7364,8 +7292,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tmp": {
           "version": "0.0.33",
@@ -7380,8 +7307,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -7439,7 +7365,6 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
@@ -7455,6 +7380,7 @@
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
@@ -7484,8 +7410,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
           "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unbzip2-stream": {
           "version": "1.3.3",
@@ -7502,8 +7427,7 @@
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unorm": {
           "version": "1.5.0",
@@ -7515,8 +7439,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uri-js": {
           "version": "4.2.2",
@@ -7532,7 +7455,6 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -7541,15 +7463,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "utf8": {
           "version": "3.0.0",
@@ -7568,8 +7488,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.3.2",
@@ -7591,8 +7510,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -7638,7 +7556,6 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
           "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -7651,7 +7568,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
           "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-eth-iban": "1.0.0-beta.35",
@@ -7663,7 +7579,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
           "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -7677,7 +7592,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
           "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "1.1.1"
@@ -7688,7 +7602,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
           "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -7702,7 +7615,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
           "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "1.1.1",
             "underscore": "1.8.3",
@@ -7735,7 +7647,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
           "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
@@ -7747,8 +7658,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7825,7 +7735,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
           "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "web3-utils": "1.0.0-beta.35"
@@ -7835,8 +7744,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7845,7 +7753,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
           "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -7859,7 +7766,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
           "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -7900,17 +7806,8 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
                 "ethereumjs-util": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
-                  }
-                }
               }
             },
             "ethereum-common": {
@@ -7922,8 +7819,10 @@
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
-                "bn.js": "^4.11.8"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             },
             "ethereumjs-block": {
@@ -7955,7 +7854,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
           "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "xhr2-cookies": "1.1.0"
@@ -7966,7 +7864,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
           "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.3",
             "underscore": "1.8.3",
@@ -7978,23 +7875,25 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
           "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.35"
+            "web3-core-helpers": "1.0.0-beta.35",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "dev": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -8022,7 +7921,6 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
           "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -8037,15 +7935,13 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "utf8": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
               "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8111,7 +8007,6 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -8135,7 +8030,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -8151,7 +8045,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -8161,7 +8054,6 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -8181,7 +8073,8 @@
         "yaeti": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+          "dev": true
         },
         "yargs": {
           "version": "4.8.1",
@@ -9090,7 +8983,8 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "mimic-response": {
       "version": "1.0.0",
@@ -9357,6 +9251,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -9741,6 +9636,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -10009,6 +9905,12 @@
         }
       }
     },
+    "sinon-chai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -10167,14 +10069,20 @@
       "dev": true
     },
     "spinnies": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.3.2.tgz",
-      "integrity": "sha512-WOvGI8X3h2XbAu/VBzIG99qJTeWCZ5RjyZtuLc4Q6qwAIv1/OPA2aL9j5wYEhwNsWLbBDHH5bLk/bOJTpexljw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.4.0.tgz",
+      "integrity": "sha512-NXwjilGR3I0rQFq89Kpzk8VsAy+4pMdzOa2jJnH7qXz8Cytlh5NJ5YaV9HgeKliN2e/pA+jDiinnmThOk5pKeQ==",
       "requires": {
         "chalk": "^2.4.2",
-        "cli-cursor": "^3.0.0"
+        "cli-cursor": "^3.0.0",
+        "strip-ansi": "^5.2.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -10186,11 +10094,41 @@
           }
         },
         "cli-cursor": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.0.0.tgz",
-          "integrity": "sha512-m7avcYLWHHQVU+cFxu301q3kKZJlcZcKXQSL9kffYnIvRNtqX+a7gJKXqOKusHoKXr4oquSgiMlAo1R0dDkSZA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "requires": {
-            "restore-cursor": "^2.0.0"
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -10675,6 +10613,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
+      }
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "typescript": {
@@ -11191,23 +11137,14 @@
       "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.37"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
         }
       }
     },
@@ -11251,6 +11188,16 @@
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "which": {
@@ -11358,6 +11305,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -70,7 +70,7 @@
     "lodash.values": "^4.3.0",
     "lodash.without": "^4.4.0",
     "semver": "^5.5.1",
-    "spinnies": "^0.3.2",
+    "spinnies": "^0.4.0",
     "truffle-flattener": "^1.3.0",
     "web3": "1.0.0-beta.37"
   },
@@ -96,6 +96,7 @@
     "mock-dependency": "file:test/mocks/mock-dependency",
     "prettier": "^1.17.1",
     "sinon": "^6.1.4",
+    "sinon-chai": "^3.3.0",
     "tmp": "^0.0.33",
     "truffle": "^5.0.5",
     "ts-node": "^7.0.1",

--- a/packages/lib/src/utils/Logger.ts
+++ b/packages/lib/src/utils/Logger.ts
@@ -130,9 +130,13 @@ export const Loggy: { [key: string]: any } = {
       const coloredMessage = color ? chalk.keyword(color)(message) : message;
       console.error(coloredMessage);
     } else if (logLevel === LogLevel.Normal) {
+      const options = color
+        ? { text, status: spinnerAction, color }
+        : { text, status: spinnerAction };
+
       !spinners.pick(reference)
-        ? spinners.add(reference, { text, status: spinnerAction, color })
-        : spinners.update(reference, { text, status: spinnerAction, color });
+        ? spinners.add(reference, options)
+        : spinners.update(reference, options);
     }
   },
 
@@ -156,7 +160,7 @@ export const Loggy: { [key: string]: any } = {
   _getColorFor(logType: LogType): string {
     switch (logType) {
       case LogType.Err:
-        return 'redBright';
+        return 'red';
       case LogType.Warn:
         return 'yellow';
       case LogType.Info:

--- a/packages/lib/test/setup.js
+++ b/packages/lib/test/setup.js
@@ -14,6 +14,7 @@ require('chai')
   .use(require('chai-as-promised')) // TODO: Remove this dependency
   .use(require('chai-string'))
   .use(helpers.assertions)
+  .use(require('sinon-chai'))
   .should();
 
 function setArtifactDefaults() {

--- a/packages/lib/test/src/utils/Logger.test.js
+++ b/packages/lib/test/src/utils/Logger.test.js
@@ -1,0 +1,285 @@
+'use strict';
+require('../../setup');
+
+import sinon from 'sinon';
+import Spinners from 'spinnies';
+
+import {
+  Loggy,
+  SpinnerAction,
+  LogLevel,
+  LogType,
+} from '../../../src/utils/Logger';
+
+describe('Loggger', function() {
+  afterEach('restore logger', function() {
+    Loggy.silent(true);
+    Loggy.verbose(false);
+    Loggy.logs = {};
+    sinon.restore();
+  });
+
+  describe('default attributes', function() {
+    it('is silent and non-verbose by default', function() {
+      Loggy.isSilent.should.be.true;
+      Loggy.isVerbose.should.be.false;
+    });
+
+    it(`has a 'logs' object initialized`, function() {
+      Loggy.logs.should.be.an('object').that.is.empty;
+    });
+  });
+
+  describe('methods', function() {
+    describe('#silent', function() {
+      it('changes isSilent property value', function() {
+        Loggy.silent(false);
+        Loggy.isSilent.should.be.false;
+      });
+    });
+
+    describe('#verbose', function() {
+      it('changes isVerbose property value', function() {
+        Loggy.verbose(true);
+        Loggy.isSilent.should.be.true;
+      });
+    });
+
+    const shouldSetLogProperties = (
+      log,
+      logType,
+      logLevel,
+      spinnerAction,
+      message,
+    ) => {
+      log.should.deep.equal({
+        file: 'filename',
+        fnName: 'function',
+        text: message,
+        logLevel,
+        logType,
+        spinnerAction,
+      });
+    };
+
+    const shouldBehaveLikeSpinnerLog = (
+      spinnerAction,
+      method,
+      reference = 'reference',
+    ) => {
+      it(`sets log and calls spinner#${method}`, function() {
+        Loggy[method]('filename', 'function', reference, 'message');
+        shouldSetLogProperties(
+          Loggy.logs[reference],
+          LogType.Info,
+          LogLevel.Normal,
+          spinnerAction,
+          'message',
+        );
+        this.spyLogger.should.have.been.calledOnceWith(reference, {
+          text: 'message',
+          status: spinnerAction,
+        });
+      });
+
+      describe('warn', function() {
+        it(`sets log and calls spinner#${method} with warn color`, function() {
+          Loggy[method].warn('filename', 'function', reference, 'message');
+          shouldSetLogProperties(
+            Loggy.logs[reference],
+            LogType.Warn,
+            LogLevel.Normal,
+            spinnerAction,
+            'message',
+          );
+          this.spyLogger.should.have.been.calledOnceWith(reference, {
+            text: 'message',
+            status: spinnerAction,
+            color: 'yellow',
+          });
+        });
+      });
+
+      describe('error', function() {
+        it(`sets log and calls spinner#${method} with error color`, function() {
+          Loggy[method].error('filename', 'function', reference, 'message');
+          shouldSetLogProperties(
+            Loggy.logs[reference],
+            LogType.Err,
+            LogLevel.Normal,
+            spinnerAction,
+            'message',
+          );
+          this.spyLogger.should.have.been.calledOnceWith(reference, {
+            text: 'message',
+            status: spinnerAction,
+            color: 'red',
+          });
+        });
+      });
+    };
+
+    const shouldBehaveLikeVerboseLog = () => {
+      it(`sets log and calls console.error`, function() {
+        Loggy[method]('filename', 'function', 'reference', 'message');
+        shouldSetLogProperties(
+          Loggy.logs[reference],
+          LogType.Info,
+          LogLevel.Normal,
+          spinnerAction,
+          'message',
+        );
+        this.spyLogger.should.have.been.calledOnceWith(
+          sinon.match(/adfdasadsfjasdff/),
+        );
+      });
+    };
+
+    context('in normal mode', function() {
+      beforeEach('set logger silent prop to false', function() {
+        Loggy.silent(false);
+      });
+
+      describe('#add', function() {
+        beforeEach(function() {
+          this.spyLogger = sinon.stub(Spinners.prototype, 'add');
+        });
+
+        describe('noSpin', function() {
+          shouldBehaveLikeSpinnerLog(SpinnerAction.NonSpinnable, 'noSpin');
+        });
+
+        describe('spin', function() {
+          shouldBehaveLikeSpinnerLog(SpinnerAction.Add, 'spin');
+        });
+      });
+
+      describe('#succeed', function() {
+        beforeEach(function() {
+          Loggy.spin('filename', 'function', 'ref-succeed', 'message');
+          this.spyLogger = sinon.stub(Spinners.prototype, 'update');
+        });
+
+        it('sets log as succeeded', function() {
+          Loggy.succeed('ref-succeed', 'new message');
+          shouldSetLogProperties(
+            Loggy.logs['ref-succeed'],
+            LogType.Info,
+            LogLevel.Normal,
+            SpinnerAction.Succeed,
+            'new message',
+          );
+          this.spyLogger.should.have.been.calledOnceWith('ref-succeed', {
+            text: 'new message',
+            status: SpinnerAction.Succeed,
+          });
+        });
+      });
+
+      describe('#fail', function() {
+        beforeEach(function() {
+          Loggy.spin('filename', 'function', 'ref-fail', 'message');
+          this.spyLogger = sinon.stub(Spinners.prototype, 'update');
+        });
+
+        it('sets log as failed', function() {
+          Loggy.fail('ref-fail', 'new message');
+          shouldSetLogProperties(
+            Loggy.logs['ref-fail'],
+            LogType.Info,
+            LogLevel.Normal,
+            SpinnerAction.Fail,
+            'new message',
+          );
+          this.spyLogger.should.have.been.calledOnceWith('ref-fail', {
+            text: 'new message',
+            status: SpinnerAction.Fail,
+          });
+        });
+      });
+
+      describe('#update', function() {
+        beforeEach(function() {
+          Loggy.spin('filename', 'function', 'ref-update', 'message');
+          this.spyLogger = sinon.stub(Spinners.prototype, 'update');
+        });
+
+        describe('noSpin', function() {
+          shouldBehaveLikeSpinnerLog(
+            SpinnerAction.NonSpinnable,
+            'noSpin',
+            'ref-update',
+          );
+        });
+
+        describe('spin', function() {
+          shouldBehaveLikeSpinnerLog(SpinnerAction.Add, 'spin', 'ref-update');
+        });
+      });
+    });
+
+    context('in verbose mode', function() {
+      beforeEach(function() {
+        Loggy.verbose(true);
+        Loggy.silent(false);
+        this.spyLogger = sinon.stub(console, 'error');
+      });
+
+      describe('#add', function() {
+        it(`sets log and calls console.error`, function() {
+          Loggy.add('filename', 'function', 'reference', 'message');
+          shouldSetLogProperties(
+            Loggy.logs['reference'],
+            LogType.Info,
+            LogLevel.Normal,
+            SpinnerAction.Add,
+            'message',
+          );
+          this.spyLogger.should.have.been.calledOnceWith(
+            sinon.match(/<started> message/),
+          );
+        });
+      });
+
+      describe('#succeed', function() {
+        it('sets log as succeeded', function() {
+          Loggy.spin('filename', 'function', 'ref-succeed', 'message');
+          Loggy.succeed('ref-succeed', 'new message');
+          shouldSetLogProperties(
+            Loggy.logs['ref-succeed'],
+            LogType.Info,
+            LogLevel.Normal,
+            SpinnerAction.Succeed,
+            'new message',
+          );
+          this.spyLogger.should.have.been.calledWith(
+            sinon.match(/<started> message/),
+          );
+          this.spyLogger.should.have.been.calledWith(
+            sinon.match(/<succeeded> new message/),
+          );
+        });
+      });
+
+      describe('#fail', function() {
+        it('sets log as failed', function() {
+          Loggy.spin('filename', 'function', 'ref-fail', 'message');
+          Loggy.fail('ref-fail', 'new message');
+          shouldSetLogProperties(
+            Loggy.logs['ref-fail'],
+            LogType.Info,
+            LogLevel.Normal,
+            SpinnerAction.Fail,
+            'new message',
+          );
+          this.spyLogger.should.have.been.calledWith(
+            sinon.match(/<started> message/),
+          );
+          this.spyLogger.should.have.been.calledWith(
+            sinon.match(/<failed> new message/),
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/979.
This PR also:
- Adds tests for the new logger.
- Updates `spinnies` to latest version, in which non-spinnable text prefix has been removed and the default terminal color has been set as default.