### PR TITLE
Explicitly require web3-utils

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -72,7 +72,8 @@
     "semver": "^5.5.1",
     "spinnies": "^0.4.3",
     "truffle-flattener": "^1.4.0",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
We are importing `web3-utils` in `Addresses.ts` in lib, and we don't have the package required in the `package.json`. Instead, we're relying in it being installed as part of web3.

This PR is an attempt to fix 1087.