### PR TITLE
Handle relative imports from project root in compiler

### DIFF
--- a/packages/cli/mocks/mock-project-with-root-imports/README.md
+++ b/packages/cli/mocks/mock-project-with-root-imports/README.md
@@ -1,0 +1,12 @@
+# mock-project-with-root-imports
+
+This project is used to test that the following three import styles are supported by the compiler:
+
+```solidity
+// contracts/subfolder/GreeterImpl.sol
+import "contracts/subfolder/GreeterLib.sol";
+import "./GreeterLib2.sol";
+import "GreeterLib3.sol";
+```
+
+This project is here and not in `test/mocks` because otherwise truffle tried to compile it and failed, as it assumed that `import "contracts/subfolder/GreeterLib.sol"` was relative to the main project root, and not to the `mock-project-with-root-imports`.

--- a/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterImpl.sol
+++ b/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterImpl.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.5.0;
+
+import "contracts/subfolder/GreeterLib.sol";
+import "./GreeterLib2.sol";
+import "GreeterLib3.sol";
+
+contract GreeterImpl {
+  using GreeterLib for string;
+  using GreeterLib2 for string;
+  using GreeterLib3 for string;
+  
+  event Greeting(string greeting);
+
+  function greet(string memory who) public {
+    emit Greeting(greeting(who));
+  }
+
+  function greeting(string memory who) public pure returns (string memory) {
+    return who.wrap();
+  }
+
+  function version() public pure returns (string memory) {
+    return "1.1.0";
+  }
+}

--- a/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib.sol
+++ b/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library GreeterLib {
+  function wrap(string memory self) public pure returns (string memory) {
+    return self;
+  }
+}

--- a/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib2.sol
+++ b/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib2.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library GreeterLib2 {
+  function wrap2(string memory self) public pure returns (string memory) {
+    return self;
+  }
+}

--- a/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib3.sol
+++ b/packages/cli/mocks/mock-project-with-root-imports/contracts/subfolder/GreeterLib3.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library GreeterLib3 {
+  function wrap3(string memory self) public pure returns (string memory) {
+    return self;
+  }
+}

--- a/packages/cli/mocks/mock-project-with-root-imports/zos.json
+++ b/packages/cli/mocks/mock-project-with-root-imports/zos.json
@@ -1,0 +1,9 @@
+{
+  "name": "mock-project-with-root-imports",
+  "zosversion": "2.2",
+  "version": "1.1.0",
+  "contracts": {
+    "Greeter": "GreeterImpl"
+  },
+  "dependencies": {}
+}

--- a/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
+++ b/packages/cli/test/models/compiler/solidity/SolidityProjectCompiler.test.js
@@ -180,4 +180,22 @@ describe('SolidityProjectCompiler', function() {
       await compileProject({ inputDir, outputDir, version: '0.5.9' });
     });
   });
+
+  describe('in mock-project-with-root-imports project', function() {
+    this.timeout(20000);
+
+    const projectDir = `${rootDir}/mocks/mock-project-with-root-imports`;
+    const inputDir = `${rootDir}/mocks/mock-project-with-root-imports/contracts`;
+    const outputDir = `${baseTestBuildDir}/mock-project-with-root-imports`;
+
+    it('compiles without errors', async function() {
+      this.cwd = process.cwd();
+      process.chdir(projectDir);
+      await compileProject({ inputDir, outputDir, version: '0.5.9' });
+    });
+
+    afterEach(function () {
+      process.chdir(this.cwd);
+    });
+  });
 });


### PR DESCRIPTION
Support the syntax `import "contracts/Folder/C2.sol"` in a contract `contracts/Folder/C1.sol`.

Fixes #1024