### PR TITLE
Fix compiler error when no contracts found

### DIFF
--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -43,7 +43,10 @@ export async function compile(
     ? compileWithTruffle()
     : compileWithSolc(resolvedOptions);
   const compileResult = await compilePromise;
-  const compileVersion = compileResult && compileResult.compilerVersion.version;
+  const compileVersion =
+    compileResult &&
+    compileResult.compilerVersion &&
+    compileResult.compilerVersion.version;
   const compileVersionOptions = compileVersion
     ? { version: compileVersion }
     : null;


### PR DESCRIPTION
Fixes error `Cannot read property version of undefined` when compiling and there are no contracts at all.