### PR TITLE
Fix compile command run on subfolder

### DIFF
--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -6,8 +6,8 @@ import { getSolidityLibNames, hasUnlinkedVariables } from '../utils/Bytecode';
 
 export default class Contracts {
   private static DEFAULT_SYNC_TIMEOUT: number = 240000;
-  private static DEFAULT_BUILD_DIR: string = `${process.cwd()}/build/contracts`;
-  private static DEFAULT_CONTRACTS_DIR: string = `${process.cwd()}/contracts`;
+  private static DEFAULT_BUILD_DIR: string = `build/contracts`;
+  private static DEFAULT_CONTRACTS_DIR: string = `contracts`;
 
   private static timeout: number = Contracts.DEFAULT_SYNC_TIMEOUT;
   private static buildDir: string = Contracts.DEFAULT_BUILD_DIR;
@@ -20,11 +20,13 @@ export default class Contracts {
   }
 
   public static getLocalBuildDir(): string {
-    return Contracts.buildDir || Contracts.DEFAULT_BUILD_DIR;
+    return path.resolve(Contracts.buildDir || Contracts.DEFAULT_BUILD_DIR);
   }
 
   public static getLocalContractsDir(): string {
-    return Contracts.contractsDir || Contracts.DEFAULT_CONTRACTS_DIR;
+    return path.resolve(
+      Contracts.contractsDir || Contracts.DEFAULT_CONTRACTS_DIR,
+    );
   }
 
   public static async getDefaultTxParams(): Promise<any> {

--- a/packages/lib/test/src/artifacts/Contracts.test.js
+++ b/packages/lib/test/src/artifacts/Contracts.test.js
@@ -33,22 +33,38 @@ contract('Contracts', function() {
       );
     });
 
-    it('can be set some custom configuration', function() {
-      const previousTimeout = Contracts.getSyncTimeout();
-      const previousBuildDir = Contracts.getLocalBuildDir();
-      const previousContractsDir = Contracts.getLocalContractsDir();
+    describe('setting custom config', function () {
+      beforeEach(function() {
+        this.previousTimeout = Contracts.getSyncTimeout();
+        this.previousBuildDir = Contracts.getLocalBuildDir();
+        this.previousContractsDir = Contracts.getLocalContractsDir();
+      });
 
-      Contracts.setSyncTimeout(10);
-      Contracts.setLocalBuildDir('build/bla');
-      Contracts.setLocalContractsDir('bla');
+      afterEach(function() {
+        Contracts.setSyncTimeout(this.previousTimeout);
+        Contracts.setLocalBuildDir(this.previousBuildDir);
+        Contracts.setLocalContractsDir(this.previousContractsDir);
+      });
 
-      Contracts.getSyncTimeout().should.be.eq(10);
-      Contracts.getLocalBuildDir().should.be.eq('build/bla');
-      Contracts.getLocalContractsDir().should.be.eq('bla');
+      it('with relative paths', function() {
+        Contracts.setSyncTimeout(10);
+        Contracts.setLocalBuildDir('build/bla');
+        Contracts.setLocalContractsDir('bla');
 
-      Contracts.setSyncTimeout(previousTimeout);
-      Contracts.setLocalBuildDir(previousBuildDir);
-      Contracts.setLocalContractsDir(previousContractsDir);
+        Contracts.getSyncTimeout().should.be.eq(10);
+        Contracts.getLocalBuildDir().should.be.eq(`${process.cwd()}/build/bla`);
+        Contracts.getLocalContractsDir().should.be.eq(`${process.cwd()}/bla`);
+      });
+
+      it('with absolute paths', function() {
+        Contracts.setSyncTimeout(10);
+        Contracts.setLocalBuildDir('/foo/bar/build/bla');
+        Contracts.setLocalContractsDir('/foo/bar/bla');
+
+        Contracts.getSyncTimeout().should.be.eq(10);
+        Contracts.getLocalBuildDir().should.be.eq(`/foo/bar/build/bla`);
+        Contracts.getLocalContractsDir().should.be.eq(`/foo/bar/bla`);
+      });
     });
   });
 });


### PR DESCRIPTION
Resolves the source and build folder **after** the process.cwd has taken place in zos-cli. Also, removes the usage of `zos-lib/FileSystem#createDirPath` which was not working properly, in favor of vanilla fs and fs-extra.

Fixes #984