### PR TITLE
Fix issues with compiler optimizer settings

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -3204,6 +3204,11 @@
       "resolved": "https://registry.npmjs.org/lodash.maxby/-/lodash.maxby-4.6.0.tgz",
       "integrity": "sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0="
     },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
     "lodash.negate": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.negate/-/lodash.negate-3.0.2.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,6 +76,7 @@
     "lodash.map": "^4.6.0",
     "lodash.max": "^4.0.1",
     "lodash.maxby": "^4.6.0",
+    "lodash.merge": "^4.6.1",
     "lodash.negate": "^3.0.2",
     "lodash.omit": "^4.5.0",
     "lodash.omitby": "^4.6.0",

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -15,8 +15,8 @@ const register: (program: any) => any = program =>
       'version of the solc compiler to use (value is written to configuration file for future runs, defaults to most recent release that satisfies contract pragmas)',
     )
     .option(
-      '--optimizer',
-      'enables compiler optimizer (value is written to configuration file for future runs, defaults to false)',
+      '--optimizer [on|off]',
+      'enables compiler optimizer (value is written to configuration file for future runs, defaults to off)',
     )
     .option(
       '--optimizer-runs [runs]',
@@ -31,7 +31,7 @@ const register: (program: any) => any = program =>
 async function action(options: {
   evmVersion: string;
   solcVersion: string;
-  optimizer: boolean;
+  optimizer: string | boolean;
   optimizerRuns: string;
 }): Promise<void> {
   const {
@@ -41,12 +41,29 @@ async function action(options: {
     optimizerRuns,
   } = options;
 
+  // Handle optimizer option:
+  //- on --optimizer or --optimizer=on, enable it
+  //- on --optimizer=off disable it
+  //- if no --optimizer is set, use default from zos.json, or false
+  //- on any other --optimizer value, throw
+  let optimizerEnabled = undefined;
+  if (typeof optimizer === 'string') {
+    if (optimizer.toLowerCase() === 'on') optimizerEnabled = true;
+    else if (optimizer.toLowerCase() === 'off') optimizerEnabled = false;
+    else
+      throw new Error(
+        `Invalid value ${optimizer} for optimizer flag (valid values are 'on' or 'off')`,
+      );
+  } else if (typeof optimizer === 'boolean') {
+    optimizerEnabled = optimizer;
+  }
+
   const compilerOptions: ProjectCompilerOptions = {
     manager: 'zos',
     evmVersion,
     version,
     optimizer: {
-      enabled: !!optimizer,
+      enabled: optimizerEnabled,
       runs: optimizerRuns && parseInt(optimizerRuns),
     },
   };

--- a/packages/cli/src/models/files/ZosPackageFile.ts
+++ b/packages/cli/src/models/files/ZosPackageFile.ts
@@ -153,7 +153,7 @@ export default class ZosPackageFile {
       version,
       optimizer: {
         enabled: optimizer && optimizer.enabled,
-        runs: optimizer && parseInt(optimizer.runs),
+        runs: optimizer && optimizer.runs && parseInt(optimizer.runs),
       },
     };
   }

--- a/packages/cli/test/commands/compile.test.js
+++ b/packages/cli/test/commands/compile.test.js
@@ -25,4 +25,17 @@ describe('compile command', function() {
       });
     },
   );
+
+  itShouldParse(
+    'should call compile with optimizer disabled',
+    'compiler',
+    'zos compile --solc-version 0.5.0 --optimizer=off',
+    function(compiler) {
+      compiler.should.have.been.calledWithMatch({
+        manager: 'zos',
+        version: '0.5.0',
+        optimizer: { enabled: false },
+      });
+    },
+  );
 });


### PR DESCRIPTION
- Allow to disable the optimizer via --optimizer=off option (was not possible to do before)
- Properly merge options from command line and defaults from zos.json (object assign replaced by lodash merge, it was not working ok for the optimizer which was a nested object)
- Handle undefined value for runs when loading it from zos.json