### PR TITLE
Avoid showing external contract emitted events

### DIFF
--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -147,7 +147,7 @@ function getCommandProps({
   return {
     ...networksList('network', 'list'),
     pickProxyBy: {
-      message: 'For which proxies would you like to transfer ownership?',
+      message: 'For which instances would you like to transfer ownership?',
       type: 'list',
       choices: [
         {
@@ -165,7 +165,7 @@ function getCommandProps({
       ],
     },
     proxy: {
-      message: 'Choose a proxy',
+      message: 'Choose an instance',
       type: 'list',
       choices: ({ pickProxyBy }) =>
         proxiesList(pickProxyBy, network, { kind: ProxyType.Upgradeable }),

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -151,7 +151,7 @@ function getCommandProps({
       type: 'list',
       choices: [
         {
-          name: 'All proxies',
+          name: 'All instances',
           value: 'all',
         },
         {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -145,7 +145,7 @@ function getCommandProps({
       type: 'list',
       choices: [
         {
-          name: 'All proxies',
+          name: 'All instances',
           value: 'all',
         },
         {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -141,7 +141,7 @@ function getCommandProps({
   return {
     ...networksList('network', 'list'),
     pickProxyBy: {
-      message: 'Which proxies would you like to upgrade?',
+      message: 'Which instances would you like to upgrade?',
       type: 'list',
       choices: [
         {
@@ -163,7 +163,7 @@ function getCommandProps({
           .length,
     },
     proxy: {
-      message: 'Pick a contract to upgrade',
+      message: 'Pick an instance to upgrade',
       type: 'list',
       choices: ({ pickProxyBy }) =>
         proxiesList(pickProxyBy, network, { kind: ProxyType.Upgradeable }),

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -2,18 +2,25 @@ import { Loggy } from 'zos-lib';
 
 export function describeEvents(events: any): void {
   let description = '';
-  Object.values(events).forEach(({ event, returnValues }) => {
-    const emitted = Object.keys(returnValues)
-      .filter(key => isNaN(Number(key)))
-      .map(key => `${key}: ${returnValues[key]}`);
+  Object.values(events)
+    .filter(({ event }) => event)
+    .forEach(({ event, returnValues }) => {
+      const emitted = Object.keys(returnValues)
+        .filter(key => !isNaN(Number(key)))
+        .map(key => returnValues[key]);
 
-    description = description.concat(`\n - ${event}(${emitted.join(', ')})`);
-  });
+      if (emitted.length !== 0)
+        description = description.concat(
+          `\n - ${event}(${emitted.join(', ')})`,
+        );
+    });
 
-  Loggy.noSpin(
-    __filename,
-    'describe',
-    'describe-events',
-    `Events emitted: ${description}`,
-  );
+  if (description) {
+    Loggy.noSpin(
+      __filename,
+      'describe',
+      'describe-events',
+      `Events emitted: ${description}`,
+    );
+  }
 }

--- a/packages/cli/test/utils/events.test.js
+++ b/packages/cli/test/utils/events.test.js
@@ -1,0 +1,50 @@
+'use strict';
+require('../setup');
+
+import utils from 'web3-utils';
+import { Transactions, Contracts } from 'zos-lib';
+
+import CaptureLogs from '../helpers/captureLogs';
+import { describeEvents } from '../../src/utils/events';
+
+const ImplV1 = Contracts.getFromLocal('ImplV1');
+
+contract('events', function(accounts) {
+  const [_, accountAddress] = accounts.map(utils.toChecksumAddress);
+  beforeEach('set capture logs', async function() {
+    this.implV1 = await ImplV1.new();
+    this.logs = new CaptureLogs();
+  });
+
+  afterEach('restore capture logs', function() {
+    this.logs.restore();
+  });
+
+  describe('#describeEvents', function() {
+    context('when the contract function emits an event', function() {
+      it('logs the emitted events', async function() {
+        const { events } = await Transactions.sendTransaction(
+          this.implV1.methods.initializeWithEvent,
+          [42],
+        );
+        describeEvents(events);
+
+        this.logs.infos[0].should.eq(
+          'Events emitted: \n - InitializeEvent(42)',
+        );
+      });
+    });
+
+    context('when the contract function does not emit events', function() {
+      it('does not log events', async function() {
+        const { events } = await Transactions.sendTransaction(
+          this.implV1.methods.initialize,
+          [42],
+        );
+        describeEvents(events);
+
+        this.logs.infos.should.have.lengthOf(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related to #1021. Doesn't solve it, but Now we can remove the `bug` flag :stuck_out_tongue: 