### PR TITLE
Save compiler version resolved by compiler in zos.json

### DIFF
--- a/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
@@ -27,16 +27,30 @@ import { tryFunc } from '../../../utils/try';
 
 export async function compileProject(
   options: ProjectCompilerOptions = {},
-): Promise<void> {
+): Promise<ProjectCompileResult> {
   const inputDir = options.inputDir || Contracts.getLocalContractsDir();
   const outputDir = options.outputDir || Contracts.getLocalBuildDir();
-  return new SolidityProjectCompiler(inputDir, outputDir, options).call();
+  const projectCompiler = new SolidityProjectCompiler(
+    inputDir,
+    outputDir,
+    options,
+  );
+  await projectCompiler.call();
+  return {
+    contracts: projectCompiler.contracts,
+    compilerVersion: projectCompiler.compilerVersion,
+  };
 }
 
 export interface ProjectCompilerOptions extends CompilerOptions {
   manager?: string;
   inputDir?: string;
   outputDir?: string;
+}
+
+export interface ProjectCompileResult {
+  compilerVersion: SolcBuild;
+  contracts: RawContract[];
 }
 
 class SolidityProjectCompiler {

--- a/packages/cli/test/models/compiler/Compiler.test.js
+++ b/packages/cli/test/models/compiler/Compiler.test.js
@@ -10,7 +10,9 @@ describe('Compiler', function () {
   beforeEach('setup', function () {
     Compiler.resetState();
     
-    this.solcCompile = sinon.stub(Compiler, 'compileWithSolc');
+    this.solcCompile = sinon.stub(Compiler, 'compileWithSolc').callsFake(({ version }) =>
+      Promise.resolve({ compilerVersion: { version: version || '0.5.6' } })
+    );
     this.truffleCompile = sinon.stub(Compiler, 'compileWithTruffle');
     this.isTruffleConfig = sinon.stub(Truffle, 'isTruffleProject').returns(false);
     this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty-lite.zos.json')
@@ -74,6 +76,11 @@ describe('Compiler', function () {
     this.packageFile.data.compiler = { solcVersion: '0.5.3' };
     await this.compile({ version: '0.5.4' });
     this.packageFile.compilerOptions.version.should.eq('0.5.4');
+  });
+
+  it('updates local config with default compiler version after running', async function () {
+    await this.compile();
+    this.packageFile.compilerOptions.version.should.eq('0.5.6');
   });
 
   it('does not compile twice', async function () {


### PR DESCRIPTION
This ensures that two subsequent compiles are done with the same version, even if a new solc is released inbetween them.

Fixes #1004.