### PR TITLE
Validate method args in interactive prompt

### DIFF
--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -97,7 +97,7 @@ function getCommandProps(
               parseArg(input, arg.type);
               return true;
             } catch (err) {
-              return `Error parsing ${input} (${err.message}). Enter a valid ${
+              return `${err.message}. Enter a valid ${
                 arg.type
               } such as: ${getPlaceholder(arg.type)}.`;
             }

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -1,4 +1,4 @@
-import { ContractMethodMutability as Mutability, Loggy } from 'zos-lib';
+import { ContractMethodMutability as Mutability } from 'zos-lib';
 import pickBy from 'lodash.pickby';
 import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -1,4 +1,4 @@
-import { ContractMethodMutability as Mutability } from 'zos-lib';
+import { ContractMethodMutability as Mutability, Loggy } from 'zos-lib';
 import pickBy from 'lodash.pickby';
 import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
@@ -89,9 +89,19 @@ function getCommandProps(
       return {
         ...accum,
         [arg.name]: {
-          message: `${arg.name}:`,
+          message: `${arg.name} (${arg.type}):`,
           type: 'input',
           when: () => !methodArgs || !methodArgs[index],
+          validate: input => {
+            try {
+              parseArg(input, arg.type);
+              return true;
+            } catch (err) {
+              return `Error parsing ${input} (${err.message}). Enter a valid ${
+                arg.type
+              } such as: ${getPlaceholder(arg.type)}.`;
+            }
+          },
           normalize: input => parseArg(input, arg.type),
         },
       };
@@ -124,4 +134,31 @@ function getCommandProps(
     },
     ...args,
   };
+}
+
+function getPlaceholder(type: string): string {
+  const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
+
+  if (type.match(ARRAY_TYPE_REGEX)) {
+    const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
+    const itemPlaceholder = getPlaceholder(arrayType);
+    return `[${itemPlaceholder}, ${itemPlaceholder}]`;
+  } else if (
+    type.startsWith('uint') ||
+    type.startsWith('int') ||
+    type.startsWith('fixed') ||
+    type.startsWith('ufixed')
+  ) {
+    return '42';
+  } else if (type === 'bool') {
+    return 'true';
+  } else if (type === 'bytes') {
+    return '0xabcdef';
+  } else if (type === 'address') {
+    return '0x1df62f291b2e969fb0849d99d9ce41e2f137006e';
+  } else if (type === 'string') {
+    return 'Hello world';
+  } else {
+    return null;
+  }
 }

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -1,6 +1,6 @@
 import BN from 'bignumber.js';
 import flattenDeep from 'lodash.flattendeep';
-import { encodeParams, Loggy } from 'zos-lib';
+import { encodeParams, Loggy, ZWeb3 } from 'zos-lib';
 
 // TODO: Deprecate in favor of a combination of parseArg and parseArray
 export function parseArgs(args: string): string[] | never {
@@ -91,22 +91,36 @@ export function parseArg(input: string | string[], type: string): any {
     else throw new Error(`Could not parse boolean value ${input}`);
   }
 
-  // Bytes, strings, addresses: untouched, as web3 handles most validations
-  else if (
-    type.startsWith('bytes') ||
-    type === 'string' ||
-    type === 'address'
-  ) {
+  // Address: just validate them
+  else if (type === 'address' && requireInputString(input)) {
+    if (!ZWeb3.isAddress(input)) {
+      throw new Error(`${input} is not a valid address`);
+    }
+    return input;
+  }
+
+  // Bytes: same, just check they are a valid hex
+  else if (type.startsWith('bytes') && requireInputString(input)) {
+    if (!ZWeb3.isHex(input)) {
+      throw new Error(`${input} is not a valid address`);
+    }
+    return input;
+  }
+
+  // Strings: pass through
+  else if (type === 'string' && requireInputString(input)) {
     return input;
   }
 
   // Warn if we see a type we don't recognise, but return it as is
-  Loggy.noSpin.warn(
-    __filename,
-    'parseArg',
-    `Unknown argument ${type} (skipping input validation)`,
-  );
-  return input;
+  else {
+    Loggy.noSpin.warn(
+      __filename,
+      'parseArg',
+      `Unknown argument ${type} (skipping input validation)`,
+    );
+    return input;
+  }
 }
 
 export function stripBrackets(inputMaybeWithBrackets: string): string {

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -102,7 +102,7 @@ export function parseArg(input: string | string[], type: string): any {
   // Bytes: same, just check they are a valid hex
   else if (type.startsWith('bytes') && requireInputString(input)) {
     if (!ZWeb3.isHex(input)) {
-      throw new Error(`${input} is not a valid address`);
+      throw new Error(`${input} is not a valid hexadecimal`);
     }
     return input;
   }

--- a/packages/lib/src/artifacts/ZWeb3.ts
+++ b/packages/lib/src/artifacts/ZWeb3.ts
@@ -54,6 +54,10 @@ export default class ZWeb3 {
     return Web3.utils.isAddress(address);
   }
 
+  public static isHex(hex: string): boolean {
+    return Web3.utils.isHex(hex);
+  }
+
   public static async checkNetworkId(
     providedNetworkId?: string | number,
   ): Promise<void | never> {


### PR DESCRIPTION
Use the arg type and inquirer validate callback to check that the user input is correct. If not, we show an example on how to input the value.

![Screenshot from 2019-06-19 17-31-02](https://user-images.githubusercontent.com/429604/59799056-ed56bb00-92b9-11e9-8476-d4dfb05bba8a.png)

Fixes #999