### PR TITLE
Remove repeated flag -f from push and set-admin

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -25,7 +25,7 @@ const register: (program: any) => any = program =>
     .option('--skip-compile', 'skips contract compilation')
     .option('-d, --deploy-dependencies', 'deploys dependencies to the network if there is no existing deployment')
     .option('--reset', 'redeploys all contracts (not only the ones that changed)')
-    .option('-f, --force', 'ignores validation errors and deploys contracts')
+    .option('--force', 'ignores validation errors and deploys contracts')
     .option(
       '--deploy-proxy-admin',
       "eagerly deploys the project's proxy admin (if not deployed yet on the provided network)",

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -25,7 +25,7 @@ const register: (program: any) => any = program =>
     .command(signature, undefined, { noHelp: true })
     .usage('[alias-or-address] [new-admin-address] --network <network> [options]')
     .description(description)
-    .option('-f, --force', 'bypass a manual check')
+    .option('--force', 'bypass a manual check')
     .withNetworkOptions()
     .withNonInteractiveOption()
     .action(action);

--- a/packages/cli/test/commands/push.test.js
+++ b/packages/cli/test/commands/push.test.js
@@ -12,7 +12,7 @@ describe('push command', function() {
     itShouldParse(
       'should call push script with options',
       'push',
-      'zos push --network test --skip-compile -d --reset -f --deploy-proxy-admin --deploy-proxy-factory',
+      'zos push --network test --skip-compile -d --reset --force --deploy-proxy-admin --deploy-proxy-factory',
       function(push) {
         push.should.have.been.calledWithExactly({
           force: true,
@@ -39,7 +39,7 @@ describe('push command', function() {
     itShouldParse(
       'should call push script with options',
       'push',
-      'zos push --network test --skip-compile -d --reset -f --deploy-proxy-admin --deploy-proxy-factory',
+      'zos push --network test --skip-compile -d --reset --force --deploy-proxy-admin --deploy-proxy-factory',
       function(push) {
         push.should.have.been.calledWithExactly({
           force: true,

--- a/packages/cli/test/commands/setAdmin.test.js
+++ b/packages/cli/test/commands/setAdmin.test.js
@@ -11,7 +11,7 @@ describe('set-admin command', function() {
   itShouldParse(
     'should call set-admin script with proxy address',
     'setAdmin',
-    `zos set-admin 0x20 ${newAdmin} -f --network test`,
+    `zos set-admin 0x20 ${newAdmin} --force --network test`,
     function(update) {
       update.should.have.been.calledWith({
         proxyAddress: '0x20',
@@ -25,7 +25,7 @@ describe('set-admin command', function() {
   itShouldParse(
     'should call set-admin script with network options',
     'setAdmin',
-    `zos set-admin 0x20 ${newAdmin} -f --network test --from 0x40`,
+    `zos set-admin 0x20 ${newAdmin} --force --network test --from 0x40`,
     function(update) {
       update.should.have.been.calledWith({
         proxyAddress: '0x20',
@@ -39,7 +39,7 @@ describe('set-admin command', function() {
   itShouldParse(
     'should call set-admin script with contract name',
     'setAdmin',
-    `zos set-admin Impl ${newAdmin} -f --network test`,
+    `zos set-admin Impl ${newAdmin} --force --network test`,
     function(update) {
       update.should.have.been.calledWith({
         contractAlias: 'Impl',
@@ -53,7 +53,7 @@ describe('set-admin command', function() {
   itShouldParse(
     'should call set-admin script with package name and contract name',
     'setAdmin',
-    `zos set-admin OpenZeppelin/Impl ${newAdmin} -f --network test`,
+    `zos set-admin OpenZeppelin/Impl ${newAdmin} --force --network test`,
     function(update) {
       update.should.have.been.calledWith({
         packageName: 'OpenZeppelin',
@@ -68,7 +68,7 @@ describe('set-admin command', function() {
   itShouldParse(
     'should call set-admin with new proxy admin owner address',
     'setAdmin',
-    `zos set-admin ${newAdmin} -f --network test`,
+    `zos set-admin ${newAdmin} --force --network test`,
     function(update) {
       update.should.have.been.calledWith({
         newAdmin: newAdmin,


### PR DESCRIPTION
Flag -f was already being used for --from, but was overwritten by both push and set-admin as force. Now --from is the only accepted meaning.

Fixes #1052