### PR TITLE
Fix set-admin command description format

### DIFF
--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -18,10 +18,7 @@ import { ProxyType } from '../scripts/interfaces';
 
 const name = 'set-admin';
 const signature = `${name} [alias-or-address] [new-admin-address]`;
-const description = `change upgradeability admin of a contract instance, all instances or proxy admin.
-Provide the [alias] or [package]/[alias] of the contract to change the ownership of all its instances,
-or its [address] to change a single one, or none to change all contract instances to a new admin.
-Note that if you transfer to an incorrect address, you may irreversibly lose control over upgrading your contract.`;
+const description = `change upgradeability admin of a contract instance, all instances or proxy admin. Provide the [alias] or [package]/[alias] of the contract to change the ownership of all its instances, or its [address] to change a single one, or none to change all contract instances to a new admin. Note that if you transfer to an incorrect address, you may irreversibly lose control over upgrading your contract.`;
 
 const register: (program: any) => any = program =>
   program


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos/issues/1041. Removed unnecessary line breaks in the `set-admin` command description that made it look inconsistent compared to the other command descriptions when running `oz --help`.

