### PR TITLE
Rename compiler manager to openzeppelin

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -51,7 +51,7 @@ async function action(options: {
   }
 
   const compilerOptions: ProjectCompilerOptions = {
-    manager: 'zos',
+    manager: 'openzeppelin',
     evmVersion,
     version,
     optimizer: {

--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -23,8 +23,8 @@ export async function compile(
 
   // Validate compiler manager setting
   const { manager } = resolvedOptions;
-  if (manager && manager !== 'truffle' && manager !== 'zos') {
-    throw new Error(`Unknown compiler manager '${manager}' (valid values are 'zos' or 'truffle')`);
+  if (manager && manager !== 'truffle' && manager !== 'zos' && manager !== 'openzeppelin') {
+    throw new Error(`Unknown compiler manager '${manager}' (valid values are 'openzeppelin' or 'truffle')`);
   }
 
   // We use truffle if set explicitly, or if nothing was set but there is a truffle.js file
@@ -41,7 +41,7 @@ export async function compile(
   projectFile.setCompilerOptions({
     ...resolvedOptions,
     ...compileVersionOptions,
-    manager: useTruffle ? 'truffle' : 'zos',
+    manager: useTruffle ? 'truffle' : 'openzeppelin',
   });
   if (projectFile.exists()) projectFile.write();
 

--- a/packages/cli/test/commands/compile.test.js
+++ b/packages/cli/test/commands/compile.test.js
@@ -18,7 +18,7 @@ describe('compile command', function() {
     'zos compile --solc-version 0.5.0 --optimizer --optimizer-runs 300 --evm-version petersburg',
     function(compiler) {
       compiler.should.have.been.calledWithMatch({
-        manager: 'zos',
+        manager: 'openzeppelin',
         version: '0.5.0',
         optimizer: { enabled: true, runs: 300 },
         evmVersion: 'petersburg',
@@ -32,7 +32,7 @@ describe('compile command', function() {
     'zos compile --solc-version 0.5.0 --optimizer=off',
     function(compiler) {
       compiler.should.have.been.calledWithMatch({
-        manager: 'zos',
+        manager: 'openzeppelin',
         version: '0.5.0',
         optimizer: { enabled: false },
       });

--- a/packages/cli/test/models/compiler/Compiler.test.js
+++ b/packages/cli/test/models/compiler/Compiler.test.js
@@ -24,7 +24,7 @@ describe('Compiler', function () {
   });
 
   it('compiles with zos if explicitly set', async function () {
-    await this.compile({ manager: 'zos' });
+    await this.compile({ manager: 'openzeppelin' });
     this.solcCompile.should.have.been.calledOnce;
   });
 
@@ -38,7 +38,7 @@ describe('Compiler', function () {
   });
 
   it('compiles with zos if set in local config', async function () {
-    this.projectFile.data.compiler = { manager: 'zos' };
+    this.projectFile.data.compiler = { manager: 'openzeppelin' };
     await this.compile();
     this.solcCompile.should.have.been.calledOnce;
   });


### PR DESCRIPTION
Still accept old "zos" naming