### PR TITLE
Use selector instead of name for identifying a method

### DIFF
--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -73,7 +73,7 @@ export default async function promptForMethodParams(
     ];
   }
 
-  return { methodName: methodName.name, methodArgs };
+  return { methodName: methodName.selector, methodArgs };
 }
 
 function getCommandProps(


### PR DESCRIPTION
Fixes #1011