### PR TITLE
Compiler optimizer runs should be an integer

### DIFF
--- a/packages/cli/src/@types/solc-wrapper.d.ts
+++ b/packages/cli/src/@types/solc-wrapper.d.ts
@@ -1,8 +1,5 @@
-declare module 'solc' {
-  const version: Compiler['version'];
-  const loadRemoteVersion: Compiler['loadRemoteVersion'];
-  const compile: Compiler['compile'];
-  const setupMethods: Compiler['setupMethods'];
+declare module 'solc-wrapper' {
+  export default function(binary: any): Compiler;
 
   export interface Compiler {
     version(): string;
@@ -10,13 +7,13 @@ declare module 'solc' {
       version: string,
       cb: (error: any, compiler: Compiler) => void,
     );
-    compile(input: string, readCb: (dependency: any) => void);
+    compile(input: string, readCb: (dependency: any) => void): string;
     setupMethods(input: any): Compiler;
   }
 
   export interface CompilerOptimizerOptions {
     enabled: boolean;
-    runs?: string;
+    runs?: number;
   }
 
   export interface CompilerSettings {

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -47,7 +47,7 @@ async function action(options: {
     version,
     optimizer: {
       enabled: !!optimizer,
-      runs: optimizerRuns,
+      runs: optimizerRuns && parseInt(optimizerRuns),
     },
   };
 

--- a/packages/cli/src/models/compiler/solidity/CompilerProvider.ts
+++ b/packages/cli/src/models/compiler/solidity/CompilerProvider.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { mkdirp, readJson, writeJson } from 'fs-extra';
 import axios from 'axios';
-import solc from 'solc-wrapper';
+import solc, { CompilerOutput, Compiler, CompilerInput } from 'solc-wrapper';
 import semver from 'semver';
 import reverse from 'lodash.reverse';
 import uniq from 'lodash.uniq';
@@ -30,7 +30,7 @@ const SOLC_LIST_URL = 'https://solc-bin.ethereum.org/bin/list.json';
 
 export interface SolcCompiler {
   version(): string;
-  compile(input: string): Promise<solc.CompilerOutput>;
+  compile(input: CompilerInput): Promise<CompilerOutput>;
 }
 
 interface SolcList {
@@ -49,7 +49,7 @@ export interface SolcBuild {
 }
 
 class SolcjsCompiler implements SolcCompiler {
-  public compiler: solc.Compiler;
+  public compiler: Compiler;
 
   public constructor(compilerBinary: any) {
     this.compiler = solc(compilerBinary);
@@ -59,7 +59,7 @@ class SolcjsCompiler implements SolcCompiler {
     return this.compiler.version();
   }
 
-  public async compile(input: any): Promise<solc.CompilerOutput> {
+  public async compile(input: any): Promise<CompilerOutput> {
     return JSON.parse(this.compiler.compile(JSON.stringify(input), undefined));
   }
 }
@@ -75,7 +75,7 @@ class SolcBinCompiler implements SolcCompiler {
     return this._version;
   }
 
-  public async compile(input: any): Promise<solc.CompilerOutput> {
+  public async compile(input: any): Promise<CompilerOutput> {
     const output = child.execSync('solc --standard-json', {
       input: JSON.stringify(input),
       env: SOLC_BIN_ENV,

--- a/packages/cli/src/models/files/ZosPackageFile.ts
+++ b/packages/cli/src/models/files/ZosPackageFile.ts
@@ -17,7 +17,7 @@ interface ConfigFileCompilerOptions {
     evmVersion: string;
     optimizer: {
       enabled: boolean;
-      runs: string;
+      runs?: string;
     };
   };
 }
@@ -151,7 +151,10 @@ export default class ZosPackageFile {
       outputDir,
       evmVersion,
       version,
-      optimizer,
+      optimizer: {
+        enabled: optimizer && optimizer.enabled,
+        runs: optimizer && parseInt(optimizer.runs),
+      },
     };
   }
 
@@ -171,7 +174,10 @@ export default class ZosPackageFile {
       contractsDir: inputDir,
       compilerSettings: {
         evmVersion,
-        optimizer,
+        optimizer: {
+          enabled: optimizer && optimizer.enabled,
+          runs: optimizer && optimizer.runs && optimizer.runs.toString(),
+        },
       },
     };
 

--- a/packages/cli/test/commands/compile.test.js
+++ b/packages/cli/test/commands/compile.test.js
@@ -20,7 +20,7 @@ describe('compile command', function() {
       compiler.should.have.been.calledWithMatch({
         manager: 'zos',
         version: '0.5.0',
-        optimizer: { enabled: true, runs: '300' },
+        optimizer: { enabled: true, runs: 300 },
         evmVersion: 'petersburg',
       });
     },


### PR DESCRIPTION
Fixed typings in solc module, and fixed error `The "runs" setting must be an unsigned number` when enabling optimizer via command line.

Fixes #1007