### PR TITLE
Explicitly specify `@resolver-engine/core` version

### DIFF
--- a/examples/lib-complex/package-lock.json
+++ b/examples/lib-complex/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "example-zos-lib-complex",
-  "version": "2.4.0-rc.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zos",
-  "version": "2.4.0-rc.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -98,14 +98,6 @@
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
       "integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/cbor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
-      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
       "requires": {
         "@types/node": "*"
       }
@@ -665,17 +657,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "cbor": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.1.5.tgz",
-      "integrity": "sha512-WqpISHl7/kk1u1uoaqctGyGiET3+wGN4A6pPsFCzEBztJJlCVxnMB4JwcuuNSrMiV4V6UBlxMkhNzJrUxDWO1A==",
-      "requires": {
-        "bignumber.js": "^8.0.2",
-        "commander": "^2.19.0",
-        "json-text-sequence": "^0.1",
-        "nofilter": "^1.0.1"
-      }
-    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -1088,11 +1069,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -2945,14 +2921,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -3087,11 +3055,6 @@
       "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
       "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
     },
-    "lodash.findlast": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
-      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
-    },
     "lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
@@ -3128,20 +3091,10 @@
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
       "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
     "lodash.intersection": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
       "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
-    },
-    "lodash.invertby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.invertby/-/lodash.invertby-4.7.0.tgz",
-      "integrity": "sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA="
     },
     "lodash.isarray": {
       "version": "4.0.0",
@@ -3177,11 +3130,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
-    },
-    "lodash.keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -3242,17 +3190,13 @@
     "lodash.random": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.random/-/lodash.random-3.2.0.tgz",
-      "integrity": "sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0="
+      "integrity": "sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0=",
+      "dev": true
     },
     "lodash.reverse": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.reverse/-/lodash.reverse-4.0.1.tgz",
       "integrity": "sha1-Hyr+2s4uFuZg86p8WdMwCm8l0Tw="
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.topairs": {
       "version": "4.3.0",
@@ -3279,16 +3223,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
       "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
-    },
-    "lodash.without": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "lolex": {
       "version": "2.7.5",
@@ -3612,11 +3546,6 @@
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
       }
-    },
-    "nofilter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.2.tgz",
-      "integrity": "sha512-d38SORxm9UNoDsnPXajV9nBEebKX4/paXAlyRGnSjZuFbLLZDFUO4objr+tbybqsbqGXDWllb6gQoKUDc9q3Cg=="
     },
     "npm-programmatic": {
       "version": "0.0.12",
@@ -5048,96 +4977,6 @@
       "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
       "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
     },
-    "truffle-flattener": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.3.0.tgz",
-      "integrity": "sha512-ppJ9xI0tDuvCYjQlcWwMBcOKZph5U4YpG/gChyUVDxOjUIniG5g7y9vZho2PRj1FohPPnOjg1KOAVNlk/bPZrw==",
-      "requires": {
-        "@resolver-engine/imports-fs": "^0.2.2",
-        "find-up": "^2.1.0",
-        "mkdirp": "^0.5.1",
-        "solidity-parser-antlr": "^0.4.0",
-        "tsort": "0.0.1"
-      },
-      "dependencies": {
-        "@resolver-engine/core": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
-          "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
-          "requires": {
-            "debug": "^3.1.0",
-            "request": "^2.85.0"
-          }
-        },
-        "@resolver-engine/fs": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
-          "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
-          "requires": {
-            "@resolver-engine/core": "^0.2.1",
-            "debug": "^3.1.0"
-          }
-        },
-        "@resolver-engine/imports": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
-          "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
-          "requires": {
-            "@resolver-engine/core": "^0.2.1",
-            "debug": "^3.1.0",
-            "hosted-git-info": "^2.6.0"
-          }
-        },
-        "@resolver-engine/imports-fs": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
-          "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
-          "requires": {
-            "@resolver-engine/fs": "^0.2.1",
-            "@resolver-engine/imports": "^0.2.2",
-            "debug": "^3.1.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        }
-      }
-    },
     "truffle-provider": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.3.tgz",
