### PR TITLE
Fix compiler logs

### DIFF
--- a/packages/cli/src/models/compiler/solidity/CompilerProvider.ts
+++ b/packages/cli/src/models/compiler/solidity/CompilerProvider.ts
@@ -205,7 +205,7 @@ async function downloadCompiler(
   localFile: string,
 ): Promise<void> {
   const { version, keccak256: expectedHash, path: versionPath } = build;
-  Loggy.spin(
+  Loggy.onVerbose(
     __filename,
     'downloadCompiler',
     'download-compiler',

--- a/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
@@ -159,6 +159,7 @@ class SolidityContractsCompiler {
     return this.contracts.reduce((sources, contract) => {
       Loggy.onVerbose(
         __filename,
+        '_buildSources',
         `compile-contract-file-${contract.fileName}`,
         `Compiling ${contract.fileName}`,
       );


### PR DESCRIPTION
As seen offline together with @spalladino, the compiler was printing some `undefined` messages on verbose mode. this PR fixes that.