### PR TITLE
Handle incorrect keys to loggy

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -233,7 +233,7 @@ export default class NetworkController {
     Loggy.spin(__filename, '_uploadSolidityLib', `upload-solidity-lib${libName}`, `Uploading ${libName} library`);
     const libInstance = await this.project.setImplementation(libClass, libName);
     this.networkFile.addSolidityLib(libName, libInstance);
-    Loggy.succeed(`upload-solidity-lob${libName}`, `${libName} library uploaded`);
+    Loggy.succeed(`upload-solidity-lib${libName}`, `${libName} library uploaded`);
   }
 
   // Contract model

--- a/packages/cli/test/setup.js
+++ b/packages/cli/test/setup.js
@@ -14,7 +14,8 @@ useTestProjectFile();
 doNotInstallStdlib();
 ZWeb3.initialize(web3.currentProvider);
 setArtifactDefaults();
-Loggy.silent(true);
+Loggy.silent(false);
+Loggy.testing(true);
 
 require('chai')
   .use(require('chai-as-promised'))

--- a/packages/lib/src/project/ProxyAdminProject.ts
+++ b/packages/lib/src/project/ProxyAdminProject.ts
@@ -52,6 +52,7 @@ class BaseProxyAdminProject extends BaseSimpleProject {
       contract,
       contractParams,
     );
+    Loggy.spin(__filename, 'upgradeProxy', `action-proxy-${pAddress}`, `Upgrading instance at ${pAddress}`);
     await this.proxyAdmin.upgradeProxy(pAddress, implementationAddress, contract, initMethodName, initArgs);
     Loggy.succeed(`action-proxy-${pAddress}`, `Instance at ${pAddress} upgraded`);
     return contract.at(pAddress);

--- a/packages/lib/src/project/SimpleProject.ts
+++ b/packages/lib/src/project/SimpleProject.ts
@@ -22,9 +22,10 @@ export default class SimpleProject extends BaseSimpleProject {
       contract,
       contractParams,
     );
+    Loggy.spin(__filename, 'upgradeProxy', `action-proxy-${pAddress}`, `Upgrading instance at ${pAddress}`);
     const proxy = Proxy.at(pAddress, this.txParams);
     await proxy.upgradeTo(implementationAddress, initCallData);
-    Loggy.succeed(`action-proxy-${implementationAddress}`, `Instance at ${pAddress} upgraded`);
+    Loggy.succeed(`action-proxy-${pAddress}`, `Instance at ${pAddress} upgraded`);
     return contract.at(proxyAddress);
   }
 

--- a/packages/lib/test/setup.js
+++ b/packages/lib/test/setup.js
@@ -6,7 +6,8 @@ import Contracts from '../src/artifacts/Contracts';
 import { helpers } from '../src/test';
 import { Loggy } from '../src/utils/Logger';
 
-Loggy.silent(true);
+Loggy.silent(false);
+Loggy.testing(true);
 ZWeb3.initialize(web3.currentProvider);
 setArtifactDefaults();
 

--- a/packages/lib/test/src/utils/Logger.test.js
+++ b/packages/lib/test/src/utils/Logger.test.js
@@ -11,20 +11,20 @@ import {
   LogType,
 } from '../../../src/utils/Logger';
 
-describe('Loggger', function() {
-  afterEach('restore logger', function() {
-    Loggy.silent(true);
+describe('Logger', function() {
+  beforeEach(function () {
+    Loggy.testing(false);
+  });
+
+  afterEach('restore logger', function() {    
+    Loggy.testing(true);
+    Loggy.silent(false);
     Loggy.verbose(false);
     Loggy.logs = {};
     sinon.restore();
   });
 
   describe('default attributes', function() {
-    it('is silent and non-verbose by default', function() {
-      Loggy.isSilent.should.be.true;
-      Loggy.isVerbose.should.be.false;
-    });
-
     it(`has a 'logs' object initialized`, function() {
       Loggy.logs.should.be.an('object').that.is.empty;
     });
@@ -41,7 +41,14 @@ describe('Loggger', function() {
     describe('#verbose', function() {
       it('changes isVerbose property value', function() {
         Loggy.verbose(true);
-        Loggy.isSilent.should.be.true;
+        Loggy.isVerbose.should.be.true;
+      });
+    });
+
+    describe('#testing', function() {
+      it('changes isTesting property value', function() {
+        Loggy.testing(true);
+        Loggy.isTesting.should.be.true;
       });
     });
 

--- a/packages/lib/test/src/utils/Logger.test.js
+++ b/packages/lib/test/src/utils/Logger.test.js
@@ -24,12 +24,6 @@ describe('Logger', function() {
     sinon.restore();
   });
 
-  describe('default attributes', function() {
-    it(`has a 'logs' object initialized`, function() {
-      Loggy.logs.should.be.an('object').that.is.empty;
-    });
-  });
-
   describe('methods', function() {
     describe('#silent', function() {
       it('changes isSilent property value', function() {


### PR DESCRIPTION
When calling Loggy.success with a non-existing key, the reference would not be found, and the call to path.basename in Loggy._log would fail (since its parameter was null). This commit:

- Catches any exceptions in _log, and displays an error (allowing to continue)
- Adds a testing mode to the logger, which is silent but executes logic, and throws an exception upon issues (only to be used in the CLI and lib tests)
- Fixes incorrect or missing keys in calls to the logger

_Note: we should cherry pick this one onto 2.4_