@@ -5191,11 +5030,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-    },
-    "tsort": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
-      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y="
     },
     "tsutils": {
       "version": "3.14.0",
@@ -5802,162 +5636,6 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
-    },
-    "zos-lib": {
-      "version": "2.4.0-rc.1",
-      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.4.0-rc.1.tgz",
-      "integrity": "sha512-Z0f5JI4Erhr1rLeM/WnDSEuSVc79L02ZawAW5BuokBa+Rwwrb03i4CXo5WVHbrDRlgysohMNMzly/gkPvEWTzg==",
-      "requires": {
-        "@types/cbor": "^2.0.0",
-        "@types/web3": "^1.0.14",
-        "axios": "^0.18.0",
-        "bignumber.js": "^7.2.0",
-        "cbor": "^4.1.5",
-        "chalk": "^2.4.1",
-        "ethers": "^4.0.20",
-        "glob": "^7.1.3",
-        "lodash.concat": "^4.5.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.every": "^4.6.0",
-        "lodash.findlast": "^4.6.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.includes": "^4.3.0",
-        "lodash.invertby": "^4.7.0",
-        "lodash.isarray": "^4.0.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isstring": "^4.0.1",
-        "lodash.keys": "^4.2.0",
-        "lodash.map": "^4.6.0",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "lodash.random": "^3.2.0",
-        "lodash.reverse": "^4.0.1",
-        "lodash.some": "^4.6.0",
-        "lodash.uniq": "^4.5.0",
-        "lodash.values": "^4.3.0",
-        "lodash.without": "^4.4.0",
-        "semver": "^5.5.1",
-        "spinnies": "^0.3.2",
-        "truffle-flattener": "^1.3.0",
-        "web3": "1.0.0-beta.37"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "elliptic": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "ethers": {
-          "version": "4.0.30",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.30.tgz",
-          "integrity": "sha512-1a39Y+q5zTfrXCLndV+CHsTHq+T5/TvAx5y0S/PKd700C0lfU70CJnU7q89bd+4pIuWp05TkrEsrTj2dXhkcSA==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-        },
-        "spinnies": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.3.2.tgz",
-          "integrity": "sha512-WOvGI8X3h2XbAu/VBzIG99qJTeWCZ5RjyZtuLc4Q6qwAIv1/OPA2aL9j5wYEhwNsWLbBDHH5bLk/bOJTpexljw==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "cli-cursor": "^3.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/zeppelinos/zos/tree/master/packages/cli#readme",
   "dependencies": {
+    "@resolver-engine/core": "^0.3.0",
     "@resolver-engine/imports-fs": "^0.3.2",
     "@types/fs-extra": "^7.0.0",
     "@types/npm": "^2.0.29",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -98,7 +98,7 @@
     "spinnies": "^0.3.0",
     "truffle-config": "1.1.2",
     "web3": "1.0.0-beta.37",
-    "zos-lib": "^2.4.0"
+    "zos-lib": "2.4.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.119",

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zos-lib",
-  "version": "2.4.0-rc.2",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/cli/workdir/package-lock.json
+++ b/tests/cli/workdir/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "tests-cli-workdir",
-	"version": "2.4.0-rc.1",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1271,33 +1271,10 @@
 			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
 			"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 			"requires": {
+				"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
 				"ethereumjs-util": "^5.1.1"
 			},
 			"dependencies": {
-				"ethereumjs-abi": {
-					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
-					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
-					"requires": {
-						"bn.js": "^4.11.8",
-						"ethereumjs-util": "^6.0.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-							"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-							"requires": {
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"ethjs-util": "0.1.6",
-								"keccak": "^1.0.2",
-								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
-							}
-						}
-					}
-				},
 				"ethereumjs-util": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -1351,6 +1328,30 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 			"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+		},
+		"ethereumjs-abi": {
+			"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+			"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+			"requires": {
+				"bn.js": "^4.11.8",
+				"ethereumjs-util": "^6.0.0"
+			},
+			"dependencies": {
+				"ethereumjs-util": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+					"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+					"requires": {
+						"bn.js": "^4.11.0",
+						"create-hash": "^1.1.2",
+						"ethjs-util": "0.1.6",
+						"keccak": "^1.0.2",
+						"rlp": "^2.0.0",
+						"safe-buffer": "^5.1.1",
+						"secp256k1": "^3.0.1"
+					}
+				}
+			}
 		},
 		"ethereumjs-account": {
 			"version": "2.0.5",


### PR DESCRIPTION
Fixes #1046. While making some tests with @spalladino, we noticed that `yarn` was installing an older version of `@resolver-engine/core` (v0.2.1) which has a different project structure and was causing problems. I've explicitly added the dependency in the `cli`'s `package.json`.
Last but not least, I also pinned the `zos-lib` version.