### PR TITLE
Upgrade spinner manager to v0.4.3

### DIFF
--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -10210,9 +10210,9 @@
       "dev": true
     },
     "spinnies": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.4.2.tgz",
-      "integrity": "sha512-do3DmZT9PiazyTDZvj7RY855qFjI895p/8JyzXhZ3YPcqdVs8YY8iQIWffwIInhO2OhcQoKLbGDXY7nbgo9BkQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.4.3.tgz",
+      "integrity": "sha512-TTA2vWXrXJpfThWAl2t2hchBnCMI1JM5Wmb2uyI7Zkefdw/xO98LDy6/SBYwQPiYXL3swx3Eb44ZxgoS8X5wpA==",
       "requires": {
         "chalk": "^2.4.2",
         "cli-cursor": "^3.0.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -70,7 +70,7 @@
     "lodash.values": "^4.3.0",
     "lodash.without": "^4.4.0",
     "semver": "^5.5.1",
-    "spinnies": "^0.4.2",
+    "spinnies": "^0.4.3",
     "truffle-flattener": "^1.4.0",
     "web3": "1.0.0-beta.37"
   },


### PR DESCRIPTION
Upgraded `spinnies` to  v0.4.3, which supports Unicode characters in some Windows terminals.