### PR TITLE
Use require.resolve to lookup contracts in deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,6 +3944,10 @@
         }
       }
     },
+    "mock-stdlib-root": {
+      "version": "file:packages/cli/test/mocks/mock-stdlib",
+      "dev": true
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "devDependencies": {
     "husky": "^2.7.0",
     "lerna": "~3.13.1",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "mock-stdlib-root": "file:./packages/cli/test/mocks/mock-stdlib"
   },
   "husky": {
     "hooks": {

--- a/packages/cli/test/models/Dependency.test.js
+++ b/packages/cli/test/models/Dependency.test.js
@@ -9,15 +9,7 @@ import Dependency from '../../src/models/dependency/Dependency';
 import ProjectFile from '../../src/models/files/ProjectFile';
 import NetworkFile from '../../src/models/files/NetworkFile';
 
-contract('Dependency', function([_, from]) {
-  const assertErrorMessage = (fn, errorMessage) => {
-    try {
-      fn();
-    } catch (error) {
-      error.message.should.match(errorMessage);
-    }
-  };
-
+contract.only('Dependency', function([_, from]) {
   describe('static methods', function() {
     describe('#satisfiesVersion', function() {
       it('verifies if requirement satisfies version', function() {
@@ -29,10 +21,9 @@ contract('Dependency', function([_, from]) {
     describe('#fromNameAndVersion', function() {
       describe('with invalid nameAndVersion', function() {
         it('throws error', function() {
-          assertErrorMessage(
-            () => Dependency.fromNameWithVersion('bildts-kcom'),
-            /Could not find a project.json file/,
-          );
+          expect(
+            () => Dependency.fromNameWithVersion('bildts-kcom')
+          ).to.throw(/Could not find a project.json file/);
         });
       });
 
@@ -114,19 +105,17 @@ contract('Dependency', function([_, from]) {
   describe('#constructor', function() {
     context('with invalid version', function() {
       it('throws an error', function() {
-        assertErrorMessage(
-          () => new Dependency('mock-stdlib', '1.2.0'),
-          /does not match version/,
-        );
+        expect(
+          () => new Dependency('mock-stdlib', '1.2.0')
+        ).to.throw(/does not match version/);
       });
     });
 
     context('with non-existent dependency name', function() {
       it('throws an error', function() {
-        assertErrorMessage(
-          () => new Dependency('bildts-kcom', '1.1.0'),
-          /Could not find a project.json file/,
-        );
+        expect(
+          () => new Dependency('bildts-kcom', '1.1.0')
+        ).to.throw(/Could not find a project.json file/);
       });
     });
 
@@ -178,10 +167,9 @@ contract('Dependency', function([_, from]) {
     describe('#getNetworkFile', function() {
       context('for a non-existent network', function() {
         it('throws an error', function() {
-          assertErrorMessage(
-            () => this.dependency.getNetworkFile('bildts-kcom'),
-            /Could not find a project file for network/,
-          );
+          expect(
+            () => this.dependency.getNetworkFile('bildts-kcom')
+          ).to.throw(/Could not find a project file for network/);
         });
       });
 

--- a/packages/cli/test/scripts/unlink.test.js
+++ b/packages/cli/test/scripts/unlink.test.js
@@ -28,7 +28,7 @@ contract('unlink script', function() {
         dependencies: [dependencyName],
         projectFile: this.projectFile,
       }).should.be.rejectedWith(
-        `Could not find a project.json file for '${dependencyName}'. Make sure it is provided by the npm package.`,
+        `Could not find dependency ${dependencyName}.`,
       );
     });
   });

--- a/packages/lib/src/artifacts/Contracts.ts
+++ b/packages/lib/src/artifacts/Contracts.ts
@@ -12,6 +12,7 @@ export default class Contracts {
   private static timeout: number = Contracts.DEFAULT_SYNC_TIMEOUT;
   private static buildDir: string = Contracts.DEFAULT_BUILD_DIR;
   private static contractsDir: string = Contracts.DEFAULT_CONTRACTS_DIR;
+  private static projectRoot: string = null;
   private static artifactDefaults: any = {};
   private static defaultFromAddress: string;
 
@@ -25,6 +26,10 @@ export default class Contracts {
 
   public static getLocalContractsDir(): string {
     return path.resolve(Contracts.contractsDir || Contracts.DEFAULT_CONTRACTS_DIR);
+  }
+
+  public static getProjectRoot(): string {
+    return path.resolve(this.projectRoot || process.cwd());
   }
 
   public static async getDefaultTxParams(): Promise<any> {
@@ -46,7 +51,7 @@ export default class Contracts {
   }
 
   public static getNodeModulesPath(dependency: string, contractName: string): string {
-    return `${process.cwd()}/node_modules/${dependency}/build/contracts/${contractName}.json`;
+    return require.resolve(`${dependency}/build/contracts/${contractName}.json`, { paths: [this.getProjectRoot()] });
   }
 
   public static getFromLocal(contractName: string): Contract {
@@ -83,6 +88,10 @@ export default class Contracts {
 
   public static setLocalContractsDir(dir: string): void {
     Contracts.contractsDir = dir;
+  }
+
+  public static setProjectRoot(dir: string): void {
+    Contracts.projectRoot = dir;
   }
 
   public static setArtifactsDefaults(defaults: any): void {

--- a/packages/lib/test/src/artifacts/Contracts.test.js
+++ b/packages/lib/test/src/artifacts/Contracts.test.js
@@ -22,6 +22,12 @@ contract('Contracts', function() {
     instance.address.should.not.be.null;
   });
 
+  it('can lookup contracts from hoisted node modules', async function() {
+    const GreeterLib = Contracts.getFromNodeModules('mock-stdlib-root', 'GreeterLib');
+    const instance = await GreeterLib.new();
+    instance.address.should.not.be.null;
+  });
+
   describe('configuration', function() {
     it('has some default configuration', function() {
       Contracts.getSyncTimeout().should.be.eq(240000);


### PR DESCRIPTION
Change lookup in both Dependency and Contracts classes. Instead of looking for just node_modules in the current folder, it uses require.resolve (relative to the current workdir) to look for the dependency.
    
Fixes #1076
